### PR TITLE
Make DiskCacheService internal

### DIFF
--- a/AEPServices/Sources/cache/DiskCacheService.swift
+++ b/AEPServices/Sources/cache/DiskCacheService.swift
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 import Foundation
 
 /// Implements a cache which saves and retrieves data from the disk
-public class DiskCacheService: CacheService {
+class DiskCacheService: CacheService {
     lazy var dataStore = NamedKeyValueStore(name: "DiskCacheService")
     let cachePrefix = "com.adobe.mobile.diskcache/"
     let fileManager = FileManager.default


### PR DESCRIPTION
This class shouldn't be accessed directly by other extensions but rather via the ServiceProvider or Cache.