### PR TITLE
Add configuration to be registered by default on old workflow

### DIFF
--- a/AEPCore/Sources/core/MobileCore.swift
+++ b/AEPCore/Sources/core/MobileCore.swift
@@ -70,7 +70,7 @@ import AEPServices
     //@available(*, deprecated, message: "Use `registerExtensions(extensions:)` for both registering extensions and starting the SDK")
     public static func start(_ completion: @escaping (()-> Void)) {
         // Start the event hub processing
-        let pending = MobileCore.pendingExtensions.shallowCopy
+        let pending = [Configuration.self] + MobileCore.pendingExtensions.shallowCopy
         MobileCore.pendingExtensions.clear()
         registerExtensions(pending, { completion() })
     }


### PR DESCRIPTION
When registering extensions the old way we need to ensure that Configuration is registered by default too.