### PR TITLE
Change concurrent queue to serial in service provider

### DIFF
--- a/Sources/services/AEPServiceProvider.swift
+++ b/Sources/services/AEPServiceProvider.swift
@@ -31,7 +31,7 @@ public class AEPServiceProvider {
             }
         }
         set {
-            barrierQueue.async(flags: .barrier) {
+            barrierQueue.async {
                 self.overrideSystemInfoService = newValue
             }
         }
@@ -47,7 +47,7 @@ public class AEPServiceProvider {
             }
         }
         set {
-            barrierQueue.async(flags: .barrier) {
+            barrierQueue.async {
                 self.overrideKeyValueService = newValue
             }
         }
@@ -60,7 +60,7 @@ public class AEPServiceProvider {
                 }
             }
             set {
-                barrierQueue.async(flags: .barrier) {
+                barrierQueue.async {
                     self.overrideNetworkService = newValue
                 }
             }


### PR DESCRIPTION
Change the concurrent queue to serial queue in the service provider. For more information on the reasoning behind this change look here: https://github.com/adobe/aepsdk-core-ios/pull/6