### PR TITLE
Add response data to HitQueue

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		213C8BD72428822A009F780A /* EventListenerContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213C8BD62428822A009F780A /* EventListenerContainer.swift */; };
 		213C8C0824297773009F780A /* EventHubError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213C8C0724297773009F780A /* EventHubError.swift */; };
 		213E87B92433E9BD00033447 /* SharedStateTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213E87B82433E9BD00033447 /* SharedStateTestHelper.swift */; };
+		213F638924C0C811006931EB /* HitQueueDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213F638724C0C7AD006931EB /* HitQueueDelegate.swift */; };
 		213F662E2492A36A000184DE /* AEPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213F662D2492A36A000184DE /* AEPError.swift */; };
 		213F66302492A808000184DE /* MID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213F662F2492A808000184DE /* MID.swift */; };
 		213F66322492A8B9000184DE /* MIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213F66312492A8B9000184DE /* MIDTests.swift */; };
@@ -226,6 +227,7 @@
 		213C8BD62428822A009F780A /* EventListenerContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventListenerContainer.swift; sourceTree = "<group>"; };
 		213C8C0724297773009F780A /* EventHubError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHubError.swift; sourceTree = "<group>"; };
 		213E87B82433E9BD00033447 /* SharedStateTestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStateTestHelper.swift; sourceTree = "<group>"; };
+		213F638724C0C7AD006931EB /* HitQueueDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitQueueDelegate.swift; sourceTree = "<group>"; };
 		213F662D2492A36A000184DE /* AEPError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AEPError.swift; path = Sources/AEPError.swift; sourceTree = "<group>"; };
 		213F662F2492A808000184DE /* MID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MID.swift; sourceTree = "<group>"; };
 		213F66312492A8B9000184DE /* MIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIDTests.swift; sourceTree = "<group>"; };
@@ -752,6 +754,7 @@
 				3F0397E324BE60910019F095 /* HitProcessable.swift */,
 				3F0397E424BE60910019F095 /* PersistentHitQueue.swift */,
 				3F0397E524BE60910019F095 /* HitQueuing.swift */,
+				213F638724C0C7AD006931EB /* HitQueueDelegate.swift */,
 			);
 			path = hitprocessor;
 			sourceTree = "<group>";
@@ -1145,6 +1148,7 @@
 				3F0397C724BE5FF30019F095 /* CacheExpiry.swift in Sources */,
 				3F0397C624BE5FF30019F095 /* DiskCacheService.swift in Sources */,
 				3F0397FC24BE60910019F095 /* OperationOrderer.swift in Sources */,
+				213F638924C0C811006931EB /* HitQueueDelegate.swift in Sources */,
 				3F0397D324BE5FF30019F095 /* AEPDataQueue.swift in Sources */,
 				3F0397C324BE5FF30019F095 /* CacheService.swift in Sources */,
 				3F0397F924BE60910019F095 /* FileManager+ZIP.swift in Sources */,

--- a/AEPServices/Sources/utility/hitprocessor/HitProcessable.swift
+++ b/AEPServices/Sources/utility/hitprocessor/HitProcessable.swift
@@ -20,6 +20,6 @@ public protocol HitProcessable: class {
     /// Function that is invoked with a `DataEntity` and provides functionality for processing the hit
     /// - Parameters:
     ///   - entity: The `DataEntity` to be processed
-    ///   - completion: a closure to be invoked with `true` if processing was successful and should not be retried, false if processing the hit should be retried
-    func processHit(entity: DataEntity, completion: (Bool) -> ())
+    ///   - completion: a closure to be invoked with `true` if processing was successful and should not be retried, false if processing the hit should be retried, along with optional response data
+    func processHit(entity: DataEntity, completion: (Bool, Data?) -> ())
 }

--- a/AEPServices/Sources/utility/hitprocessor/HitQueueDelegate.swift
+++ b/AEPServices/Sources/utility/hitprocessor/HitQueueDelegate.swift
@@ -1,0 +1,22 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import Foundation
+
+/// Defines a set of types which are notified when a hit is processed
+public protocol HitQueueDelegate {
+    
+    /// Invoked by an instance of `HitQueueing` each time a hit is processed
+    /// - Parameters:
+    ///   - hit: The hit processed
+    ///   - response: The response of processing the hit in the form of data
+    func didProcess(hit: DataEntity, response: Data?)
+}

--- a/AEPServices/Sources/utility/hitprocessor/HitQueuing.swift
+++ b/AEPServices/Sources/utility/hitprocessor/HitQueuing.swift
@@ -14,8 +14,8 @@ import Foundation
 /// A class of types who provide the functionality for queuing hits
 public protocol HitQueuing {
     
-    /// The delegate responsible for implementing the logic for processing an individual hit
-    var delegate: HitProcessable? { get set }
+    /// The delegate responsible for handling the result of a hit after it has been processed
+    var delegate: HitQueueDelegate? { get set }
     
     /// Queues a `DataEntity` to be processed
     /// - Parameters:

--- a/AEPServices/Sources/utility/hitprocessor/PersistentHitQueue.swift
+++ b/AEPServices/Sources/utility/hitprocessor/PersistentHitQueue.swift
@@ -14,16 +14,18 @@ import Foundation
 /// Provides functionality for asynchronous processing of hits in a synchronous manner while providing the ability to retry hits
 public class PersistentHitQueue: HitQueuing {
     let dataQueue: DataQueue
-    weak public var delegate: HitProcessable?
+    let processor: HitProcessable
+    public var delegate: HitQueueDelegate?
     
     private static let DEFAULT_RETRY_INTERVAL = TimeInterval(30)
     private var suspended = true
-    private let queue = DispatchQueue(label: "com.adobe.mobile.hitqueue")
+    private let queue = DispatchQueue(label: "com.adobe.mobile.persistenthitqueue")
     
     /// Creates a new `HitQueue` with the underlying `DataQueue` which is used to persist hits
     /// - Parameter dataQueue: a `DataQueue` used to persist hits
-    init(dataQueue: DataQueue) {
+    init(dataQueue: DataQueue, processor: HitProcessable) {
         self.dataQueue = dataQueue
+        self.processor = processor
     }
     
     @discardableResult
@@ -52,14 +54,15 @@ public class PersistentHitQueue: HitQueuing {
             guard !self.suspended else { return }
             guard let hit = self.dataQueue.peek() else { return } // nothing let in the queue, stop processing
             
-            self.delegate?.processHit(entity: hit, completion: { [weak self] (success) in
+            self.processor.processHit(entity: hit, completion: { [weak self] (success, data) in
                 if success {
                     // successful processing of hit, remove it from the queue, move to next hit
                     let _ = self?.dataQueue.remove()
+                    self?.delegate?.didProcess(hit: hit, response: data)
                     self?.processNextHit()
                 } else {
                     // processing hit failed, leave it in the queue, retry after the retry interval
-                    self?.queue.asyncAfter(deadline: .now() + (self?.delegate?.retryInterval ?? PersistentHitQueue.DEFAULT_RETRY_INTERVAL)) {
+                    self?.queue.asyncAfter(deadline: .now() + (self?.processor.retryInterval ?? PersistentHitQueue.DEFAULT_RETRY_INTERVAL)) {
                         self?.processNextHit()
                     }
                 }

--- a/AEPServices/Tests/utility/PersistentHitQueueTests.swift
+++ b/AEPServices/Tests/utility/PersistentHitQueueTests.swift
@@ -17,15 +17,18 @@ class PersistentHitQueueTests: XCTestCase {
 
     var hitQueue: PersistentHitQueue!
     var hitProcessor: HitProcessable!
+    var hitDelegate: HitQueueDelegate!
+    
     var processedHits: [DataEntity] {
         guard let mockProcessor = hitProcessor as? MockHitProcessor else { return [] }
         return mockProcessor.processedHits.shallowCopy
     }
     
     override func setUp() {
-        hitQueue = PersistentHitQueue(dataQueue: MockDataQueue())
         hitProcessor = MockHitProcessor()
-        hitQueue.delegate = hitProcessor
+        hitDelegate = MockHitQueueDelegate()
+        hitQueue = PersistentHitQueue(dataQueue: MockDataQueue(), processor: hitProcessor)
+        hitQueue.delegate = hitDelegate
     }
     
     /// Tests that when the queue is in a suspended state that we store the hit in the data queue and do not invoke the processor
@@ -40,6 +43,8 @@ class PersistentHitQueueTests: XCTestCase {
         XCTAssertEqual(hitQueue.dataQueue.peek(), entity) // hit should be in persistent queue
         XCTAssertTrue(processedHits.isEmpty) // mock hit processor should have never been invoked with the data entity
         XCTAssertTrue(result) // queuing hit should be successful
+        let hitDelegate = hitQueue.delegate as? MockHitQueueDelegate
+        XCTAssertTrue(hitDelegate?.processedHits.isEmpty ?? false) // hit delegate should not have been invoked with any hits
     }
     
     /// Tests that when the queue is in a suspended state that we store the hit in the data queue and do not invoke the processor
@@ -55,6 +60,8 @@ class PersistentHitQueueTests: XCTestCase {
         XCTAssertNil(hitQueue.dataQueue.peek()) // hit should no longer be in the queue
         XCTAssertTrue(processedHits.isEmpty) // mock hit processor should have never been invoked with the data entity
         XCTAssertTrue(result) // queuing hit should be successful
+        let hitDelegate = hitQueue.delegate as? MockHitQueueDelegate
+        XCTAssertTrue(hitDelegate?.processedHits.isEmpty ?? false) // hit delegate should not have been invoked with any hits
     }
     
     /// Tests that when the queue is not in a suspended state that the hit processor is invoked with the hit
@@ -71,6 +78,8 @@ class PersistentHitQueueTests: XCTestCase {
         XCTAssertNil(hitQueue.dataQueue.peek()) // hit should no longer be in the queue as its been processed
         XCTAssertEqual(processedHits.first, entity) // mock hit processor should have been invoked with the data entity
         XCTAssertTrue(result) // queuing hit should be successful
+        let hitDelegate = hitQueue.delegate as? MockHitQueueDelegate
+        XCTAssertEqual(hitDelegate?.processedHits.first?.0, entity) // delegate should have been invoked with processed hit
     }
     
     /// Tests that multiple hits are processed and the data queue is empty
@@ -91,6 +100,9 @@ class PersistentHitQueueTests: XCTestCase {
         XCTAssertEqual(processedHits.last, entity1) // mock hit processor should have been invoked with the data entity
         XCTAssertTrue(result) // queuing hit should be successful
         XCTAssertTrue(result1) // queuing hit should be successful
+        let hitDelegate = hitQueue.delegate as? MockHitQueueDelegate
+        XCTAssertEqual(hitDelegate?.processedHits.first?.0, entity) // delegate should have been invoked with processed hit
+        XCTAssertEqual(hitDelegate?.processedHits.last?.0, entity1) // delegate should have been invoked with processed hit
     }
     
     /// Tests that many hits are processed and the data queue is empty
@@ -108,6 +120,8 @@ class PersistentHitQueueTests: XCTestCase {
         // verify
         XCTAssertNil(hitQueue.dataQueue.peek()) // hit should no longer be in the queue as its been processed
         XCTAssertEqual(100, processedHits.count) // all 100 hits should have been processed
+        let hitDelegate = hitQueue.delegate as? MockHitQueueDelegate
+        XCTAssertEqual(100, hitDelegate?.processedHits.count)
     }
     
     /// Tests that not all hits are processed when we suspend the queue
@@ -124,6 +138,8 @@ class PersistentHitQueueTests: XCTestCase {
         // verify
         XCTAssertNotNil(hitQueue.dataQueue.peek()) // some hits should still be in the queue
         XCTAssertNotEqual(100, processedHits.count) // we should have not processed all 100 hits by the time we have suspended
+        let hitDelegate = hitQueue.delegate as? MockHitQueueDelegate
+        XCTAssertNotEqual(100, hitDelegate?.processedHits.count)
     }
     
     /// Tests that not all hits are processed when we suspend the queue, but then when we resume processing that the remaining hits a processed
@@ -138,8 +154,10 @@ class PersistentHitQueueTests: XCTestCase {
         sleep(1)
         
         // verify pt. 1
+        let hitDelegate = hitQueue.delegate as? MockHitQueueDelegate
         XCTAssertNotNil(hitQueue.dataQueue.peek()) // some hits should still be in the queue
         XCTAssertNotEqual(100, processedHits.count) // we should have not processed all 100 hits by the time we have suspended
+        XCTAssertNotEqual(100, hitDelegate?.processedHits.count) // delegate should have not been invoked with 100 hits
         
         hitQueue.beginProcessing()
         sleep(1)
@@ -147,12 +165,14 @@ class PersistentHitQueueTests: XCTestCase {
         // verify pt. 2
         XCTAssertNil(hitQueue.dataQueue.peek()) // hit should no longer be in the queue as its been processed
         XCTAssertEqual(100, processedHits.count) // now all hits should have been sent to the hit processor
+        XCTAssertEqual(100, hitDelegate?.processedHits.count) // delegate should have been invoked with 100 hits
     }
     
     /// Tests that hits are retried properly and do not block the queue
     func testProcessesHitsManyWithIntermittentProcessor() {
         hitProcessor = MockHitIntermittentProcessor()
-        hitQueue.delegate = hitProcessor
+        hitQueue = PersistentHitQueue(dataQueue: MockDataQueue(), processor: hitProcessor)
+        hitQueue.delegate = MockHitQueueDelegate()
         
         // test
         for _ in 0..<100 {
@@ -163,10 +183,12 @@ class PersistentHitQueueTests: XCTestCase {
         sleep(1)
         
         // verify
+        let intermittentProcessor = hitQueue.processor as? MockHitIntermittentProcessor
+        let hitDelegate = hitQueue.delegate as? MockHitQueueDelegate
         XCTAssertNil(hitQueue.dataQueue.peek()) // hits should no longer be in the queue as its been processed
-        let intermittentProcessor = hitQueue.delegate as? MockHitIntermittentProcessor
         XCTAssertEqual(100, intermittentProcessor?.processedHits.count) // all hits should be eventually processed
         XCTAssertFalse(intermittentProcessor?.failedHits.isEmpty ?? true) // some of the hits should have failed
+        XCTAssertEqual(100, hitDelegate?.processedHits.count) // delegate should have been invoked with 100 hits
     }
 
 
@@ -177,9 +199,9 @@ class MockHitProcessor: HitProcessable {
     
     let processedHits = ThreadSafeArray<DataEntity>()
     
-    func processHit(entity: DataEntity, completion: (Bool) -> ()) {
+    func processHit(entity: DataEntity, completion: (Bool, Data?) -> ()) {
         processedHits.append(entity)
-        completion(true)
+        completion(true, nil)
     }
 }
 
@@ -190,11 +212,11 @@ class MockHitIntermittentProcessor: HitProcessable {
     var failedHits = Set<String>()
     
     // 50% of hits need to be processed twice, other 50% process successfully the first time
-    func processHit(entity: DataEntity, completion: (Bool) -> ()) {
+    func processHit(entity: DataEntity, completion: (Bool, Data?) -> ()) {
         // check if we've already "failed" at processing this hit
         if failedHits.contains(entity.uniqueIdentifier) {
             processedHits.append(entity)
-            completion(true)
+            completion(true, nil)
             return
         }
         
@@ -202,10 +224,19 @@ class MockHitIntermittentProcessor: HitProcessable {
         
         if !shouldRetry {
             processedHits.append(entity)
-            completion(true)
+            completion(true, nil)
         } else {
             failedHits.insert(entity.uniqueIdentifier)
-            completion(false)
+            completion(false, nil)
         }
     }
+}
+
+class MockHitQueueDelegate: HitQueueDelegate {
+    var processedHits = [(DataEntity, Data?)]()
+    
+    func didProcess(hit: DataEntity, response: Data?) {
+        processedHits.append((hit, response))
+    }
+    
 }


### PR DESCRIPTION
This PR adds:
1. Ability to pass response data back when done processing a hit
2. Add a delegate to the HitQueuing protocol which is invoked each time the hit queue 
3. Moved the hit processor to be an instance variable that is injected via the init

The use-case here, for example, is when Identity processes a hit it makes a network request. It would be useful to notify the owner of the HitQueue that we have finished processing the hit and that we have some response data (network response in this case)