### PR TITLE
Added getCanonicalPlatformName API in SystemInfoService

### DIFF
--- a/AEPIdentity/Sources/MobileIdentities.swift
+++ b/AEPIdentity/Sources/MobileIdentities.swift
@@ -132,8 +132,8 @@ struct MobileIdentities: Codable {
     /// - Returns: a `UserID` where the namespace is value, value is identifier, and type is integrationCode
     private static func dictToUserID(dict: [String: Any]) -> UserID? {
         guard let type = dict[CustomIdentity.CodingKeys.type.rawValue] as? String,
-              let identifier = dict[CustomIdentity.CodingKeys.identifier.rawValue] as? String,
-              !identifier.isEmpty else { return nil }
+            let identifier = dict[CustomIdentity.CodingKeys.identifier.rawValue] as? String,
+            !identifier.isEmpty else { return nil }
         return UserID(namespace: type, value: identifier, type: MobileIdentities.INTEGRATION_CODE)
     }
 }

--- a/AEPIdentity/Sources/MobileIdentities.swift
+++ b/AEPIdentity/Sources/MobileIdentities.swift
@@ -132,8 +132,8 @@ struct MobileIdentities: Codable {
     /// - Returns: a `UserID` where the namespace is value, value is identifier, and type is integrationCode
     private static func dictToUserID(dict: [String: Any]) -> UserID? {
         guard let type = dict[CustomIdentity.CodingKeys.type.rawValue] as? String,
-            let identifier = dict[CustomIdentity.CodingKeys.identifier.rawValue] as? String,
-            !identifier.isEmpty else { return nil }
+              let identifier = dict[CustomIdentity.CodingKeys.identifier.rawValue] as? String,
+              !identifier.isEmpty else { return nil }
         return UserID(namespace: type, value: identifier, type: MobileIdentities.INTEGRATION_CODE)
     }
 }

--- a/AEPServices/Mocks/MockSystemInfoService.swift
+++ b/AEPServices/Mocks/MockSystemInfoService.swift
@@ -76,6 +76,11 @@ public class MockSystemInfoService: SystemInfoService {
         return operatingSystemName
     }
 
+    public var platformName: String = ""
+    public func getCanonicalPlatformName() -> String {
+        return platformName
+    }
+
     public var displayInformation: (width: Int, height: Int) = (0, 0)
     public func getDisplayInformation() -> (width: Int, height: Int) {
         return displayInformation

--- a/AEPServices/Sources/ApplicationSystemInfoService.swift
+++ b/AEPServices/Sources/ApplicationSystemInfoService.swift
@@ -103,7 +103,7 @@ class ApplicationSystemInfoService: SystemInfoService {
 
     func getApplicationName() -> String? {
         guard let infoDict = bundle.infoDictionary,
-              let appName = infoDict["CFBundleName"] as? String ?? infoDict["CFBundleDisplayName"] as? String else {
+            let appName = infoDict["CFBundleName"] as? String ?? infoDict["CFBundleDisplayName"] as? String else {
             return nil
         }
 
@@ -120,6 +120,10 @@ class ApplicationSystemInfoService: SystemInfoService {
 
     func getOperatingSystemName() -> String {
         return UIDevice.current.systemName
+    }
+
+    func getCanonicalPlatformName() -> String {
+        return "ios"
     }
 
     func getDisplayInformation() -> (width: Int, height: Int) {

--- a/AEPServices/Sources/ApplicationSystemInfoService.swift
+++ b/AEPServices/Sources/ApplicationSystemInfoService.swift
@@ -103,7 +103,7 @@ class ApplicationSystemInfoService: SystemInfoService {
 
     func getApplicationName() -> String? {
         guard let infoDict = bundle.infoDictionary,
-            let appName = infoDict["CFBundleName"] as? String ?? infoDict["CFBundleDisplayName"] as? String else {
+              let appName = infoDict["CFBundleName"] as? String ?? infoDict["CFBundleDisplayName"] as? String else {
             return nil
         }
 

--- a/AEPServices/Sources/SystemInfoService.swift
+++ b/AEPServices/Sources/SystemInfoService.swift
@@ -59,6 +59,10 @@ public protocol SystemInfoService {
     /// - Return: `String` the operating system's name
     func getOperatingSystemName() -> String
 
+    /// Gets the string representation of the canonical platform name
+    /// - Return: `String` the platform name name
+    func getCanonicalPlatformName() -> String
+
     /// Gets the display information for the system
     /// - Return: `DisplayInformation` the system's display information
     func getDisplayInformation() -> (width: Int, height: Int)

--- a/AEPServices/Tests/services/MockSystemInfoService.swift
+++ b/AEPServices/Tests/services/MockSystemInfoService.swift
@@ -74,6 +74,11 @@ class MockSystemInfoService: SystemInfoService {
         return operatingSystemName
     }
 
+    var platformName: String = ""
+    func getCanonicalPlatformName() -> String {
+        return platformName
+    }
+
     var displayInformation: (width: Int, height: Int) = (0, 0)
     func getDisplayInformation() -> (width: Int, height: Int) {
         return displayInformation

--- a/AEPServices/Tests/services/SystemInfoServiceTest.swift
+++ b/AEPServices/Tests/services/SystemInfoServiceTest.swift
@@ -109,6 +109,10 @@ class SystemInfoServiceTest: XCTestCase {
         XCTAssertNotNil(systemInfoService.getOperatingSystemName())
     }
 
+    func testGetCanonicalPlatformName() {
+        XCTAssertEqual("ios", systemInfoService.getCanonicalPlatformName())
+    }
+
     func testGetDisplayInformation() {
         let displayInfo = NativeDisplayInformation()
         let testDisplayInfo = systemInfoService.getDisplayInformation()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added getCanonicalPlatformName API that is used by Audience Manager Extension
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
This API is present in the Objective-C services and needs to be added in this Swift services as well. 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Unit test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
