### PR TITLE
Minor upgrade to PersistentHitQueue

### DIFF
--- a/AEPServices/Sources/utility/hitprocessor/HitQueuing.swift
+++ b/AEPServices/Sources/utility/hitprocessor/HitQueuing.swift
@@ -14,8 +14,8 @@ import Foundation
 /// A class of types who provide the functionality for queuing hits
 public protocol HitQueuing {
     
-    /// The delegate responsible for implementing the logic for processing an individual hit
-    var delegate: HitProcessable? { get set }
+    /// The processor responsible for implementing the logic for processing an individual hit
+    var processor: HitProcessable { get }
     
     /// Queues a `DataEntity` to be processed
     /// - Parameters:

--- a/AEPServices/Sources/utility/hitprocessor/PersistentHitQueue.swift
+++ b/AEPServices/Sources/utility/hitprocessor/PersistentHitQueue.swift
@@ -13,17 +13,19 @@ import Foundation
 
 /// Provides functionality for asynchronous processing of hits in a synchronous manner while providing the ability to retry hits
 public class PersistentHitQueue: HitQueuing {
+    public let processor: HitProcessable
     let dataQueue: DataQueue
-    weak public var delegate: HitProcessable?
     
     private static let DEFAULT_RETRY_INTERVAL = TimeInterval(30)
     private var suspended = true
-    private let queue = DispatchQueue(label: "com.adobe.mobile.hitqueue")
+    private let queue = DispatchQueue(label: "com.adobe.mobile.persistenthitqueue")
     
     /// Creates a new `HitQueue` with the underlying `DataQueue` which is used to persist hits
     /// - Parameter dataQueue: a `DataQueue` used to persist hits
-    init(dataQueue: DataQueue) {
+    /// - Parameter processor: a `HitProcessable` used to process hits
+    init(dataQueue: DataQueue, processor: HitProcessable) {
         self.dataQueue = dataQueue
+        self.processor = processor
     }
     
     @discardableResult
@@ -52,14 +54,14 @@ public class PersistentHitQueue: HitQueuing {
             guard !self.suspended else { return }
             guard let hit = self.dataQueue.peek() else { return } // nothing let in the queue, stop processing
             
-            self.delegate?.processHit(entity: hit, completion: { [weak self] (success) in
+            self.processor.processHit(entity: hit, completion: { [weak self] (success) in
                 if success {
                     // successful processing of hit, remove it from the queue, move to next hit
                     let _ = self?.dataQueue.remove()
                     self?.processNextHit()
                 } else {
                     // processing hit failed, leave it in the queue, retry after the retry interval
-                    self?.queue.asyncAfter(deadline: .now() + (self?.delegate?.retryInterval ?? PersistentHitQueue.DEFAULT_RETRY_INTERVAL)) {
+                    self?.queue.asyncAfter(deadline: .now() + (self?.processor.retryInterval ?? PersistentHitQueue.DEFAULT_RETRY_INTERVAL)) {
                         self?.processNextHit()
                     }
                 }

--- a/AEPServices/Tests/utility/PersistentHitQueueTests.swift
+++ b/AEPServices/Tests/utility/PersistentHitQueueTests.swift
@@ -23,9 +23,8 @@ class PersistentHitQueueTests: XCTestCase {
     }
     
     override func setUp() {
-        hitQueue = PersistentHitQueue(dataQueue: MockDataQueue())
         hitProcessor = MockHitProcessor()
-        hitQueue.delegate = hitProcessor
+        hitQueue = PersistentHitQueue(dataQueue: MockDataQueue(), processor: hitProcessor)
     }
     
     /// Tests that when the queue is in a suspended state that we store the hit in the data queue and do not invoke the processor
@@ -152,7 +151,7 @@ class PersistentHitQueueTests: XCTestCase {
     /// Tests that hits are retried properly and do not block the queue
     func testProcessesHitsManyWithIntermittentProcessor() {
         hitProcessor = MockHitIntermittentProcessor()
-        hitQueue.delegate = hitProcessor
+        hitQueue = PersistentHitQueue(dataQueue: MockDataQueue(), processor: hitProcessor)
         
         // test
         for _ in 0..<100 {
@@ -164,7 +163,7 @@ class PersistentHitQueueTests: XCTestCase {
         
         // verify
         XCTAssertNil(hitQueue.dataQueue.peek()) // hits should no longer be in the queue as its been processed
-        let intermittentProcessor = hitQueue.delegate as? MockHitIntermittentProcessor
+        let intermittentProcessor = hitQueue.processor as? MockHitIntermittentProcessor
         XCTAssertEqual(100, intermittentProcessor?.processedHits.count) // all hits should be eventually processed
         XCTAssertFalse(intermittentProcessor?.failedHits.isEmpty ?? true) // some of the hits should have failed
     }


### PR DESCRIPTION
Moving away from the delegate pattern as I think it reduces the ergonomics of using this class. Instead, we will inject a `HitProcessable` and this will also simplify the optional handling within the class.