### PR TITLE
add a log prefix

### DIFF
--- a/AEPServices/Sources/log/LoggingService.swift
+++ b/AEPServices/Sources/log/LoggingService.swift
@@ -50,6 +50,6 @@ class LoggingService: Logging {
     // MARK: Logging
 
     func log(level: LogLevel, label: String, message: String) {
-        os_log("[AEP SDK] : %@", log: osLog(label), type: osLogType(level), message)
+        os_log("%@", log: osLog("AEP SDK : \(label)"), type: osLogType(level), message)
     }
 }

--- a/AEPServices/Sources/log/LoggingService.swift
+++ b/AEPServices/Sources/log/LoggingService.swift
@@ -50,6 +50,6 @@ class LoggingService: Logging {
     // MARK: Logging
 
     func log(level: LogLevel, label: String, message: String) {
-        os_log("%@", log: osLog(label), type: osLogType(level), message)
+        os_log("[AEP SDK] : %@", log: osLog(label), type: osLogType(level), message)
     }
 }


### PR DESCRIPTION
With the log prefix `AEP SDK  {Log Level} ` now the log looks like this: 
```
2020-09-25 15:28:55.231320-0500 E2ETesting[57955:1712641] [AEP SDK TRACE - <SQLiteDataQueue>] Database record did not have valid data: SELECT min(id),uniqueIdentifier,timestamp,data FROM TB_AEP_DATA_ENTITY;.
```