### PR TITLE
Get event hub shared state API

### DIFF
--- a/AEPCore/Sources/core/MobileCore.swift
+++ b/AEPCore/Sources/core/MobileCore.swift
@@ -72,6 +72,15 @@ public final class MobileCore: NSObject {
         }
     }
 
+    /// Fetches a list of registered extensions along with their respective versions
+    /// - Returns: list of registered extensions along with their respective versions
+    @objc
+    public static func getRegisteredExtensions() -> String {
+        let registeredExtensions = EventHub.shared.getSharedState(extensionName: EventHubConstants.NAME, event: nil)?.value
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: registeredExtensions ?? [:], options: .prettyPrinted) else { return "{}" }
+        return String(data: jsonData, encoding: .utf8) ?? "{}"
+    }
+
     /// Dispatches an `Event` through the `EventHub`
     /// - Parameter event: The `Event` to be dispatched
     @objc(dispatch:)

--- a/AEPCore/Tests/MobileCoreTests.swift
+++ b/AEPCore/Tests/MobileCoreTests.swift
@@ -180,6 +180,52 @@ class MobileCoreTests: XCTestCase {
         wait(for: [expectation], timeout: 0.25)
     }
 
+    func testGetRegisteredExtensions() {
+        // setup
+        let expectation = XCTestExpectation(description: "extensions are registered")
+        expectation.assertForOverFulfill = true
+
+        let expected = """
+        {
+          "extensions" : {
+            "mockExtension" : {
+              "version" : "0.0.1"
+            },
+            "Configuration" : {
+              "version" : "3.0.0-beta.1"
+            },
+            "mockExtensionTwo" : {
+              "metadata" : {
+                "testMetaKey" : "testMetaVal"
+              },
+              "version" : "0.0.1"
+            }
+          },
+          "version" : "3.0.0-beta.1"
+        }
+        """
+        let expectedDict = jsonStrToDict(jsonStr: expected)
+
+        // test
+        MobileCore.registerExtensions([MockExtension.self, MockExtensionTwo.self], {
+            let registered = MobileCore.getRegisteredExtensions()
+            let registeredDict = self.jsonStrToDict(jsonStr: registered)
+            let equal = NSDictionary(dictionary: registeredDict!).isEqual(to: expectedDict!)
+            XCTAssertTrue(equal)
+            expectation.fulfill()
+        })
+
+        // verify
+        wait(for: [expectation], timeout: 0.25)
+    }
+
+    private func jsonStrToDict(jsonStr: String) -> [String: Any]? {
+        if let data = jsonStr.data(using: .utf8) {
+            return try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+        }
+        return nil
+    }
+
     func testDispatchEventSimple() {
         // setup
         let expectedEvent = Event(name: "test", type: EventType.analytics, source: EventSource.requestContent, data: nil)

--- a/Documentation/Usage/MobileCore.md
+++ b/Documentation/Usage/MobileCore.md
@@ -81,7 +81,7 @@ MobileCore.registerExtension(Lifecycle.self) {
 }];
 ```
 
-##### Ungegistering a single extension:
+##### Unregistering a single extension:
 
 ###### Swift
 
@@ -97,6 +97,20 @@ MobileCore.unregisterExtension(Lifecycle.self) {
 [AEPMobileCore unregisterExtension:AEPMobileLifecycle.class completion:^{
     // handle completion
 }];
+```
+
+##### Getting a list of registered extensions:
+
+###### Swift
+
+```swift
+let registered = MobileCore.getRegisteredExtensions()
+```
+
+###### Objective-C
+
+```objective-c
+NSString *registered = [AEPMobileCore getRegisteredExtensions];
 ```
 
 ##### Configuring the SDK with an app id:
@@ -400,4 +414,3 @@ MobileCore.collectPii(data: data)
 NSDictionary *data = @{@"testKey": @"testVal"}
 [AEPMobileCore collectPii:data];
 ```
-


### PR DESCRIPTION
This PR provides an API for retrieving the Event Hub shared state from a public API in `MobileCore`. It provides a pretty printed string of all the currently registered extensions.