### PR TITLE
Resolve SystemInfoService within ConfigDownloader

### DIFF
--- a/AEPCoreTests/ConfigurationTests/ConfigurationDownloaderTests.swift
+++ b/AEPCoreTests/ConfigurationTests/ConfigurationDownloaderTests.swift
@@ -20,6 +20,7 @@ class ConfigurationDownloaderTests: XCTestCase {
     
     override func setUp() {
         AEPServiceProvider.shared.networkService = AEPNetworkService()
+        AEPServiceProvider.shared.systemInfoService = ApplicationSystemInfoService()
         dataStore.removeAll()
     }
     
@@ -150,10 +151,10 @@ class ConfigurationDownloaderTests: XCTestCase {
     /// Ensures that when a config is present in the manifest it can be loaded.
     func testLoadDefaultBundledConfig() {
         // setup
-        let systemInfoService = ApplicationSystemInfoService(bundle: Bundle(for: type(of: self)))
+        AEPServiceProvider.shared.systemInfoService = ApplicationSystemInfoService(bundle: Bundle(for: type(of: self)))
 
         // test
-        let config = ConfigurationDownloader().loadDefaultConfigFrom(systemInfoService: systemInfoService)
+        let config = ConfigurationDownloader().loadDefaultConfigFromManifest()
 
         // verify
         XCTAssertEqual(16, config?.count)

--- a/AEPCoreTests/TestHelpers/MockConfigurationDownloader.swift
+++ b/AEPCoreTests/TestHelpers/MockConfigurationDownloader.swift
@@ -21,7 +21,7 @@ class MockConfigurationDownloader: ConfigurationDownloadable {
     
     var configFromManifest: [String: Any]?
     var calledLoadDefaultConfig = false
-    func loadDefaultConfigFrom(systemInfoService: SystemInfoService) -> [String : Any]? {
+    func loadDefaultConfigFromManifest() -> [String: Any]? {
         calledLoadDefaultConfig = true
         return configFromManifest
     }

--- a/Sources/configuration/ConfigurationDownloadable.swift
+++ b/Sources/configuration/ConfigurationDownloadable.swift
@@ -20,9 +20,8 @@ protocol ConfigurationDownloadable {
     func loadConfigFrom(filePath: String) -> [String: Any]?
     
     /// Loads the default config in the main bundled named `ConfigurationConstants.CONFIG_BUNDLED_FILE_NAME`.
-    /// - Parameter systemInfoService: The system info service
     /// - Returns: The default configuration stored in the manifest, nil if not found
-    func loadDefaultConfigFrom(systemInfoService: SystemInfoService) -> [String: Any]?
+    func loadDefaultConfigFromManifest() -> [String: Any]?
     
     /// Loads the cached configuration for `appId`.
     /// - Parameters:

--- a/Sources/configuration/ConfigurationDownloader.swift
+++ b/Sources/configuration/ConfigurationDownloader.swift
@@ -20,7 +20,8 @@ struct ConfigurationDownloader: ConfigurationDownloadable {
         return AnyCodable.toAnyDictionary(dictionary: decoded)
     }
 
-    func loadDefaultConfigFrom(systemInfoService: SystemInfoService) -> [String: Any]? {
+    func loadDefaultConfigFromManifest() -> [String: Any]? {
+        let systemInfoService = AEPServiceProvider.shared.systemInfoService
         guard let data = systemInfoService.getAsset(fileName: ConfigurationConstants.CONFIG_BUNDLED_FILE_NAME, fileType: "json")?.data(using: .utf8) else { return nil }
         let decoded = try? JSONDecoder().decode([String: AnyCodable].self, from: data)
         return AnyCodable.toAnyDictionary(dictionary: decoded)

--- a/Sources/configuration/ConfigurationState.swift
+++ b/Sources/configuration/ConfigurationState.swift
@@ -41,16 +41,15 @@ class ConfigurationState {
     
     /// Loads the first configuration at launch
     func loadInitialConfig() {
-        let systemInfoService = AEPServiceProvider.shared.systemInfoService
         var config = [String: Any]()
         
         // Load any existing application ID, either saved in persistence or read from the ADBMobileAppID property in the platform's System Info Service.
         if let appId = appIdManager.loadAppId() {
             config = configDownloader.loadConfigFromCache(appId: appId, dataStore: dataStore)
-                        ?? configDownloader.loadDefaultConfigFrom(systemInfoService: systemInfoService)
+                        ?? configDownloader.loadDefaultConfigFromManifest()
                         ?? [:]
         } else {
-            config = configDownloader.loadDefaultConfigFrom(systemInfoService: systemInfoService) ?? [:]
+            config = configDownloader.loadDefaultConfigFromManifest() ?? [:]
         }
         
         updateWith(newConfig: config)


### PR DESCRIPTION
 Don't inject system info service into config downloader, instead resolve via the AEPServiceProvider directly.