### PR TITLE
Invoke registerExtension completion block after extension has been registered

### DIFF
--- a/AEPEventHub/Sources/eventhub/EventHub.swift
+++ b/AEPEventHub/Sources/eventhub/EventHub.swift
@@ -92,9 +92,8 @@ final public class EventHub {
             
             // Init the extension on a dedicated queue
             let extensionQueue = DispatchQueue(label: "com.adobe.eventhub.extension.\(type.typeName)")
-            let extensionContainer = ExtensionContainer(type, extensionQueue)
+            let extensionContainer = ExtensionContainer(type, extensionQueue, completion: completion)
             self.registeredExtensions[type.typeName] = extensionContainer
-            completion(nil)
         }
     }
     

--- a/AEPEventHub/Sources/eventhub/ExtensionContainer.swift
+++ b/AEPEventHub/Sources/eventhub/ExtensionContainer.swift
@@ -33,7 +33,7 @@ class ExtensionContainer {
     /// Listeners array of `EventListeners` for this extension
     let eventListeners: ThreadSafeArray<EventListenerContainer>
         
-    init(_ type: Extension.Type, _ queue: DispatchQueue) {
+    init(_ type: Extension.Type, _ queue: DispatchQueue, completion: @escaping (EventHubError?) -> ()) {
         extensionQueue = queue
         eventOrderer = OperationOrderer<Event>()
         eventListeners = ThreadSafeArray<EventListenerContainer>()
@@ -47,6 +47,7 @@ class ExtensionContainer {
             self.sharedStateName = unwrappedExtension.name
             unwrappedExtension.onRegistered()
             self.eventOrderer.start()
+            completion(nil)
         }
     }
 }


### PR DESCRIPTION
In the current implementation we could invoke the registerExtension completion handler before the actual extension has finished registering. In this PR I am proposing that we wait until the extension has been initialized and invoked `onRegistered`.