### PR TITLE
Settle shared state after processing an event

### DIFF
--- a/AEPCore/Sources/eventhub/EventHub.swift
+++ b/AEPCore/Sources/eventhub/EventHub.swift
@@ -195,6 +195,13 @@ final class EventHub {
         preprocessors.append(preprocessor)
     }
 
+    /// Returns the event number for the given `Event`
+    /// - Parameter event: An `Event` that has been processed through the `EventHub`
+    /// - Returns: The event number for the `Event` if it has been dispatched through the `EventHub`, otherwise nil
+    func eventNumberFor(event: Event) -> Int? {
+        return eventNumberMap[event.id]
+    }
+
     // MARK: Private
 
     private func versionSharedState(extensionName: String, event: Event?) -> (SharedState, Int)? {

--- a/AEPCore/Sources/eventhub/ExtensionContainer.swift
+++ b/AEPCore/Sources/eventhub/ExtensionContainer.swift
@@ -107,6 +107,10 @@ private extension ExtensionContainer {
             }
         }
 
+        if let eventNumber = EventHub.shared.eventNumberFor(event: event) {
+            sharedState?.settle(for: eventNumber)
+        }
+
         return true
     }
 }

--- a/AEPCore/Tests/EventHubTests/SharedStateTest.swift
+++ b/AEPCore/Tests/EventHubTests/SharedStateTest.swift
@@ -143,6 +143,65 @@ class SharedStateTest: XCTestCase {
         XCTAssertEqual(SharedStateTestHelper.ONE as! [String: String], data as! [String: String])
     }
 
+    // MARK: settle(...) tests
+
+    /// Tests that when the version is equal to the head version that we settle the set shared state
+    func testSettleShouldSettleSet() {
+        // setup
+        sharedState.set(version: 1, data: SharedStateTestHelper.ONE)
+
+        // test
+        sharedState.settle(for: 1)
+
+        // verify
+        XCTAssertEqual(SharedStateStatus.settled, sharedState.resolve(version: 1).status)
+    }
+
+    /// Tests that when the version is greater than or equal to the head version that we settle the set shared state
+    func testSettleShouldSettleSetGreaterThan() {
+        // setup
+        sharedState.set(version: 1, data: SharedStateTestHelper.ONE)
+
+        // test
+        sharedState.settle(for: 2)
+
+        // verify
+        XCTAssertEqual(SharedStateStatus.settled, sharedState.resolve(version: 1).status)
+    }
+
+    /// Tests that when the version is less than to the head version that we do not settle the shared state
+    func testSettleShouldNotSettle() {
+        // setup
+        sharedState.set(version: 2, data: SharedStateTestHelper.ONE)
+
+        // test
+        sharedState.settle(for: 1)
+
+        // verify
+        XCTAssertEqual(SharedStateStatus.set, sharedState.resolve(version: 1).status)
+    }
+
+    /// Tests that we do not settle the pending shared state even when version is greater than or equal to the head version
+    func testSettleShouldNotSettlePending() {
+        // setup
+        sharedState.addPending(version: 1)
+
+        // test
+        sharedState.settle(for: 1)
+
+        // verify
+        XCTAssertEqual(SharedStateStatus.pending, sharedState.resolve(version: 1).status)
+    }
+
+    /// Tests that we do not settle the pending shared state even when version is greater than or equal to the head version
+    func testSettleShouldNotSettleNone() {
+        // test
+        sharedState.settle(for: 1)
+
+        // verify
+        XCTAssertEqual(SharedStateStatus.none, sharedState.resolve(version: 1).status)
+    }
+
     func testAddPerformance() {
         // This is an example of a performance test case.
         measure {


### PR DESCRIPTION
Addresses the shared state discussion around: https://github.com/adobe/aepsdk-core-ios/issues
> Scenario 2 - Accuracy is required
This is the strong dependency, meaning that the consuming extension must be able to get a concrete state in order to process an event. This is for things like privacy, or any cases where "wrong" decisions can be made without a valid answer.

Implements @pfransenadb suggestion of settling shared state after an extension has moved passed that event so we can guarantee that the shared state is solidified for that given event.

If we like this approach, I will make a separate PR to update our existing extensions to check for `.settled` in `readyForEvent` and update our docs with this difference.