### PR TITLE
Flatten CustomIdentities in SharedState and Identity Refactor

### DIFF
--- a/AEPIdentity/Sources/CustomIdentity.swift
+++ b/AEPIdentity/Sources/CustomIdentity.swift
@@ -12,11 +12,12 @@
 import Foundation
 
 /// CustomIdentity contains identifier origin, identifier type, identifier value and authentication state.
-public class CustomIdentity: Identifiable, Codable {
-    public var origin: String?
-    public var type: String?
-    public var identifier: String?
-    public var authenticationState: MobileVisitorAuthenticationState
+@objc(AEPCustomIdentity)
+final public class CustomIdentity: NSObject {
+    @objc public var origin: String?
+    @objc public var type: String?
+    @objc public var identifier: String?
+    @objc public var authenticationState: MobileVisitorAuthenticationState
 
     /// Creates a new `CustomIdentity` with the given parameters
     /// - Parameters:
@@ -24,15 +25,18 @@ public class CustomIdentity: Identifiable, Codable {
     ///   - type: Type of the identifier
     ///   - identifier: The identifier
     ///   - authenticationState: Authentication state for the identifier
-    init(origin: String?, type: String?, identifier: String?, authenticationState: MobileVisitorAuthenticationState) {
+    @objc init(origin: String?, type: String?, identifier: String?, authenticationState: MobileVisitorAuthenticationState) {
         self.origin = origin
         self.type = type
         self.identifier = identifier
         self.authenticationState = authenticationState
     }
+
 }
 
-extension CustomIdentity: Equatable {
+extension CustomIdentity: Identifiable, Codable {}
+
+extension CustomIdentity {
     public static func == (lhs: CustomIdentity, rhs: CustomIdentity) -> Bool {
         return lhs.type == rhs.type
     }

--- a/AEPIdentity/Sources/CustomIdentity.swift
+++ b/AEPIdentity/Sources/CustomIdentity.swift
@@ -12,12 +12,11 @@
 import Foundation
 
 /// CustomIdentity contains identifier origin, identifier type, identifier value and authentication state.
-@objc(AEPCustomIdentity)
-final public class CustomIdentity: NSObject {
-    @objc public var origin: String?
-    @objc public var type: String?
-    @objc public var identifier: String?
-    @objc public var authenticationState: MobileVisitorAuthenticationState
+public class CustomIdentity: Identifiable, Codable {
+    public var origin: String?
+    public var type: String?
+    public var identifier: String?
+    public var authenticationState: MobileVisitorAuthenticationState
 
     /// Creates a new `CustomIdentity` with the given parameters
     /// - Parameters:
@@ -25,18 +24,15 @@ final public class CustomIdentity: NSObject {
     ///   - type: Type of the identifier
     ///   - identifier: The identifier
     ///   - authenticationState: Authentication state for the identifier
-    @objc init(origin: String?, type: String?, identifier: String?, authenticationState: MobileVisitorAuthenticationState) {
+    init(origin: String?, type: String?, identifier: String?, authenticationState: MobileVisitorAuthenticationState) {
         self.origin = origin
         self.type = type
         self.identifier = identifier
         self.authenticationState = authenticationState
     }
-
 }
 
-extension CustomIdentity: Identifiable, Codable {}
-
-extension CustomIdentity {
+extension CustomIdentity: Equatable {
     public static func == (lhs: CustomIdentity, rhs: CustomIdentity) -> Bool {
         return lhs.type == rhs.type
     }

--- a/AEPIdentity/Sources/CustomIdentity.swift
+++ b/AEPIdentity/Sources/CustomIdentity.swift
@@ -31,7 +31,7 @@ public class CustomIdentity: Identifiable, Codable {
         self.authenticationState = authenticationState
     }
 
-    private enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case origin = "id.origin"
         case type = "id.type"
         case identifier = "id"

--- a/AEPIdentity/Sources/CustomIdentity.swift
+++ b/AEPIdentity/Sources/CustomIdentity.swift
@@ -30,6 +30,13 @@ public class CustomIdentity: Identifiable, Codable {
         self.identifier = identifier
         self.authenticationState = authenticationState
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case origin = "id.origin"
+        case type = "id.type"
+        case identifier = "id"
+        case authenticationState = "authentication.state"
+    }
 }
 
 extension CustomIdentity: Equatable {

--- a/AEPIdentity/Sources/Identity.swift
+++ b/AEPIdentity/Sources/Identity.swift
@@ -33,7 +33,7 @@ import Foundation
             return
         }
 
-        let hitQueue = PersistentHitQueue(dataQueue: dataQueue, processor: IdentityHitProcessor(responseHandler: handleNetworkResponse(entity:responseData:)))
+        let hitQueue = PersistentHitQueue(dataQueue: dataQueue, processor: IdentityHitProcessor(responseHandler: handleNetworkResponse(hit:responseData:)))
 
         let dataStore = NamedCollectionDataStore(name: IdentityConstants.DATASTORE_NAME)
         let pushIdManager = PushIDManager(dataStore: dataStore, eventDispatcher: dispatch(event:))
@@ -192,10 +192,10 @@ import Foundation
 
     /// Invoked by the `IdentityHitProcessor` each time we receive a network response
     /// - Parameters:
-    ///   - entity: The `DataEntity` that was processed by the hit processor
+    ///   - entity: The `IdentityHit` that was processed by the hit processor
     ///   - responseData: the network response data if any
-    private func handleNetworkResponse(entity: DataEntity, responseData: Data?) {
-        state?.handleHitResponse(hit: entity, response: responseData, eventDispatcher: dispatch(event:), createSharedState: createSharedState(data:event:))
+    private func handleNetworkResponse(hit: IdentityHit, responseData: Data?) {
+        state?.handleHitResponse(hit: hit, response: responseData, eventDispatcher: dispatch(event:), createSharedState: createSharedState(data:event:))
     }
 
     /// Sends an opt-out network request if the current privacy status is opt-out

--- a/AEPIdentity/Sources/IdentityProperties.swift
+++ b/AEPIdentity/Sources/IdentityProperties.swift
@@ -56,7 +56,7 @@ struct IdentityProperties: Codable {
         eventData[IdentityConstants.EventDataKeys.VISITOR_ID_BLOB] = blob
         eventData[IdentityConstants.EventDataKeys.VISITOR_ID_LOCATION_HINT] = locationHint
         if let customerIds = customerIds, !customerIds.isEmpty {
-            eventData[IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] = customerIds
+            eventData[IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] = customerIds.map({$0.asDictionary()})
         }
         eventData[IdentityConstants.EventDataKeys.VISITOR_IDS_LAST_SYNC] = lastSync?.timeIntervalSince1970
 

--- a/AEPIdentity/Sources/IdentityState.swift
+++ b/AEPIdentity/Sources/IdentityState.swift
@@ -145,12 +145,12 @@ class IdentityState {
     ///   - response: the response data if any
     ///   - eventDispatcher: a function which when invoked dispatches an `Event` to the `EventHub`
     ///   - createSharedState: a function which when invoked creates a shared state for the Identity extension
-    func handleHitResponse(hit: DataEntity, response: Data?, eventDispatcher: (Event) -> Void, createSharedState: ([String: Any], Event?) -> Void) {
+    func handleHitResponse(hit: IdentityHit, response: Data?, eventDispatcher: (Event) -> Void, createSharedState: ([String: Any], Event?) -> Void) {
         // regardless of response, update last sync time
         identityProperties.lastSync = Date()
 
         // check privacy here in case the status changed while response was in-flight
-        if identityProperties.privacyStatus != .optedOut, let data = hit.data, let hit = try? JSONDecoder().decode(IdentityHit.self, from: data) {
+        if identityProperties.privacyStatus != .optedOut {
             // update properties
             handleNetworkResponse(response: response, eventDispatcher: eventDispatcher, createSharedState: createSharedState, event: hit.event)
 
@@ -166,13 +166,12 @@ class IdentityState {
                                          data: eventData)
         eventDispatcher(updatedIdentityEvent)
 
-        if let data = hit.data, let hit = try? JSONDecoder().decode(IdentityHit.self, from: data) {
-            let identityResponse = hit.event.createResponseEvent(name: IdentityConstants.EventNames.UPDATED_IDENTITY_RESPONSE,
-                                                                 type: EventType.identity,
-                                                                 source: EventSource.responseIdentity,
-                                                                 data: eventData)
-            eventDispatcher(identityResponse)
-        }
+        let identityResponse = hit.event.createResponseEvent(name: IdentityConstants.EventNames.UPDATED_IDENTITY_RESPONSE,
+                                                             type: EventType.identity,
+                                                             source: EventSource.responseIdentity,
+                                                             data: eventData)
+        eventDispatcher(identityResponse)
+
     }
 
     /// Verifies if a sync network call is required. This method returns true if there is at least one identifier to be synced,

--- a/AEPIdentity/Sources/MobileIdentities.swift
+++ b/AEPIdentity/Sources/MobileIdentities.swift
@@ -104,7 +104,7 @@ struct MobileIdentities: Codable {
         // So, there is no need to fetch the advertising identifier with advertisingidentifer namespace DSID_20914 separately.
         if let customVisitorIds = identitySharedState.value?[IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [[String: Any]] {
             // convert each `CustomIdentity` dictionary representations to a `UserID`, then remove any nil values
-            visitorIds.append(contentsOf: customVisitorIds.map { dictToUserID(dict: $0) }.compactMap { $0 })
+            visitorIds.append(contentsOf: customVisitorIds.map { MobileIdentities.dictToUserID(dict: $0) }.compactMap { $0 })
         }
 
         // push identifier
@@ -130,7 +130,7 @@ struct MobileIdentities: Codable {
 
     /// Converts a `CustomIdentity` dictionary representation into a `UserID`
     /// - Returns: a `UserID` where the namespace is value, value is identifier, and type is integrationCode
-    private func dictToUserID(dict: [String: Any]) -> UserID? {
+    private static func dictToUserID(dict: [String: Any]) -> UserID? {
         guard let type = dict[CustomIdentity.CodingKeys.type.rawValue] as? String,
               let identifier = dict[CustomIdentity.CodingKeys.identifier.rawValue] as? String,
               !identifier.isEmpty else { return nil }

--- a/AEPIdentity/Sources/MobileIdentities.swift
+++ b/AEPIdentity/Sources/MobileIdentities.swift
@@ -102,9 +102,9 @@ struct MobileIdentities: Codable {
         // visitor ids and advertising id
         // Identity sets the advertising identifier both in ‘visitoridslist’ and as ‘advertisingidentifer’ in the Identity shared state.
         // So, there is no need to fetch the advertising identifier with advertisingidentifer namespace DSID_20914 separately.
-        if let customVisitorIds = identitySharedState.value?[IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [CustomIdentity] {
-            // convert each `CustomIdentity` to a `UserID`, then remove any nil values
-            visitorIds.append(contentsOf: customVisitorIds.map { $0.toUserID() }.compactMap { $0 })
+        if let customVisitorIds = identitySharedState.value?[IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [[String: Any]] {
+            // convert each `CustomIdentity` dictionary representations to a `UserID`, then remove any nil values
+            visitorIds.append(contentsOf: customVisitorIds.map { dictToUserID(dict: $0) }.compactMap { $0 })
         }
 
         // push identifier
@@ -127,13 +127,13 @@ struct MobileIdentities: Codable {
 
         return CompanyContext(marketingCloudId: marketingCloudOrgId)
     }
-}
 
-private extension CustomIdentity {
-    /// Converts a `CustomIdentity` into a `UserID`
+    /// Converts a `CustomIdentity` dictionary representation into a `UserID`
     /// - Returns: a `UserID` where the namespace is value, value is identifier, and type is integrationCode
-    func toUserID() -> UserID? {
-        guard let type = type, let identifier = identifier, !identifier.isEmpty else { return nil }
+    private func dictToUserID(dict: [String: Any]) -> UserID? {
+        guard let type = dict[CustomIdentity.CodingKeys.type.rawValue] as? String,
+              let identifier = dict[CustomIdentity.CodingKeys.identifier.rawValue] as? String,
+              !identifier.isEmpty else { return nil }
         return UserID(namespace: type, value: identifier, type: MobileIdentities.INTEGRATION_CODE)
     }
 }

--- a/AEPIdentity/Tests/IdentityHitProcessorTests.swift
+++ b/AEPIdentity/Tests/IdentityHitProcessorTests.swift
@@ -17,15 +17,15 @@ import XCTest
 
 class IdentityHitProcessorTests: XCTestCase {
     var hitProcessor: IdentityHitProcessor!
-    var responseCallbackArgs = [(DataEntity, Data?)]()
+    var responseCallbackArgs = [(IdentityHit, Data?)]()
     var mockNetworkService: MockNetworkServiceOverrider? {
         return ServiceProvider.shared.networkService as? MockNetworkServiceOverrider
     }
 
     override func setUp() {
         ServiceProvider.shared.networkService = MockNetworkServiceOverrider()
-        hitProcessor = IdentityHitProcessor(responseHandler: { [weak self] entity, data in
-            self?.responseCallbackArgs.append((entity, data))
+        hitProcessor = IdentityHitProcessor(responseHandler: { [weak self] hit, data in
+            self?.responseCallbackArgs.append((hit, data))
         })
     }
 

--- a/AEPIdentity/Tests/IdentityPropertiesTests.swift
+++ b/AEPIdentity/Tests/IdentityPropertiesTests.swift
@@ -47,7 +47,7 @@ class IdentityPropertiesTests: XCTestCase {
         XCTAssertEqual(properties.pushIdentifier, eventData[IdentityConstants.EventDataKeys.PUSH_IDENTIFIER] as? String)
         XCTAssertEqual(properties.blob, eventData[IdentityConstants.EventDataKeys.VISITOR_ID_BLOB] as? String)
         XCTAssertEqual(properties.locationHint, eventData[IdentityConstants.EventDataKeys.VISITOR_ID_LOCATION_HINT] as? String)
-        XCTAssertNotNil(eventData[IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [CustomIdentity])
+        XCTAssertNotNil(eventData[IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [[String: Any]])
         XCTAssertEqual(properties.lastSync?.timeIntervalSince1970, eventData[IdentityConstants.EventDataKeys.VISITOR_IDS_LAST_SYNC] as? TimeInterval)
     }
 

--- a/AEPIdentity/Tests/IdentityStateTests.swift
+++ b/AEPIdentity/Tests/IdentityStateTests.swift
@@ -610,13 +610,13 @@ class IdentityStateTests: XCTestCase {
         var props = IdentityProperties()
         props.lastSync = Date()
         props.privacyStatus = .optedIn
-        let entity = DataEntity.fakeDataEntity()
+        let hit = IdentityHit.fakeHit()
         let hitResponse = IdentityHitResponse.fakeHitResponse(error: nil, optOutList: nil)
 
         state = IdentityState(identityProperties: props, hitQueue: MockHitQueue(processor: MockHitProcessor()), pushIdManager: mockPushIdManager)
 
         // test
-        state.handleHitResponse(hit: entity, response: try! JSONEncoder().encode(hitResponse), eventDispatcher: { event in
+        state.handleHitResponse(hit: hit, response: try! JSONEncoder().encode(hitResponse), eventDispatcher: { event in
             XCTAssertEqual(state.identityProperties.toEventData().count, event.data?.count) // event should contain the identity properties in the event data
             dispatchedEventExpectation.fulfill()
         }) { _, _ in
@@ -643,13 +643,13 @@ class IdentityStateTests: XCTestCase {
         var props = IdentityProperties()
         props.lastSync = Date()
         props.privacyStatus = .optedIn
-        let entity = DataEntity.fakeDataEntity()
+        let hit = IdentityHit.fakeHit()
         let hitResponse = IdentityHitResponse.fakeHitResponse(error: nil, optOutList: ["optOut"])
 
         state = IdentityState(identityProperties: props, hitQueue: MockHitQueue(processor: MockHitProcessor()), pushIdManager: mockPushIdManager)
 
         // test
-        state.handleHitResponse(hit: entity, response: try! JSONEncoder().encode(hitResponse), eventDispatcher: { _ in
+        state.handleHitResponse(hit: hit, response: try! JSONEncoder().encode(hitResponse), eventDispatcher: { _ in
             dispatchedEventExpectation.fulfill()
         }) { _, _ in
             sharedStateExpectation.fulfill()
@@ -675,13 +675,13 @@ class IdentityStateTests: XCTestCase {
         var props = IdentityProperties()
         props.lastSync = Date()
         props.privacyStatus = .optedIn
-        let entity = DataEntity.fakeDataEntity()
+        let hit = IdentityHit.fakeHit()
         let hitResponse = IdentityHitResponse.fakeHitResponse(error: "err message", optOutList: nil)
 
         state = IdentityState(identityProperties: props, hitQueue: MockHitQueue(processor: MockHitProcessor()), pushIdManager: mockPushIdManager)
 
         // test
-        state.handleHitResponse(hit: entity, response: try! JSONEncoder().encode(hitResponse), eventDispatcher: { _ in
+        state.handleHitResponse(hit: hit, response: try! JSONEncoder().encode(hitResponse), eventDispatcher: { _ in
             dispatchedEventExpectation.fulfill()
         }) { _, _ in
             sharedStateExpectation.fulfill()
@@ -707,13 +707,13 @@ class IdentityStateTests: XCTestCase {
         var props = IdentityProperties()
         props.lastSync = Date()
         props.privacyStatus = .optedOut
-        let entity = DataEntity.fakeDataEntity()
+        let hit = IdentityHit.fakeHit()
         let hitResponse = IdentityHitResponse.fakeHitResponse(error: nil, optOutList: ["optOut"])
 
         state = IdentityState(identityProperties: props, hitQueue: MockHitQueue(processor: MockHitProcessor()), pushIdManager: mockPushIdManager)
 
         // test
-        state.handleHitResponse(hit: entity, response: try! JSONEncoder().encode(hitResponse), eventDispatcher: { _ in
+        state.handleHitResponse(hit: hit, response: try! JSONEncoder().encode(hitResponse), eventDispatcher: { _ in
             dispatchedEventExpectation.fulfill()
         }) { _, _ in
             sharedStateExpectation.fulfill()
@@ -732,6 +732,7 @@ class IdentityStateTests: XCTestCase {
         // setup
         let dispatchedEventExpectation = XCTestExpectation(description: "One event should be dispatched")
         dispatchedEventExpectation.assertForOverFulfill = true
+        dispatchedEventExpectation.expectedFulfillmentCount = 2
         let sharedStateExpectation = XCTestExpectation(description: "Shared state should not be updated as the response was empty")
         sharedStateExpectation.isInverted = true
 
@@ -742,7 +743,7 @@ class IdentityStateTests: XCTestCase {
         state = IdentityState(identityProperties: props, hitQueue: MockHitQueue(processor: MockHitProcessor()), pushIdManager: mockPushIdManager)
 
         // test
-        state.handleHitResponse(hit: DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: nil), response: nil, eventDispatcher: { _ in
+        state.handleHitResponse(hit: IdentityHit.fakeHit(), response: nil, eventDispatcher: { _ in
             dispatchedEventExpectation.fulfill()
         }) { _, _ in
             sharedStateExpectation.fulfill()
@@ -894,13 +895,12 @@ private extension Event {
     }
 }
 
-private extension DataEntity {
-    static func fakeDataEntity() -> DataEntity {
+private extension IdentityHit {
+    static func fakeHit() -> IdentityHit {
         let event = Event(name: "Hit Event", type: EventType.identity, source: EventSource.requestIdentity, data: nil)
         let hit = IdentityHit(url: URL(string: "adobe.com")!, event: event)
-        let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try! JSONEncoder().encode(hit))
 
-        return entity
+        return hit
     }
 }
 

--- a/AEPIdentity/Tests/IdentityStateTests.swift
+++ b/AEPIdentity/Tests/IdentityStateTests.swift
@@ -103,7 +103,7 @@ class IdentityStateTests: XCTestCase {
         // verify
         XCTAssertEqual(2, eventData!.count)
         XCTAssertNotNil(eventData![IdentityConstants.EventDataKeys.VISITOR_ID_ECID])
-        let idList = eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [CustomIdentity]
+        let idList = eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [[String: Any]]
         XCTAssertEqual(2, idList?.count)
         XCTAssertFalse(mockHitQueue.queuedHits.isEmpty) // hit should be queued in the hit queue
     }
@@ -156,12 +156,13 @@ class IdentityStateTests: XCTestCase {
         XCTAssertEqual(3, eventData!.count)
         XCTAssertNotNil(eventData![IdentityConstants.EventDataKeys.VISITOR_ID_ECID])
         XCTAssertEqual("test-ad-id", eventData![IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] as? String)
-        let idList = eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [CustomIdentity]
+        let idList = eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [[String: Any]]
         XCTAssertEqual(1, idList?.count)
         let customId = idList?.first!
-        XCTAssertEqual("test-ad-id", customId?.identifier)
-        XCTAssertEqual("d_cid_ic", customId?.origin)
-        XCTAssertEqual("DSID_20915", customId?.type)
+        
+        XCTAssertEqual("test-ad-id", customId?[CustomIdentity.CodingKeys.identifier.rawValue] as? String)
+        XCTAssertEqual("d_cid_ic", customId?[CustomIdentity.CodingKeys.origin.rawValue] as? String)
+        XCTAssertEqual("DSID_20915", customId?[CustomIdentity.CodingKeys.type.rawValue] as? String)
         XCTAssertFalse(mockHitQueue.queuedHits.isEmpty) // hit should be queued in the hit queue
     }
 
@@ -208,12 +209,12 @@ class IdentityStateTests: XCTestCase {
         // verify
         XCTAssertEqual(4, eventData!.count)
         XCTAssertEqual("test-ad-id", eventData![IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] as? String)
-        let idList = eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [CustomIdentity]
+        let idList = eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [[String: Any]]
         XCTAssertEqual(1, idList?.count)
         let customId = idList?.first!
-        XCTAssertEqual("test-id", customId?.identifier)
-        XCTAssertEqual("test-origin", customId?.origin)
-        XCTAssertEqual("test-type", customId?.type)
+        XCTAssertEqual("test-id", customId?[CustomIdentity.CodingKeys.identifier.rawValue] as? String)
+        XCTAssertEqual("test-origin", customId?[CustomIdentity.CodingKeys.origin.rawValue] as? String)
+        XCTAssertEqual("test-type", customId?[CustomIdentity.CodingKeys.type.rawValue] as? String)
         XCTAssertTrue(mockHitQueue.queuedHits.isEmpty) // hit should NOT be queued in the hit queue
     }
 
@@ -258,12 +259,12 @@ class IdentityStateTests: XCTestCase {
         XCTAssertEqual(3, eventData!.count)
         XCTAssertNotNil(eventData![IdentityConstants.EventDataKeys.VISITOR_ID_ECID])
         XCTAssertEqual("test-ad-id", eventData![IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] as? String)
-        let idList = eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [CustomIdentity]
+        let idList = eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [[String: Any]]
         XCTAssertEqual(1, idList?.count)
         let customId = idList?.first!
-        XCTAssertEqual("test-ad-id", customId?.identifier)
-        XCTAssertEqual("d_cid_ic", customId?.origin)
-        XCTAssertEqual("DSID_20915", customId?.type)
+        XCTAssertEqual("test-ad-id", customId?[CustomIdentity.CodingKeys.identifier.rawValue] as? String)
+        XCTAssertEqual("d_cid_ic", customId?[CustomIdentity.CodingKeys.origin.rawValue] as? String)
+        XCTAssertEqual("DSID_20915", customId?[CustomIdentity.CodingKeys.type.rawValue] as? String)
         XCTAssertFalse(mockHitQueue.queuedHits.isEmpty) // hit should be queued in the hit queue
         let hit = try! JSONDecoder().decode(IdentityHit.self, from: mockHitQueue.queuedHits.first!.data!)
         XCTAssertFalse(hit.url.absoluteString.contains("device_consent")) // device flag should NOT be added
@@ -287,12 +288,12 @@ class IdentityStateTests: XCTestCase {
         XCTAssertEqual(3, eventData!.count)
         XCTAssertNotNil(eventData![IdentityConstants.EventDataKeys.VISITOR_ID_ECID])
         XCTAssertEqual("test-ad-id", eventData![IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] as? String)
-        let idList = eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [CustomIdentity]
+        let idList = eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [[String: Any]]
         XCTAssertEqual(1, idList?.count)
         let customId = idList?.first!
-        XCTAssertEqual("test-ad-id", customId?.identifier)
-        XCTAssertEqual("d_cid_ic", customId?.origin)
-        XCTAssertEqual("DSID_20915", customId?.type)
+        XCTAssertEqual("test-ad-id", customId?[CustomIdentity.CodingKeys.identifier.rawValue] as? String)
+        XCTAssertEqual("d_cid_ic", customId?[CustomIdentity.CodingKeys.origin.rawValue] as? String)
+        XCTAssertEqual("DSID_20915", customId?[CustomIdentity.CodingKeys.type.rawValue] as? String)
         XCTAssertFalse(mockHitQueue.queuedHits.isEmpty) // hit should be queued in the hit queue
         let hit = try! JSONDecoder().decode(IdentityHit.self, from: mockHitQueue.queuedHits.first!.data!)
         XCTAssertTrue(hit.url.absoluteString.contains("device_consent=1")) // device flag should be added
@@ -316,12 +317,12 @@ class IdentityStateTests: XCTestCase {
         XCTAssertEqual(3, eventData!.count)
         XCTAssertNotNil(eventData![IdentityConstants.EventDataKeys.VISITOR_ID_ECID])
         XCTAssertEqual("test-ad-id", eventData![IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] as? String)
-        let idList = eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [CustomIdentity]
+        let idList = eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [[String: Any]]
         XCTAssertEqual(1, idList?.count)
         let customId = idList?.first!
-        XCTAssertEqual("test-ad-id", customId?.identifier)
-        XCTAssertEqual("d_cid_ic", customId?.origin)
-        XCTAssertEqual("DSID_20915", customId?.type)
+        XCTAssertEqual("test-ad-id", customId?[CustomIdentity.CodingKeys.identifier.rawValue] as? String)
+        XCTAssertEqual("d_cid_ic", customId?[CustomIdentity.CodingKeys.origin.rawValue] as? String)
+        XCTAssertEqual("DSID_20915", customId?[CustomIdentity.CodingKeys.type.rawValue] as? String)
         XCTAssertFalse(mockHitQueue.queuedHits.isEmpty) // hit should be queued in the hit queue
         let hit = try! JSONDecoder().decode(IdentityHit.self, from: mockHitQueue.queuedHits.first!.data!)
         XCTAssertTrue(hit.url.absoluteString.contains("device_consent=1")) // device flag should be added
@@ -345,12 +346,12 @@ class IdentityStateTests: XCTestCase {
         XCTAssertEqual(3, eventData!.count)
         XCTAssertNotNil(eventData![IdentityConstants.EventDataKeys.VISITOR_ID_ECID])
         XCTAssertEqual("test-ad-id", eventData![IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] as? String)
-        let idList = eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [CustomIdentity]
+        let idList = eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [[String: Any]]
         XCTAssertEqual(1, idList?.count)
         let customId = idList?.first!
-        XCTAssertEqual("test-ad-id", customId?.identifier)
-        XCTAssertEqual("d_cid_ic", customId?.origin)
-        XCTAssertEqual("DSID_20915", customId?.type)
+        XCTAssertEqual("test-ad-id", customId?[CustomIdentity.CodingKeys.identifier.rawValue] as? String)
+        XCTAssertEqual("d_cid_ic", customId?[CustomIdentity.CodingKeys.origin.rawValue] as? String)
+        XCTAssertEqual("DSID_20915", customId?[CustomIdentity.CodingKeys.type.rawValue] as? String)
         XCTAssertFalse(mockHitQueue.queuedHits.isEmpty) // hit should be queued in the hit queue
         let hit = try! JSONDecoder().decode(IdentityHit.self, from: mockHitQueue.queuedHits.first!.data!)
         XCTAssertTrue(hit.url.absoluteString.contains("device_consent=1")) // device flag should be added
@@ -484,12 +485,12 @@ class IdentityStateTests: XCTestCase {
         XCTAssertEqual(3, eventData!.count)
         XCTAssertNotNil(eventData![IdentityConstants.EventDataKeys.VISITOR_ID_ECID])
         XCTAssertEqual("test-ad-id", eventData![IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] as? String)
-        let idList = eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [CustomIdentity]
+        let idList = eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [[String: Any]]
         XCTAssertEqual(1, idList?.count)
         let customId = idList?.first!
-        XCTAssertEqual("test-ad-id", customId?.identifier)
-        XCTAssertEqual("d_cid_ic", customId?.origin)
-        XCTAssertEqual("DSID_20915", customId?.type)
+        XCTAssertEqual("test-ad-id", customId?[CustomIdentity.CodingKeys.identifier.rawValue] as? String)
+        XCTAssertEqual("d_cid_ic", customId?[CustomIdentity.CodingKeys.origin.rawValue] as? String)
+        XCTAssertEqual("DSID_20915", customId?[CustomIdentity.CodingKeys.type.rawValue] as? String)
         XCTAssertFalse(mockHitQueue.queuedHits.isEmpty) // hit should be queued in the hit queue
         let hit = try! JSONDecoder().decode(IdentityHit.self, from: mockHitQueue.queuedHits.first!.data!)
         XCTAssertTrue(hit.url.absoluteString.contains("device_consent=1")) // device flag should be added

--- a/AEPIdentity/Tests/IdentityStateTests.swift
+++ b/AEPIdentity/Tests/IdentityStateTests.swift
@@ -159,7 +159,7 @@ class IdentityStateTests: XCTestCase {
         let idList = eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [[String: Any]]
         XCTAssertEqual(1, idList?.count)
         let customId = idList?.first!
-        
+
         XCTAssertEqual("test-ad-id", customId?[CustomIdentity.CodingKeys.identifier.rawValue] as? String)
         XCTAssertEqual("d_cid_ic", customId?[CustomIdentity.CodingKeys.origin.rawValue] as? String)
         XCTAssertEqual("DSID_20915", customId?[CustomIdentity.CodingKeys.type.rawValue] as? String)

--- a/AEPIdentity/Tests/MobileIdentitiesTests.swift
+++ b/AEPIdentity/Tests/MobileIdentitiesTests.swift
@@ -28,7 +28,7 @@ class MobileIdentitiesTests: XCTestCase {
         let customIdTwo = CustomIdentity(origin: "origin2", type: "type2", identifier: "id2", authenticationState: .loggedOut)
         let customIdThree = CustomIdentity(origin: "origin3", type: "DSID_20915", identifier: "test-advertisingId", authenticationState: .loggedOut)
 
-        identitySharedState[IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] = [customIdOne, customIdTwo, customIdThree]
+        identitySharedState[IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] = [customIdOne, customIdTwo, customIdThree].map({$0.asDictionary()})
         identitySharedState[IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] = "test-advertisingId"
         identitySharedState[IdentityConstants.EventDataKeys.PUSH_IDENTIFIER] = "test-pushid"
 

--- a/AEPServices/Sources/utility/AnyCodable.swift
+++ b/AEPServices/Sources/utility/AnyCodable.swift
@@ -251,5 +251,5 @@ extension Encodable {
     public func asDictionary() -> [String: Any]? {
         guard let data = try? JSONEncoder().encode(self) else { return nil }
         return (try? JSONSerialization.jsonObject(with: data, options: .allowFragments)).flatMap { $0 as? [String: Any] }
-  }
+    }
 }

--- a/AEPServices/Sources/utility/AnyCodable.swift
+++ b/AEPServices/Sources/utility/AnyCodable.swift
@@ -245,3 +245,11 @@ extension AnyCodable: Equatable {
         }
     }
 }
+
+// MARK: Codable Helpers
+extension Encodable {
+    public func asDictionary() -> [String: Any]? {
+        guard let data = try? JSONEncoder().encode(self) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data, options: .allowFragments)).flatMap { $0 as? [String: Any] }
+  }
+}


### PR DESCRIPTION
In Events and shared state coming from Identity, we were putting in our custom Swift type `CustomIdentity`, this format didn't match 100% with our v5 event format and also was causing issues when the data was being sent to Assurance as it was unable to deserialize the type.

Original event data:
```jsx
{
    blob = j8Odv6LonN4r3an7LhD3WZrU1bUpAkFkkiY1ncBR96t2PTI;
    lastsync = "1603311210.452279";
    locationhint = 9;
    mid = 90520654536133369506854802638635608086;
    visitoridslist =     (
        "AEPIdentity.CustomIdentity",
        "AEPIdentity.CustomIdentity"
    );
}
```

Updated event data, so now we flatten our `CustomIdentity` to a dictionary for easy reading in event data.
```jsx
{
    "visitoridslist": [
      {
        "id": "1234567",
        "authentication.state": 1,
        "id.origin": "d_cid_ic",
        "id.type": "idType1"
      }
    ],
    "mid": "47638672570484457245556507411373198888",
    "blob": "j8Odv6LonN4r3an7LhD3WZrU1bUpAkFkkiY1ncBR96t2PTI",
    "locationhint": "9"
  }
```

This PR also does some minor refactoring to reduce the number of times we need to decode a `DataEntity` when processing an `IdentityHit`.