### PR TITLE
XDM shared state APIs

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		21F79ABF24E71B03003204C3 /* IDParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F79ABD24E7144F003204C3 /* IDParserTests.swift */; };
 		21F79AC124E72204003204C3 /* V4MigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F79AC024E72204003204C3 /* V4MigratorTests.swift */; };
 		21F905F5255099010067D61B /* SharedStateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F905F4255099010067D61B /* SharedStateType.swift */; };
+		21F906052550A3C60067D61B /* SharedStateData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F906042550A3C60067D61B /* SharedStateData.swift */; };
 		21FE152024F03254008A82FF /* IdentityPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FE151F24F03254008A82FF /* IdentityPublicAPITests.swift */; };
 		21FE152124F0335E008A82FF /* MockExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3951F524CA096100F7325B /* MockExtension.swift */; };
 		21FE152224F03386008A82FF /* EventHub+Testable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3951FC24CA096100F7325B /* EventHub+Testable.swift */; };
@@ -585,6 +586,7 @@
 		21F79ABD24E7144F003204C3 /* IDParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDParserTests.swift; sourceTree = "<group>"; };
 		21F79AC024E72204003204C3 /* V4MigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V4MigratorTests.swift; sourceTree = "<group>"; };
 		21F905F4255099010067D61B /* SharedStateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStateType.swift; sourceTree = "<group>"; };
+		21F906042550A3C60067D61B /* SharedStateData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStateData.swift; sourceTree = "<group>"; };
 		21FE151F24F03254008A82FF /* IdentityPublicAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityPublicAPITests.swift; sourceTree = "<group>"; };
 		2420365124E35EEB0069C89D /* SignalHitProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalHitProcessorTests.swift; sourceTree = "<group>"; };
 		243DCE4624C7AA2800E99AD9 /* AEPServices.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEPServices.h; sourceTree = "<group>"; };
@@ -1595,6 +1597,7 @@
 				3FB66AAB24CA004400502CAF /* SharedState.swift */,
 				217E220424D1FD7900B70B3E /* SharedStateResult.swift */,
 				21F905F4255099010067D61B /* SharedStateType.swift */,
+				21F906042550A3C60067D61B /* SharedStateData.swift */,
 			);
 			path = eventhub;
 			sourceTree = "<group>";
@@ -2432,6 +2435,7 @@
 				215A6CE224ED92C500FE0657 /* V4MigrationConstants.swift in Sources */,
 				217E220524D1FD7900B70B3E /* SharedStateResult.swift in Sources */,
 				BB00E26924D8C94600C578C1 /* Dictionary+Flatten.swift in Sources */,
+				21F906052550A3C60067D61B /* SharedStateData.swift in Sources */,
 				3FB66AD524CA004400502CAF /* EventHubError.swift in Sources */,
 				3FB66AD324CA004400502CAF /* ExtensionRuntime.swift in Sources */,
 				3FB66AE324CA004400502CAF /* ConfigurationDownloadable.swift in Sources */,

--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		21F79ABB24E70CDC003204C3 /* IDParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F79ABA24E70CDC003204C3 /* IDParsing.swift */; };
 		21F79ABF24E71B03003204C3 /* IDParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F79ABD24E7144F003204C3 /* IDParserTests.swift */; };
 		21F79AC124E72204003204C3 /* V4MigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F79AC024E72204003204C3 /* V4MigratorTests.swift */; };
+		21F905F5255099010067D61B /* SharedStateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F905F4255099010067D61B /* SharedStateType.swift */; };
 		21FE152024F03254008A82FF /* IdentityPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FE151F24F03254008A82FF /* IdentityPublicAPITests.swift */; };
 		21FE152124F0335E008A82FF /* MockExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3951F524CA096100F7325B /* MockExtension.swift */; };
 		21FE152224F03386008A82FF /* EventHub+Testable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3951FC24CA096100F7325B /* EventHub+Testable.swift */; };
@@ -583,6 +584,7 @@
 		21F79ABA24E70CDC003204C3 /* IDParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDParsing.swift; sourceTree = "<group>"; };
 		21F79ABD24E7144F003204C3 /* IDParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDParserTests.swift; sourceTree = "<group>"; };
 		21F79AC024E72204003204C3 /* V4MigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V4MigratorTests.swift; sourceTree = "<group>"; };
+		21F905F4255099010067D61B /* SharedStateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStateType.swift; sourceTree = "<group>"; };
 		21FE151F24F03254008A82FF /* IdentityPublicAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityPublicAPITests.swift; sourceTree = "<group>"; };
 		2420365124E35EEB0069C89D /* SignalHitProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalHitProcessorTests.swift; sourceTree = "<group>"; };
 		243DCE4624C7AA2800E99AD9 /* AEPServices.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEPServices.h; sourceTree = "<group>"; };
@@ -1592,6 +1594,7 @@
 				3FB66AAD24CA004400502CAF /* ExtensionRuntime.swift */,
 				3FB66AAB24CA004400502CAF /* SharedState.swift */,
 				217E220424D1FD7900B70B3E /* SharedStateResult.swift */,
+				21F905F4255099010067D61B /* SharedStateType.swift */,
 			);
 			path = eventhub;
 			sourceTree = "<group>";
@@ -2457,6 +2460,7 @@
 				3FB66AD024CA004400502CAF /* AEPError.swift in Sources */,
 				3FB66AD424CA004400502CAF /* EventType.swift in Sources */,
 				3F5D45F8251903030040E298 /* LaunchRuleTransformer.swift in Sources */,
+				21F905F5255099010067D61B /* SharedStateType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AEPCore/Mocks/TestableExtensionRuntime.swift
+++ b/AEPCore/Mocks/TestableExtensionRuntime.swift
@@ -56,12 +56,12 @@ public class TestableExtensionRuntime: ExtensionRuntime {
         }
         return mockedSharedStates["\(extensionName)"]
     }
-    
+
     public func createSharedState(data: [String : Any], xdmData: [String : Any], event: Event?) {
         createdSharedStates += [data]
         createdXdmSharedStates += [xdmData]
     }
-    
+
     public func getXDMSharedState(extensionName: String, event: Event?) -> SharedStateResult? {
         if let id = event?.id {
             return mockedXdmSharedStates["\(extensionName)-\(id)"] ?? mockedXdmSharedStates["\(extensionName)"]

--- a/AEPCore/Mocks/TestableExtensionRuntime.swift
+++ b/AEPCore/Mocks/TestableExtensionRuntime.swift
@@ -20,7 +20,9 @@ public class TestableExtensionRuntime: ExtensionRuntime {
     public var listeners: [String: EventListener] = [:]
     public var dispatchedEvents: [Event] = []
     public var createdSharedStates: [[String: Any]?] = []
+    public var createdXdmSharedStates: [[String: Any]?] = []
     public var mockedSharedStates: [String: SharedStateResult] = [:]
+    public var mockedXdmSharedStates: [String: SharedStateResult] = [:]
 
     public init() {}
 
@@ -53,6 +55,18 @@ public class TestableExtensionRuntime: ExtensionRuntime {
             return mockedSharedStates["\(extensionName)-\(id)"] ?? mockedSharedStates["\(extensionName)"]
         }
         return mockedSharedStates["\(extensionName)"]
+    }
+    
+    public func createSharedState(data: [String : Any], xdmData: [String : Any], event: Event?) {
+        createdSharedStates += [data]
+        createdXdmSharedStates += [xdmData]
+    }
+    
+    public func getXDMSharedState(extensionName: String, event: Event?) -> SharedStateResult? {
+        if let id = event?.id {
+            return mockedXdmSharedStates["\(extensionName)-\(id)"] ?? mockedXdmSharedStates["\(extensionName)"]
+        }
+        return mockedXdmSharedStates["\(extensionName)"]
     }
 
     public func startEvents() {}

--- a/AEPCore/Mocks/TestableExtensionRuntime.swift
+++ b/AEPCore/Mocks/TestableExtensionRuntime.swift
@@ -39,8 +39,9 @@ public class TestableExtensionRuntime: ExtensionRuntime {
         dispatchedEvents += [event]
     }
 
-    public func createSharedState(data: [String: Any], event _: Event?) {
+    public func createSharedState(data: [String : Any], xdmData: [String : Any]?, event: Event?) {
         createdSharedStates += [data]
+        createdXdmSharedStates += [xdmData]
     }
 
     public func createPendingSharedState(event _: Event?) -> SharedStateResolver {
@@ -55,11 +56,6 @@ public class TestableExtensionRuntime: ExtensionRuntime {
             return mockedSharedStates["\(extensionName)-\(id)"] ?? mockedSharedStates["\(extensionName)"]
         }
         return mockedSharedStates["\(extensionName)"]
-    }
-
-    public func createSharedState(data: [String : Any], xdmData: [String : Any], event: Event?) {
-        createdSharedStates += [data]
-        createdXdmSharedStates += [xdmData]
     }
 
     public func getXDMSharedState(extensionName: String, event: Event?) -> SharedStateResult? {

--- a/AEPCore/Sources/configuration/Configuration.swift
+++ b/AEPCore/Sources/configuration/Configuration.swift
@@ -56,7 +56,7 @@ class Configuration: Extension {
         if !config.isEmpty {
             let responseEvent = Event(name: CoreConstants.EventNames.CONFIGURATION_RESPONSE_EVENT, type: EventType.configuration, source: EventSource.responseContent, data: config)
             dispatch(event: responseEvent)
-            createSharedState(data: config, event: nil)
+            createSharedState(data: config, xdmData: nil, event: nil)
             // notify rules engine to load cached rules
             if let rulesURLString = config[ConfigurationConstants.Keys.RULES_URL] as? String {
                 rulesEngine.loadCachedRules(for: rulesURLString)

--- a/AEPCore/Sources/eventhub/Extension.swift
+++ b/AEPCore/Sources/eventhub/Extension.swift
@@ -81,9 +81,10 @@ public extension Extension {
     /// 2. If this extension has previously published a shared state, shared state will be versioned at the latest
     /// - Parameters:
     ///   - data: Data for the `SharedState`
+    ///   - xdmData: XDM data for the `SharedState`
     ///   - event: `Event` for which the `SharedState` should be versioned
-    func createSharedState(data: [String: Any], event: Event?) {
-        runtime.createSharedState(data: data, event: event)
+    func createSharedState(data: [String: Any], xdmData: [String: Any]?, event: Event?) {
+        runtime.createSharedState(data: data, xdmData: xdmData, event: event)
     }
 
     /// Creates a pending `SharedState` versioned at `event`

--- a/AEPCore/Sources/eventhub/ExtensionContainer.swift
+++ b/AEPCore/Sources/eventhub/ExtensionContainer.swift
@@ -85,7 +85,7 @@ extension ExtensionContainer: ExtensionRuntime {
     }
 
     func createSharedState(data: [String: Any], event: Event?) {
-        EventHub.shared.createSharedState(extensionName: sharedStateName, data: data, event: event)
+        EventHub.shared.createSharedState(extensionName: sharedStateName, data: data, xdmData: nil, event: event)
     }
 
     func createPendingSharedState(event: Event?) -> SharedStateResolver {
@@ -94,6 +94,14 @@ extension ExtensionContainer: ExtensionRuntime {
 
     func getSharedState(extensionName: String, event: Event?, barrier: Bool = true) -> SharedStateResult? {
         return EventHub.shared.getSharedState(extensionName: extensionName, event: event, barrier: barrier)
+    }
+
+    func createSharedState(data: [String: Any], xdmData: [String: Any], event: Event?) {
+        EventHub.shared.createSharedState(extensionName: sharedStateName, data: data, xdmData: xdmData, event: event)
+    }
+    
+    func getXDMSharedState(extensionName: String, event: Event?, barrier: Bool = true) -> SharedStateResult? {
+        return EventHub.shared.getSharedState(extensionName: extensionName, event: event, sharedStateType: .xdm, barrier: barrier)
     }
 
     func startEvents() {

--- a/AEPCore/Sources/eventhub/ExtensionContainer.swift
+++ b/AEPCore/Sources/eventhub/ExtensionContainer.swift
@@ -99,7 +99,7 @@ extension ExtensionContainer: ExtensionRuntime {
     func createSharedState(data: [String: Any], xdmData: [String: Any], event: Event?) {
         EventHub.shared.createSharedState(extensionName: sharedStateName, data: data, xdmData: xdmData, event: event)
     }
-    
+
     func getXDMSharedState(extensionName: String, event: Event?, barrier: Bool = true) -> SharedStateResult? {
         return EventHub.shared.getSharedState(extensionName: extensionName, event: event, sharedStateType: .xdm, barrier: barrier)
     }

--- a/AEPCore/Sources/eventhub/ExtensionContainer.swift
+++ b/AEPCore/Sources/eventhub/ExtensionContainer.swift
@@ -84,8 +84,8 @@ extension ExtensionContainer: ExtensionRuntime {
         EventHub.shared.dispatch(event: event)
     }
 
-    func createSharedState(data: [String: Any], event: Event?) {
-        EventHub.shared.createSharedState(extensionName: sharedStateName, data: data, xdmData: nil, event: event)
+    func createSharedState(data: [String: Any], xdmData: [String: Any]?, event: Event?) {
+        EventHub.shared.createSharedState(extensionName: sharedStateName, data: data, xdmData: xdmData, event: event)
     }
 
     func createPendingSharedState(event: Event?) -> SharedStateResolver {
@@ -94,10 +94,6 @@ extension ExtensionContainer: ExtensionRuntime {
 
     func getSharedState(extensionName: String, event: Event?, barrier: Bool = true) -> SharedStateResult? {
         return EventHub.shared.getSharedState(extensionName: extensionName, event: event, barrier: barrier)
-    }
-
-    func createSharedState(data: [String: Any], xdmData: [String: Any], event: Event?) {
-        EventHub.shared.createSharedState(extensionName: sharedStateName, data: data, xdmData: xdmData, event: event)
     }
 
     func getXDMSharedState(extensionName: String, event: Event?) -> SharedStateResult? {

--- a/AEPCore/Sources/eventhub/ExtensionContainer.swift
+++ b/AEPCore/Sources/eventhub/ExtensionContainer.swift
@@ -100,8 +100,8 @@ extension ExtensionContainer: ExtensionRuntime {
         EventHub.shared.createSharedState(extensionName: sharedStateName, data: data, xdmData: xdmData, event: event)
     }
 
-    func getXDMSharedState(extensionName: String, event: Event?, barrier: Bool = true) -> SharedStateResult? {
-        return EventHub.shared.getSharedState(extensionName: extensionName, event: event, sharedStateType: .xdm, barrier: barrier)
+    func getXDMSharedState(extensionName: String, event: Event?) -> SharedStateResult? {
+        return EventHub.shared.getSharedState(extensionName: extensionName, event: event, sharedStateType: .xdm, barrier: false)
     }
 
     func startEvents() {

--- a/AEPCore/Sources/eventhub/ExtensionRuntime.swift
+++ b/AEPCore/Sources/eventhub/ExtensionRuntime.swift
@@ -66,7 +66,7 @@ public protocol ExtensionRuntime {
     ///   - barrier: If true, the `EventHub` will only return `.set` if `extensionName` has moved past `event`
     /// - Returns: A `SharedStateResult?` for the requested `extensionName` and `event`
     func getSharedState(extensionName: String, event: Event?, barrier: Bool) -> SharedStateResult?
-    
+
     /// Creates a new `SharedState` for this extension
     /// If `event` is nil, one of two behaviors will be observed:
     /// 1. If this extension has not previously published a shared state, shared state will be versioned at 0
@@ -76,7 +76,7 @@ public protocol ExtensionRuntime {
     ///   - xdmData: XDM data for the `SharedState`
     ///   - event: `Event` for which the `SharedState` should be versioned
     func createSharedState(data: [String: Any], xdmData: [String: Any], event: Event?)
-    
+
     /// Gets the XDM `SharedState` data for a specified extension
     /// - Parameters:
     ///   - extensionName: An extension name whose `SharedState` will be returned

--- a/AEPCore/Sources/eventhub/ExtensionRuntime.swift
+++ b/AEPCore/Sources/eventhub/ExtensionRuntime.swift
@@ -48,8 +48,9 @@ public protocol ExtensionRuntime {
     /// 2. If this extension has previously published a shared state, shared state will be versioned at the latest
     /// - Parameters:
     ///   - data: Data for the `SharedState`
+    ///   - xdmData: XDM data for the `SharedState`
     ///   - event: `Event` for which the `SharedState` should be versioned
-    func createSharedState(data: [String: Any], event: Event?)
+    func createSharedState(data: [String: Any], xdmData: [String: Any]?, event: Event?)
 
     /// Creates a pending `SharedState` versioned at `event`
     /// If `event` is nil, one of two behaviors will be observed:
@@ -66,16 +67,6 @@ public protocol ExtensionRuntime {
     ///   - barrier: If true, the `EventHub` will only return `.set` if `extensionName` has moved past `event`
     /// - Returns: A `SharedStateResult?` for the requested `extensionName` and `event`
     func getSharedState(extensionName: String, event: Event?, barrier: Bool) -> SharedStateResult?
-
-    /// Creates a new `SharedState` for this extension
-    /// If `event` is nil, one of two behaviors will be observed:
-    /// 1. If this extension has not previously published a shared state, shared state will be versioned at 0
-    /// 2. If this extension has previously published a shared state, shared state will be versioned at the latest
-    /// - Parameters:
-    ///   - data: Data for the `SharedState`
-    ///   - xdmData: XDM data for the `SharedState`
-    ///   - event: `Event` for which the `SharedState` should be versioned
-    func createSharedState(data: [String: Any], xdmData: [String: Any], event: Event?)
 
     /// Gets the XDM `SharedState` data for a specified extension
     /// - Parameters:

--- a/AEPCore/Sources/eventhub/ExtensionRuntime.swift
+++ b/AEPCore/Sources/eventhub/ExtensionRuntime.swift
@@ -66,4 +66,21 @@ public protocol ExtensionRuntime {
     ///   - barrier: If true, the `EventHub` will only return `.set` if `extensionName` has moved past `event`
     /// - Returns: A `SharedStateResult?` for the requested `extensionName` and `event`
     func getSharedState(extensionName: String, event: Event?, barrier: Bool) -> SharedStateResult?
+    
+    /// Creates a new `SharedState` for this extension
+    /// If `event` is nil, one of two behaviors will be observed:
+    /// 1. If this extension has not previously published a shared state, shared state will be versioned at 0
+    /// 2. If this extension has previously published a shared state, shared state will be versioned at the latest
+    /// - Parameters:
+    ///   - data: Data for the `SharedState`
+    ///   - xdmData: XDM data for the `SharedState`
+    ///   - event: `Event` for which the `SharedState` should be versioned
+    func createSharedState(data: [String: Any], xdmData: [String: Any], event: Event?)
+    
+    /// Gets the XDM `SharedState` data for a specified extension
+    /// - Parameters:
+    ///   - extensionName: An extension name whose `SharedState` will be returned
+    ///   - event: If not nil, will retrieve the `SharedState` that corresponds with the event's version, if nil will return the latest `SharedState`
+    /// - Returns: A `SharedStateResult?` for the requested `extensionName` and `event`
+    func getXDMSharedState(extensionName: String, event: Event?) -> SharedStateResult?
 }

--- a/AEPCore/Sources/eventhub/SharedState.swift
+++ b/AEPCore/Sources/eventhub/SharedState.swift
@@ -40,7 +40,7 @@ class SharedState {
     /// - Parameters:
     ///   - version: The version of the `SharedState` to set (must be > any existing version)
     ///   - data: The data dictionary to set.
-    internal func set(version: Int, data: [String: Any]?) {
+    internal func set(version: Int, data: SharedStateData?) {
         add(version: version, data: data, status: .set)
     }
 
@@ -56,7 +56,7 @@ class SharedState {
     /// - Parameters:
     ///   - version: The version of the pending `SharedState` to set (must already exist)
     ///   - data: The data dictionary to set.
-    internal func updatePending(version: Int, data: [String: Any]?) {
+    internal func updatePending(version: Int, data: SharedStateData?) {
         queue.async(flags: .barrier) {
             var current = self.head
             while let node = current {
@@ -81,7 +81,7 @@ class SharedState {
     /// - Returns
     ///     - value: The current set value for the shared state
     ///     - status: The current `SharedState.Status` of the returned state
-    internal func resolve(version: Int) -> (value: [String: Any]?, status: SharedStateStatus) {
+    internal func resolve(version: Int) -> (value: SharedStateData?, status: SharedStateStatus) {
         return queue.sync {
             var current = self.head
             while let node = current {
@@ -98,7 +98,7 @@ class SharedState {
 
     // MARK: - Private API
 
-    private func add(version: Int, data: [String: Any]?, status: SharedStateStatus) {
+    private func add(version: Int, data: SharedStateData?, status: SharedStateStatus) {
         queue.async(flags: .barrier) {
             if let head = self.head {
                 if head.version < version {
@@ -119,7 +119,7 @@ class SharedState {
         var nodeStatus: SharedStateStatus = .pending
         var previousNode: Node?
         let version: Int
-        var data: [String: Any]?
+        var data: SharedStateData?
 
         /// Appends a `Node` to this `Node` and returns the new `Node`
         /// - Parameters:
@@ -127,13 +127,13 @@ class SharedState {
         ///   - data: the data for the shared state
         ///   - status: the status of the shared state
         /// - Returns: A `Node` with a reference to the previous `Node`
-        func append(version: Int, data: [String: Any]?, status: SharedStateStatus) -> Node {
+        func append(version: Int, data: SharedStateData?, status: SharedStateStatus) -> Node {
             let newNode = Node(version: version, data: data, status: status)
             newNode.previousNode = self
             return newNode
         }
 
-        init(version: Int, data: [String: Any]?, status: SharedStateStatus) {
+        init(version: Int, data: SharedStateData?, status: SharedStateStatus) {
             self.version = version
             self.data = data
             nodeStatus = status

--- a/AEPCore/Sources/eventhub/SharedStateData.swift
+++ b/AEPCore/Sources/eventhub/SharedStateData.swift
@@ -11,8 +11,8 @@
 
 import Foundation
 
-/// Represents the `SharedState` types in `EventHub`
-enum SharedStateType: String {
-    case standard
-    case xdm
+/// Represents data stored in `SharedState`
+struct SharedStateData {
+    let standard: [String: Any]?
+    let xdm: [String: Any]?
 }

--- a/AEPCore/Sources/eventhub/SharedStateType.swift
+++ b/AEPCore/Sources/eventhub/SharedStateType.swift
@@ -1,0 +1,18 @@
+/*
+ Copyright 2020 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+
+/// Represents the `SharedState` types in `EventHub`
+enum SharedStateType: String {
+    case standard = "standard"
+    case xdm = "xdm"
+}

--- a/AEPCore/Tests/EventHubTests/EventHubTests.swift
+++ b/AEPCore/Tests/EventHubTests/EventHubTests.swift
@@ -33,6 +33,10 @@ class EventHubTests: XCTestCase {
         XCTAssertEqual(eventHub.getSharedState(extensionName: extensionName, event: event)?.value![SharedStateTestHelper.DICT_KEY] as! String, dictionaryValue)
     }
 
+    private func validateXDMSharedState(_ extensionName: String, _ event: Event?, _ dictionaryValue: String) {
+        XCTAssertEqual(eventHub.getSharedState(extensionName: extensionName, event: event, sharedStateType: .xdm)?.value![SharedStateTestHelper.DICT_KEY] as! String, dictionaryValue)
+    }
+
     private func registerMockExtension<T: Extension>(_ type: T.Type) {
         let semaphore = DispatchSemaphore(value: 0)
         eventHub.registerExtension(type) { error in
@@ -629,7 +633,7 @@ class EventHubTests: XCTestCase {
         eventHub.start()
 
         // test
-        eventHub.createSharedState(extensionName: "mockExtensionTwo", data: SharedStateTestHelper.ONE, event: nil)
+        eventHub.createSharedState(extensionName: "mockExtensionTwo", data: SharedStateTestHelper.ONE.standard, event: nil)
 
         // verify
         XCTAssertNil(eventHub.getSharedState(extensionName: "notRegistered", event: nil))
@@ -641,7 +645,7 @@ class EventHubTests: XCTestCase {
         eventHub.start()
 
         // test
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE, event: nil)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE.standard, event: nil)
 
         // verify
         validateSharedState(EventHubTests.MOCK_EXTENSION_NAME, nil, "one")
@@ -655,7 +659,7 @@ class EventHubTests: XCTestCase {
         // test
         let event = Event(name: "event", type: EventType.analytics, source: EventSource.requestContent, data: nil)
         eventHub.dispatch(event: event)
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE, event: event)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE.standard, event: event)
 
         // verify
         validateSharedState(EventHubTests.MOCK_EXTENSION_NAME, event, "one")
@@ -669,10 +673,10 @@ class EventHubTests: XCTestCase {
         // test
         let event = Event(name: "event", type: EventType.analytics, source: EventSource.requestContent, data: nil)
         eventHub.dispatch(event: event)
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE, event: event)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE.standard, event: event)
 
         validateSharedState(EventHubTests.MOCK_EXTENSION_NAME, event, "one")
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.TWO, event: event) // already set shared state for this version, should fail
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.TWO.standard, event: event) // already set shared state for this version, should fail
 
         // verify
         validateSharedState(EventHubTests.MOCK_EXTENSION_NAME, event, "one")
@@ -686,10 +690,10 @@ class EventHubTests: XCTestCase {
         // test
         let event = Event(name: "event", type: EventType.analytics, source: EventSource.requestContent, data: nil)
         eventHub.dispatch(event: event)
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE, event: event)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE.standard, event: event)
         let event1 = Event(name: "event1", type: EventType.analytics, source: EventSource.requestContent, data: nil)
         eventHub.dispatch(event: event1)
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.TWO, event: event1)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.TWO.standard, event: event1)
 
         // verify
         validateSharedState(EventHubTests.MOCK_EXTENSION_NAME, event, "one")
@@ -704,10 +708,10 @@ class EventHubTests: XCTestCase {
         // test
         let event = Event(name: "Test event", type: EventType.analytics, source: EventSource.none, data: nil)
         eventHub.dispatch(event: event)
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE, event: event)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE.standard, event: event)
         let event1 = Event(name: "Test event", type: EventType.analytics, source: EventSource.none, data: nil)
         eventHub.dispatch(event: event1)
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.TWO, event: event1)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.TWO.standard, event: event1)
 
         // verify
         validateSharedState(EventHubTests.MOCK_EXTENSION_NAME, event1, "two")
@@ -721,17 +725,17 @@ class EventHubTests: XCTestCase {
         // test
         let event = Event(name: "Test event", type: EventType.analytics, source: EventSource.none, data: nil)
         eventHub.dispatch(event: event)
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE, event: event)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE.standard, event: event)
         validateSharedState(EventHubTests.MOCK_EXTENSION_NAME, event, "one")
 
         let event1 = Event(name: "Test event", type: EventType.analytics, source: EventSource.none, data: nil)
         eventHub.dispatch(event: event1)
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.TWO, event: event1)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.TWO.standard, event: event1)
         validateSharedState(EventHubTests.MOCK_EXTENSION_NAME, event1, "two")
 
         let event2 = Event(name: "Test event", type: EventType.analytics, source: EventSource.none, data: nil)
         eventHub.dispatch(event: event2)
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.THREE, event: event2)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.THREE.standard, event: event2)
 
         // verify
         validateSharedState(EventHubTests.MOCK_EXTENSION_NAME, event2, "three")
@@ -745,7 +749,7 @@ class EventHubTests: XCTestCase {
         // test
         let event = Event(name: "test", type: EventType.analytics, source: EventSource.requestContent, data: nil)
         eventHub.dispatch(event: event)
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE, event: nil)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE.standard, event: nil)
 
         // verify
         validateSharedState(EventHubTests.MOCK_EXTENSION_NAME, event, "one")
@@ -759,10 +763,10 @@ class EventHubTests: XCTestCase {
         // test
         let event = Event(name: "test", type: EventType.analytics, source: EventSource.requestContent, data: nil)
         eventHub.dispatch(event: event)
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE, event: event)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE.standard, event: event)
         let event1 = Event(name: "test1", type: EventType.analytics, source: EventSource.requestContent, data: nil)
         eventHub.dispatch(event: event1)
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.TWO, event: event1)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.TWO.standard, event: event1)
 
         // verify
         validateSharedState(EventHubTests.MOCK_EXTENSION_NAME, event, "one")
@@ -774,7 +778,7 @@ class EventHubTests: XCTestCase {
         eventHub.start()
 
         // test
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE, event: nil)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE.standard, event: nil)
 
         // verify
         validateSharedState(EventHubTests.MOCK_EXTENSION_NAME, nil, "one")
@@ -785,8 +789,8 @@ class EventHubTests: XCTestCase {
         eventHub.start()
 
         // test
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE, event: nil)
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.TWO, event: nil)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE.standard, event: nil)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.TWO.standard, event: nil)
 
         // verify
         validateSharedState(EventHubTests.MOCK_EXTENSION_NAME, nil, "one")
@@ -797,10 +801,10 @@ class EventHubTests: XCTestCase {
         eventHub.start()
 
         // test
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE, event: nil)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE.standard, event: nil)
         let event1 = Event(name: "test1", type: EventType.analytics, source: EventSource.requestContent, data: nil)
         eventHub.dispatch(event: event1)
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.TWO, event: event1)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.TWO.standard, event: event1)
 
         // verify
         validateSharedState(EventHubTests.MOCK_EXTENSION_NAME, nil, "one")
@@ -871,7 +875,7 @@ class EventHubTests: XCTestCase {
 
         // test
         let pendingResolver = eventHub.createPendingSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, event: event)
-        pendingResolver(SharedStateTestHelper.ONE)
+        pendingResolver(SharedStateTestHelper.ONE.standard)
 
         // verify
         wait(for: [expectation], timeout: 1)
@@ -918,13 +922,13 @@ class EventHubTests: XCTestCase {
             }
         }
 
-        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE, event: nil)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: SharedStateTestHelper.ONE.standard, event: nil)
 
         // test
         let event = Event(name: "test", type: EventType.acquisition, source: EventSource.sharedState, data: nil)
         eventHub.dispatch(event: event)
         let pendingResolver = eventHub.createPendingSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, event: event)
-        pendingResolver(SharedStateTestHelper.TWO)
+        pendingResolver(SharedStateTestHelper.TWO.standard)
 
         wait(for: [expectation], timeout: 1)
         validateSharedState(EventHubTests.MOCK_EXTENSION_NAME, event, "two")
@@ -1004,7 +1008,7 @@ class EventHubTests: XCTestCase {
 
         // test
         let pendingResolver = eventHub.createPendingSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, event: nil)
-        pendingResolver(SharedStateTestHelper.ONE)
+        pendingResolver(SharedStateTestHelper.ONE.standard)
 
         // verify
         wait(for: [expectation], timeout: 1)
@@ -1040,5 +1044,32 @@ class EventHubTests: XCTestCase {
 
         // verify
         wait(for: [targetRequestContentExpectation, analyticsRequestContentExpectation], timeout: 1)
+    }
+
+    // MARK: XDM SharedState Tests
+    /// Tests that a registered extension can publish shared state
+    func testGetXDMSharedStateSimple() {
+        // setup
+        eventHub.start()
+
+        // test
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: nil, xdmData: SharedStateTestHelper.ONE.standard, event: nil)
+
+        // verify
+        validateXDMSharedState(EventHubTests.MOCK_EXTENSION_NAME, nil, "one")
+    }
+
+    /// Tests that a registered extension can publish shared state versioned at an event
+    func testGetXDMSharedStateSimpleWithEvent() {
+        // setup
+        eventHub.start()
+
+        // test
+        let event = Event(name: "event", type: EventType.analytics, source: EventSource.requestContent, data: nil)
+        eventHub.dispatch(event: event)
+        eventHub.createSharedState(extensionName: EventHubTests.MOCK_EXTENSION_NAME, data: nil, xdmData: SharedStateTestHelper.ONE.standard, event: event)
+
+        // verify
+        validateXDMSharedState(EventHubTests.MOCK_EXTENSION_NAME, event, "one")
     }
 }

--- a/AEPCore/Tests/EventHubTests/SharedStateTest.swift
+++ b/AEPCore/Tests/EventHubTests/SharedStateTest.swift
@@ -19,7 +19,7 @@ class SharedStateTest: XCTestCase {
 
     // helper function
     func validateSharedState(_ version: Int, _ dictionaryValue: String) {
-        XCTAssertEqual(sharedState.resolve(version: version).value![SharedStateTestHelper.DICT_KEY] as! String, dictionaryValue)
+        XCTAssertEqual(sharedState.resolve(version: version).value!.standard?[SharedStateTestHelper.DICT_KEY] as! String, dictionaryValue)
     }
 
     override func setUp() {
@@ -140,7 +140,7 @@ class SharedStateTest: XCTestCase {
         let (data, _) = sharedState.resolve(version: 2)
 
         // verify
-        XCTAssertEqual(SharedStateTestHelper.ONE as! [String: String], data as! [String: String])
+        XCTAssertEqual(SharedStateTestHelper.ONE.standard as! [String: String], data?.standard as! [String: String])
     }
 
     func testSharedStateIsEmpty() {

--- a/AEPCore/Tests/FunctionalTests/EventHubContractTests.swift
+++ b/AEPCore/Tests/FunctionalTests/EventHubContractTests.swift
@@ -281,8 +281,8 @@ class EventHubContractTest: XCTestCase {
             startExpectation.fulfill()
         }
         wait(for: [startExpectation], timeout: 1)
-        ContractExtensionOne.runtime?.createSharedState(data: ["event":"first"], event: event1)
-        ContractExtensionOne.runtime?.createSharedState(data: ["event":"second"], event: event2)
+        ContractExtensionOne.runtime?.createSharedState(data: ["event":"first"], xdmData: nil, event: event1)
+        ContractExtensionOne.runtime?.createSharedState(data: ["event":"second"], xdmData: nil, event: event2)
 
         // verify
         let sharedStateForEvent1 = ContractExtensionOne.runtime?.getSharedState(extensionName: "com.adobe.ContractExtensionOne", event: event1, barrier: true)
@@ -306,8 +306,8 @@ class EventHubContractTest: XCTestCase {
             startExpectation.fulfill()
         }
         wait(for: [startExpectation], timeout: 1)
-        ContractExtensionOne.runtime?.createSharedState(data: ["event":"second"], event: event2)
-        ContractExtensionOne.runtime?.createSharedState(data: ["event":"first"], event: event1)
+        ContractExtensionOne.runtime?.createSharedState(data: ["event":"second"], xdmData: nil, event: event2)
+        ContractExtensionOne.runtime?.createSharedState(data: ["event":"first"], xdmData: nil, event: event1)
 
         // verify
         let sharedStateForEvent1 = ContractExtensionOne.runtime?.getSharedState(extensionName: "com.adobe.ContractExtensionOne", event: event1, barrier: true)
@@ -334,7 +334,7 @@ class EventHubContractTest: XCTestCase {
             startExpectation.fulfill()
         }
         wait(for: [startExpectation], timeout: 1)
-        ContractExtensionOne.runtime?.createSharedState(data: ["event":"first"], event: event1)
+        ContractExtensionOne.runtime?.createSharedState(data: ["event":"first"], xdmData: nil, event: event1)
 
         // verify
         let sharedStateForEvent1 = ContractExtensionOne.runtime?.getSharedState(extensionName: "com.adobe.ContractExtensionOne", event: event1, barrier: true)
@@ -364,8 +364,8 @@ class EventHubContractTest: XCTestCase {
             startExpectation.fulfill()
         }
         wait(for: [startExpectation], timeout: 1)
-        ContractExtensionOne.runtime?.createSharedState(data: ["event":"first"], event: event1)
-        ContractExtensionOne.runtime?.createSharedState(data: ["event":"three"], event: event3)
+        ContractExtensionOne.runtime?.createSharedState(data: ["event":"first"], xdmData: nil, event: event1)
+        ContractExtensionOne.runtime?.createSharedState(data: ["event":"three"], xdmData: nil, event: event3)
 
         // verify
         let sharedStateForEvent1 = ContractExtensionOne.runtime?.getSharedState(extensionName: "com.adobe.ContractExtensionOne", event: event1, barrier: true)
@@ -438,7 +438,7 @@ class EventHubContractTest: XCTestCase {
             startExpectation.fulfill()
         }
         wait(for: [startExpectation], timeout: 1)
-        ContractExtensionOne.runtime?.createSharedState(data: ["event":"three"], event: event3)
+        ContractExtensionOne.runtime?.createSharedState(data: ["event":"three"], xdmData: nil, event: event3)
 
         // verify
         let sharedStateForEvent1New = ContractExtensionOne.runtime?.getSharedState(extensionName: "com.adobe.ContractExtensionOne", event: event1, barrier: true)

--- a/AEPCore/Tests/TestHelpers/SharedStateTestHelper.swift
+++ b/AEPCore/Tests/TestHelpers/SharedStateTestHelper.swift
@@ -11,14 +11,15 @@
  */
 
 import Foundation
+@testable import AEPCore
 
 struct SharedStateTestHelper {
     public static let DICT_KEY: String = "dictionary"
-    public static let ZERO: [String: Any] = [DICT_KEY: "zero"]
-    public static let ONE: [String: Any] = [DICT_KEY: "one"]
-    public static let TWO: [String: Any] = [DICT_KEY: "two"]
-    public static let THREE: [String: Any] = [DICT_KEY: "three"]
-    public static let FOUR: [String: Any] = [DICT_KEY: "four"]
-    public static let FIVE: [String: Any] = [DICT_KEY: "five"]
-    public static let TEN: [String: Any] = [DICT_KEY: "ten"]
+    public static let ZERO = SharedStateData(standard: [DICT_KEY: "zero"], xdm: [DICT_KEY: "zero_xdm"])
+    public static let ONE = SharedStateData(standard: [DICT_KEY: "one"], xdm: [DICT_KEY: "one_xdm"])
+    public static let TWO = SharedStateData(standard: [DICT_KEY: "two"], xdm: [DICT_KEY: "two_xdm"])
+    public static let THREE = SharedStateData(standard: [DICT_KEY: "three"], xdm: [DICT_KEY: "three_xdm"])
+    public static let FOUR = SharedStateData(standard: [DICT_KEY: "four"], xdm: [DICT_KEY: "four_xdm"])
+    public static let FIVE = SharedStateData(standard: [DICT_KEY: "five"], xdm: [DICT_KEY: "five_xdm"])
+    public static let TEN = SharedStateData(standard: [DICT_KEY: "ten"], xdm: [DICT_KEY: "ten_xdm"])
 }

--- a/AEPIdentity/Sources/Identity.swift
+++ b/AEPIdentity/Sources/Identity.swift
@@ -74,7 +74,7 @@ import Foundation
         guard let configSharedState = getSharedState(extensionName: IdentityConstants.SharedStateKeys.CONFIGURATION, event: event)?.value else { return false }
         // attempt to bootup
         if state.bootupIfReady(configSharedState: configSharedState, event: event) {
-            createSharedState(data: state.identityProperties.toEventData(), event: nil)
+            createSharedState(data: state.identityProperties.toEventData(), xdmData: nil, event: nil)
         }
 
         return false // cannot handle any events until we have booted
@@ -86,7 +86,7 @@ import Foundation
     private func handleIdentityRequest(event: Event) {
         if event.isSyncEvent || event.type == EventType.genericIdentity {
             if let eventData = state?.syncIdentifiers(event: event) {
-                createSharedState(data: eventData, event: event)
+                createSharedState(data: eventData, xdmData: nil, event: event)
             }
         } else if let baseUrl = event.baseUrl {
             processAppendToUrl(baseUrl: baseUrl, event: event)
@@ -113,7 +113,7 @@ import Foundation
                 handleOptOut(event: event)
             }
             // if config contains new global privacy status, process the request
-            state?.processPrivacyChange(event: event, createSharedState: createSharedState(data:event:))
+            state?.processPrivacyChange(event: event, createSharedState: createSharedState(data:xdmData:event:))
         }
     }
 
@@ -195,7 +195,7 @@ import Foundation
     ///   - entity: The `IdentityHit` that was processed by the hit processor
     ///   - responseData: the network response data if any
     private func handleNetworkResponse(hit: IdentityHit, responseData: Data?) {
-        state?.handleHitResponse(hit: hit, response: responseData, eventDispatcher: dispatch(event:), createSharedState: createSharedState(data:event:))
+        state?.handleHitResponse(hit: hit, response: responseData, eventDispatcher: dispatch(event:), createSharedState: createSharedState(data:xdmData:event:))
     }
 
     /// Sends an opt-out network request if the current privacy status is opt-out

--- a/AEPIdentity/Tests/IdentityStateTests.swift
+++ b/AEPIdentity/Tests/IdentityStateTests.swift
@@ -620,7 +620,7 @@ class IdentityStateTests: XCTestCase {
         state.handleHitResponse(hit: hit, response: try! JSONEncoder().encode(hitResponse), eventDispatcher: { event in
             XCTAssertEqual(state.identityProperties.toEventData().count, event.data?.count) // event should contain the identity properties in the event data
             dispatchedEventExpectation.fulfill()
-        }) { _, _ in
+        }) { _, _, _ in
             sharedStateExpectation.fulfill()
         }
 
@@ -652,7 +652,7 @@ class IdentityStateTests: XCTestCase {
         // test
         state.handleHitResponse(hit: hit, response: try! JSONEncoder().encode(hitResponse), eventDispatcher: { _ in
             dispatchedEventExpectation.fulfill()
-        }) { _, _ in
+        }) { _, _, _ in
             sharedStateExpectation.fulfill()
         }
 
@@ -684,7 +684,7 @@ class IdentityStateTests: XCTestCase {
         // test
         state.handleHitResponse(hit: hit, response: try! JSONEncoder().encode(hitResponse), eventDispatcher: { _ in
             dispatchedEventExpectation.fulfill()
-        }) { _, _ in
+        }) { _, _, _ in
             sharedStateExpectation.fulfill()
         }
 
@@ -716,7 +716,7 @@ class IdentityStateTests: XCTestCase {
         // test
         state.handleHitResponse(hit: hit, response: try! JSONEncoder().encode(hitResponse), eventDispatcher: { _ in
             dispatchedEventExpectation.fulfill()
-        }) { _, _ in
+        }) { _, _, _ in
             sharedStateExpectation.fulfill()
         }
 
@@ -746,7 +746,7 @@ class IdentityStateTests: XCTestCase {
         // test
         state.handleHitResponse(hit: IdentityHit.fakeHit(), response: nil, eventDispatcher: { _ in
             dispatchedEventExpectation.fulfill()
-        }) { _, _ in
+        }) { _, _, _ in
             sharedStateExpectation.fulfill()
         }
 
@@ -768,7 +768,7 @@ class IdentityStateTests: XCTestCase {
         let event = Event(name: "Test event", type: EventType.identity, source: EventSource.requestIdentity, data: nil)
 
         // test
-        state.processPrivacyChange(event: event, createSharedState: { (data, event) in
+        state.processPrivacyChange(event: event, createSharedState: { (data, xdmData, event)  in
             XCTFail("Shared state should not be updated")
         })
 
@@ -790,7 +790,7 @@ class IdentityStateTests: XCTestCase {
         let event = Event(name: "Test event", type: EventType.identity, source: EventSource.requestIdentity, data: [IdentityConstants.Configuration.GLOBAL_CONFIG_PRIVACY: PrivacyStatus.optedIn.rawValue])
 
         // test
-        state.processPrivacyChange(event: event, createSharedState: { (_, _) in
+        state.processPrivacyChange(event: event, createSharedState: { (_, _, _) in
             XCTFail("Shared state should not be updated")
         })
 
@@ -813,7 +813,7 @@ class IdentityStateTests: XCTestCase {
         let event = Event(name: "Test event", type: EventType.identity, source: EventSource.requestIdentity, data: [IdentityConstants.Configuration.GLOBAL_CONFIG_PRIVACY: PrivacyStatus.optedOut.rawValue])
 
         // test
-        state.processPrivacyChange(event: event, createSharedState: { (data, event) in
+        state.processPrivacyChange(event: event, createSharedState: { (data, xdmData, event) in
             sharedStateExpectation.fulfill()
         })
 
@@ -840,7 +840,7 @@ class IdentityStateTests: XCTestCase {
         let event = Event(name: "Test event", type: EventType.identity, source: EventSource.requestIdentity, data: [IdentityConstants.Configuration.GLOBAL_CONFIG_PRIVACY: PrivacyStatus.optedIn.rawValue])
 
         // test
-        state.processPrivacyChange(event: event, createSharedState: { (_, _) in
+        state.processPrivacyChange(event: event, createSharedState: { (_, _, _) in
             sharedStateExpectation.fulfill()
         })
 
@@ -866,7 +866,7 @@ class IdentityStateTests: XCTestCase {
         let event = Event(name: "Test event", type: EventType.identity, source: EventSource.requestIdentity, data: [IdentityConstants.Configuration.GLOBAL_CONFIG_PRIVACY: PrivacyStatus.unknown.rawValue])
 
         // test
-        state.processPrivacyChange(event: event, createSharedState: { _, _ in
+        state.processPrivacyChange(event: event, createSharedState: { (_, _, _) in
             sharedStateExpectation.fulfill()
         })
 

--- a/AEPIdentity/Tests/TestHelpers/TestableExtensionRuntime.swift
+++ b/AEPIdentity/Tests/TestHelpers/TestableExtensionRuntime.swift
@@ -17,7 +17,9 @@ class TestableExtensionRuntime: ExtensionRuntime {
     var listeners: [String: EventListener] = [:]
     var dispatchedEvents: [Event] = []
     var createdSharedStates: [[String: Any]?] = []
+    var createdXdmSharedStates: [[String: Any]?] = []
     var otherSharedStates: [String: SharedStateResult] = [:]
+    var otherXDMSharedStates: [String: SharedStateResult] = [:]
 
     func getListener(type: String, source: String) -> EventListener? {
         return listeners["\(type)-\(source)"]
@@ -52,6 +54,15 @@ class TestableExtensionRuntime: ExtensionRuntime {
 
     func getSharedState(extensionName: String, event: Event?, barrier: Bool) -> SharedStateResult? {
         return otherSharedStates["\(extensionName)-\(String(describing: event?.id))"] ?? nil
+    }
+    
+    func createSharedState(data: [String : Any], xdmData: [String : Any], event: Event?) {
+        createdSharedStates += [data]
+        createdXdmSharedStates += [data]
+    }
+    
+    func getXDMSharedState(extensionName: String, event: Event?) -> SharedStateResult? {
+        return otherXDMSharedStates["\(extensionName)-\(String(describing: event?.id))"] ?? nil
     }
 
     func simulateSharedState(extensionName: String, event: Event?, data: (value: [String: Any]?, status: SharedStateStatus)) {

--- a/AEPIdentity/Tests/TestHelpers/TestableExtensionRuntime.swift
+++ b/AEPIdentity/Tests/TestHelpers/TestableExtensionRuntime.swift
@@ -42,10 +42,6 @@ class TestableExtensionRuntime: ExtensionRuntime {
         dispatchedEvents += [event]
     }
 
-    func createSharedState(data: [String: Any], event _: Event?) {
-        createdSharedStates += [data]
-    }
-
     func createPendingSharedState(event _: Event?) -> SharedStateResolver {
         return { data in
             self.createdSharedStates += [data]
@@ -56,7 +52,7 @@ class TestableExtensionRuntime: ExtensionRuntime {
         return otherSharedStates["\(extensionName)-\(String(describing: event?.id))"] ?? nil
     }
 
-    func createSharedState(data: [String : Any], xdmData: [String : Any], event: Event?) {
+    func createSharedState(data: [String : Any], xdmData: [String : Any]?, event: Event?) {
         createdSharedStates += [data]
         createdXdmSharedStates += [data]
     }

--- a/AEPIdentity/Tests/TestHelpers/TestableExtensionRuntime.swift
+++ b/AEPIdentity/Tests/TestHelpers/TestableExtensionRuntime.swift
@@ -55,12 +55,12 @@ class TestableExtensionRuntime: ExtensionRuntime {
     func getSharedState(extensionName: String, event: Event?, barrier: Bool) -> SharedStateResult? {
         return otherSharedStates["\(extensionName)-\(String(describing: event?.id))"] ?? nil
     }
-    
+
     func createSharedState(data: [String : Any], xdmData: [String : Any], event: Event?) {
         createdSharedStates += [data]
         createdXdmSharedStates += [data]
     }
-    
+
     func getXDMSharedState(extensionName: String, event: Event?) -> SharedStateResult? {
         return otherXDMSharedStates["\(extensionName)-\(String(describing: event?.id))"] ?? nil
     }

--- a/AEPIdentity/Tests/TestHelpers/TestableExtensionRuntime.swift
+++ b/AEPIdentity/Tests/TestHelpers/TestableExtensionRuntime.swift
@@ -54,7 +54,7 @@ class TestableExtensionRuntime: ExtensionRuntime {
 
     func createSharedState(data: [String : Any], xdmData: [String : Any]?, event: Event?) {
         createdSharedStates += [data]
-        createdXdmSharedStates += [data]
+        createdXdmSharedStates += [xdmData]
     }
 
     func getXDMSharedState(extensionName: String, event: Event?) -> SharedStateResult? {

--- a/AEPLifecycle/Sources/Lifecycle.swift
+++ b/AEPLifecycle/Sources/Lifecycle.swift
@@ -39,7 +39,7 @@ public class Lifecycle: NSObject, Extension {
         registerListener(type: EventType.genericLifecycle, source: EventSource.requestContent, listener: receiveLifecycleRequest(event:))
 
         let sharedStateData = [LifecycleConstants.EventDataKeys.LIFECYCLE_CONTEXT_DATA: lifecycleState.computeBootData().toEventData()]
-        createSharedState(data: sharedStateData as [String: Any], event: nil)
+        createSharedState(data: sharedStateData as [String: Any], xdmData: nil, event: nil)
     }
 
     public func onUnregistered() {}
@@ -109,7 +109,7 @@ public class Lifecycle: NSObject, Extension {
     ///   - data: data for the shared state
     private func updateSharedState(event: Event, data: [String: Any]) {
         let sharedStateData = [LifecycleConstants.EventDataKeys.LIFECYCLE_CONTEXT_DATA: data]
-        createSharedState(data: sharedStateData as [String: Any], event: event)
+        createSharedState(data: sharedStateData as [String: Any], xdmData: nil, event: event)
     }
 
     /// Dispatches a Lifecycle response content event with appropriate event data


### PR DESCRIPTION
A follow up to https://github.com/adobe/aepsdk-core-ios/pull/421

This PR implements XDM shared state APIs as described in this doc and based on feedback in PR #421: https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=adms&title=XDM+Shared+States

These APIs will be used for extensions to write XDM data to shared state, then the Edge extension will read this data and attach it to outgoing Platform events.

Note: The added tests are pretty light, I feel that we have adequate tests for SharedState logic, however, I've added a test to ensure that we are reading/writing to the correct SharedState instance based on the SharedStateType.