### PR TITLE
Preserve shared state data when setting to pending

### DIFF
--- a/AEPCore/Sources/eventhub/SharedState.swift
+++ b/AEPCore/Sources/eventhub/SharedState.swift
@@ -42,7 +42,8 @@ class SharedState {
     /// - Parameters:
     ///   - version: The version of the `SharedState` to to create as pending
     internal func addPending(version: Int) {
-        add(version: version, data: nil, status: .pending)
+        // set state to pending and use the existing (if any) shared state data as placeholder
+        add(version: version, data: resolve(version: Int.max).value, status: .pending)
     }
 
     /// Updates a pending version of `SharedState` to a concrete value.

--- a/AEPCore/Tests/EventHubTests/SharedStateTest.swift
+++ b/AEPCore/Tests/EventHubTests/SharedStateTest.swift
@@ -131,6 +131,18 @@ class SharedStateTest: XCTestCase {
         XCTAssertEqual(sharedState.resolve(version: 0).status, SharedStateStatus.none)
     }
 
+    func testSharedStatePendingPreservesData() {
+        // setup
+        sharedState.set(version: 1, data: SharedStateTestHelper.ONE)
+        sharedState.addPending(version: 2)
+
+        // test
+        let (data, _) = sharedState.resolve(version: 2)
+
+        // verify
+        XCTAssertEqual(SharedStateTestHelper.ONE as! [String: String], data as! [String: String])
+    }
+
     func testAddPerformance() {
         // This is an example of a performance test case.
         measure {


### PR DESCRIPTION
https://github.com/adobe/aepsdk-core-ios/issues/280

Scenario 1 - Last state is "good enough"

This is the weak dependency case - the consuming extension (the one reading the shared state) would like data if possible, but it's not necessary for the event to be processed.