### PR TITLE
Listen for generic identity from setAdvertisting API

### DIFF
--- a/AEPIdentity/Sources/AEPIdentity.swift
+++ b/AEPIdentity/Sources/AEPIdentity.swift
@@ -26,6 +26,7 @@ class AEPIdentity: Extension {
     
     func onRegistered() {
         registerListener(type: .identity, source: .requestIdentity, listener: handleIdentityRequest)
+        registerListener(type: .genericIdentity, source: .requestContent, listener: handleIdentityRequest)
         registerListener(type: .configuration, source: .requestIdentity, listener: receiveConfigurationIdentity(event:))
     }
     


### PR DESCRIPTION
Simple change to get Identity to listen for the generic identity event dispatched by the setAdvertising API