### PR TITLE
Publish Identity XDM Shared State (ECID, CustomIdentities)

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		218C813E24EC4101009B4F31 /* V5MigrationConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218C813D24EC4101009B4F31 /* V5MigrationConstants.swift */; };
 		218E01C024C7595000BEC470 /* HitQueuing+PrivacyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218E01BF24C7595000BEC470 /* HitQueuing+PrivacyTests.swift */; };
 		21A6737325434AE600A7E906 /* SharedStateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A6737225434AE600A7E906 /* SharedStateType.swift */; };
+		21C47D86255B411D009D24B4 /* IdentityMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C47D85255B411D009D24B4 /* IdentityMap.swift */; };
+		21C47DA4255B44A1009D24B4 /* IdentityMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C47DA3255B44A1009D24B4 /* IdentityMapTests.swift */; };
 		21CAC0E02422917600C11388 /* AEPCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21CAC0D62422917600C11388 /* AEPCore.framework */; };
 		21CAC0E72422917600C11388 /* AEPCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 21CAC0D92422917600C11388 /* AEPCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		21CD581124EC7B8900D9D590 /* V5MigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CD581024EC7B8900D9D590 /* V5MigratorTests.swift */; };
@@ -576,6 +578,8 @@
 		218C813D24EC4101009B4F31 /* V5MigrationConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V5MigrationConstants.swift; sourceTree = "<group>"; };
 		218E01BF24C7595000BEC470 /* HitQueuing+PrivacyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HitQueuing+PrivacyTests.swift"; sourceTree = "<group>"; };
 		21A6737225434AE600A7E906 /* SharedStateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStateType.swift; sourceTree = "<group>"; };
+		21C47D85255B411D009D24B4 /* IdentityMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityMap.swift; sourceTree = "<group>"; };
+		21C47DA3255B44A1009D24B4 /* IdentityMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityMapTests.swift; sourceTree = "<group>"; };
 		21CAC0D62422917600C11388 /* AEPCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AEPCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		21CAC0D92422917600C11388 /* AEPCore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AEPCore.h; sourceTree = "<group>"; };
 		21CAC0DA2422917600C11388 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1111,6 +1115,7 @@
 				3FE6DE5424C643060065EA05 /* IdentityHitResponse.swift */,
 				3FE6DE4824C643050065EA05 /* IdentityProperties.swift */,
 				3FE6DE4D24C643050065EA05 /* IdentityState.swift */,
+				21C47D85255B411D009D24B4 /* IdentityMap.swift */,
 				3FE6DE4924C643050065EA05 /* Identity+PublicAPI.swift */,
 				3FE6DE3224C642330065EA05 /* Info.plist */,
 				3FE6DE4E24C643060065EA05 /* ECID.swift */,
@@ -1149,6 +1154,7 @@
 				2107F02924C9FF46002935CF /* PushIDManagerTests.swift */,
 				21FE151F24F03254008A82FF /* IdentityPublicAPITests.swift */,
 				214154A725186734005CEB80 /* CustomIdentityTests.swift */,
+				21C47DA3255B44A1009D24B4 /* IdentityMapTests.swift */,
 			);
 			name = Tests;
 			path = AEPIdentity/Tests;
@@ -2700,6 +2706,7 @@
 				3FE6DE5B24C643060065EA05 /* IdentityProperties.swift in Sources */,
 				3FE6DE6624C643060065EA05 /* MobileIdentities.swift in Sources */,
 				3FE6DE6B24C643060065EA05 /* URL+Identity.swift in Sources */,
+				21C47D86255B411D009D24B4 /* IdentityMap.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2720,6 +2727,7 @@
 				3FE6DE8224C643620065EA05 /* IdentityTests.swift in Sources */,
 				3FE6DE7A24C643620065EA05 /* URL+IdentityTests.swift in Sources */,
 				3FE6DE7F24C643620065EA05 /* IdentityHitProcessorTests.swift in Sources */,
+				21C47DA4255B44A1009D24B4 /* IdentityMapTests.swift in Sources */,
 				3FE6DE8824C643EA0065EA05 /* TestableExtensionRuntime.swift in Sources */,
 				3FE6DE7E24C643620065EA05 /* URLAppenderTests.swift in Sources */,
 				218E01C024C7595000BEC470 /* HitQueuing+PrivacyTests.swift in Sources */,

--- a/AEPCore/Sources/eventhub/Extension.swift
+++ b/AEPCore/Sources/eventhub/Extension.swift
@@ -115,6 +115,39 @@ public extension Extension {
         return runtime.getSharedState(extensionName: extensionName, event: event, barrier: true)
     }
 
+    // MARK: - XDM Shared State
+
+    /// Creates a new XDM SharedState for this extension.
+    /// The data passed to this API needs to be mapped to known XDM mixins; if an extension uses multiple mixins, the current data for all of them should be provided when the XDM shared state is set.
+    /// If `event` is nil, one of two behaviors will be observed:
+    /// 1. If this extension has not previously published a shared state, shared state will be versioned at 0
+    /// 2. If this extension has previously published a shared state, shared state will be versioned at the latest
+    /// - Parameters:
+    ///   - data: Data for the `SharedState`
+    ///   - event: `Event` for which the `SharedState` should be versioned
+    func createXDMSharedState(data: [String: Any], event: Event?) {
+        runtime.createXDMSharedState(data: data, event: event)
+    }
+
+    /// Creates a pending XDM `SharedState` versioned at `event`
+    /// If `event` is nil, one of two behaviors will be observed:
+    /// 1. If this extension has not previously published a shared state, shared state will be versioned at 0
+    /// 2. If this extension has previously published a shared state, shared state will be versioned at the latest
+    /// - Parameter event: `Event` for which the `SharedState` should be versioned
+    /// - Returns: a `SharedStateResolver` that should be called with the `SharedState` data when it is ready
+    func createPendingXDMSharedState(event: Event?) -> SharedStateResolver {
+        return runtime.createPendingXDMSharedState(event: event)
+    }
+
+    /// Gets the XDM SharedState data for a specified extension. If this extension populates multiple mixins in their shared state, all the data will be returned at once and it can be accessed using path discovery.
+    /// - Parameters:
+    ///   - extensionName: An extension name whose `SharedState` will be returned
+    ///   - event: If not nil, will retrieve the `SharedState` that corresponds with the event's version, if nil will return the latest `SharedState`
+    /// - Returns: A `SharedStateResult?` for the requested `extensionName` and `event`
+    func getXDMSharedState(extensionName: String, event: Event?) -> SharedStateResult? {
+        return runtime.getXDMSharedState(extensionName: extensionName, event: event)
+    }
+
     /// Called before each `Event` is processed by any `ExtensionListener` owned by this `Extension`
     /// Should be overridden by any extension that wants to control it's own event flow on a per event basis.
     /// - Parameter event: `Event` that will be processed next

--- a/AEPIdentity/Sources/Identity.swift
+++ b/AEPIdentity/Sources/Identity.swift
@@ -75,6 +75,7 @@ import Foundation
         // attempt to bootup
         if state.bootupIfReady(configSharedState: configSharedState, event: event) {
             createSharedState(data: state.identityProperties.toEventData(), event: nil)
+            createXDMSharedState(data: state.identityProperties.toXDMData(), event: nil)
         }
 
         return false // cannot handle any events until we have booted
@@ -87,6 +88,9 @@ import Foundation
         if event.isSyncEvent || event.type == EventType.genericIdentity {
             if let eventData = state?.syncIdentifiers(event: event) {
                 createSharedState(data: eventData, event: event)
+                if let xdmData = state?.identityProperties.toXDMData() {
+                    createXDMSharedState(data: xdmData, event: event)
+                }
             }
         } else if let baseUrl = event.baseUrl {
             processAppendToUrl(baseUrl: baseUrl, event: event)
@@ -113,7 +117,7 @@ import Foundation
                 handleOptOut(event: event)
             }
             // if config contains new global privacy status, process the request
-            state?.processPrivacyChange(event: event, createSharedState: createSharedState(data:event:))
+            state?.processPrivacyChange(event: event, createSharedState: createSharedState(data:event:), createXDMSharedState: createXDMSharedState(data:event:))
         }
     }
 
@@ -195,7 +199,7 @@ import Foundation
     ///   - entity: The `IdentityHit` that was processed by the hit processor
     ///   - responseData: the network response data if any
     private func handleNetworkResponse(hit: IdentityHit, responseData: Data?) {
-        state?.handleHitResponse(hit: hit, response: responseData, eventDispatcher: dispatch(event:), createSharedState: createSharedState(data:event:))
+        state?.handleHitResponse(hit: hit, response: responseData, eventDispatcher: dispatch(event:), createSharedState: createSharedState(data:event:), createXDMSharedState: createXDMSharedState(data:event:))
     }
 
     /// Sends an opt-out network request if the current privacy status is opt-out

--- a/AEPIdentity/Sources/Identity.swift
+++ b/AEPIdentity/Sources/Identity.swift
@@ -199,7 +199,7 @@ import Foundation
     ///   - entity: The `IdentityHit` that was processed by the hit processor
     ///   - responseData: the network response data if any
     private func handleNetworkResponse(hit: IdentityHit, responseData: Data?) {
-        state?.handleHitResponse(hit: hit, response: responseData, eventDispatcher: dispatch(event:), createSharedState: createSharedState(data:event:), createXDMSharedState: createXDMSharedState(data:event:))
+        state?.handleHitResponse(hit: hit, response: responseData, eventDispatcher: dispatch(event:), createSharedState: createSharedState(data:event:))
     }
 
     /// Sends an opt-out network request if the current privacy status is opt-out

--- a/AEPIdentity/Sources/IdentityConstants.swift
+++ b/AEPIdentity/Sources/IdentityConstants.swift
@@ -101,4 +101,11 @@ enum IdentityConstants {
         static let PUSH_ID_ENABLED_ACTION_NAME = "Push"
         static let TRACK_INTERNAL = "trackinternal"
     }
+
+    enum XDM {
+        enum Keys {
+            static let IDENTITY_MAP = "identityMap"
+            static let ECID = "ECID"
+        }
+    }
 }

--- a/AEPIdentity/Sources/IdentityMap.swift
+++ b/AEPIdentity/Sources/IdentityMap.swift
@@ -42,10 +42,10 @@ struct IdentityMap: Equatable {
     ///   - primary: Indicates if this identity is the preferred identity. It is used as a hint to help systems better organize how identities are queried.
     mutating func addItem(namespace: String,
                           id: String,
-                          authenticationState: MobileVisitorAuthenticationState? = nil,
+                          authenticationState: XDMAuthenticationState? = nil,
                           primary: Bool? = nil) {
         let item = IdentityItem(id: id,
-                                authenticationState: XDMAuthenticationState.authStateFromMobileAuthState(authState: authenticationState), primary: primary)
+                                authenticationState: authenticationState, primary: primary)
 
         if var namespaceItems = items[namespace] {
             if let index = namespaceItems.firstIndex(of: item) {

--- a/AEPIdentity/Sources/IdentityMap.swift
+++ b/AEPIdentity/Sources/IdentityMap.swift
@@ -1,0 +1,98 @@
+//
+// Copyright 2020 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+import Foundation
+
+enum XDMAuthenticationState: String, Codable {
+    case ambiguous
+    case authenticated
+    case loggedOut
+
+    static func authStateFromMobileAuthState(authState: MobileVisitorAuthenticationState?) -> XDMAuthenticationState {
+        switch authState {
+        case .authenticated:
+            return .authenticated
+        case .loggedOut:
+            return .loggedOut
+        default:
+            return .ambiguous
+        }
+    }
+}
+
+/// Defines a map containing a set of end user identities, keyed on either namespace integration code or the namespace ID of the identity.
+/// Within each namespace, the identity is unique. The values of the map are an array, meaning that more than one identity of each namespace may be carried.
+struct IdentityMap: Equatable {
+    private var items: [String: [IdentityItem]] = [:]
+
+    /// Adds an `IdentityItem` to this map. If an item is added which shares the same `namespace` and `id` as an item
+    /// already in the map, then the new item replaces the existing item.
+    /// - Parameters:
+    ///   - namespace: The namespace for this identity
+    ///   - id: Identity of the consumer in the related namespace.
+    ///   - authenticationState: The state this identity is authenticated as for this observed ExperienceEvent.
+    ///   - primary: Indicates if this identity is the preferred identity. It is used as a hint to help systems better organize how identities are queried.
+    mutating func addItem(namespace: String,
+                          id: String,
+                          authenticationState: MobileVisitorAuthenticationState? = nil,
+                          primary: Bool? = nil) {
+        let item = IdentityItem(id: id,
+                                authenticationState: XDMAuthenticationState.authStateFromMobileAuthState(authState: authenticationState), primary: primary)
+
+        if var namespaceItems = items[namespace] {
+            if let index = namespaceItems.firstIndex(of: item) {
+                namespaceItems[index] = item
+            } else {
+                namespaceItems.append(item)
+            }
+            items[namespace] = namespaceItems
+        } else {
+            items[namespace] = [item]
+        }
+    }
+
+    /// Get the array of `IdentityItem`(s) for the given namespace.
+    /// - Parameter namespace: the namespace of items to retrieve
+    /// - Returns: An array of `IdentityItem` for the given `namespace` or nil if this `IdentityMap` does not contain the `namespace`.
+    func getItemsFor(namespace: String) -> [IdentityItem]? {
+        return items[namespace]
+    }
+}
+
+extension IdentityMap: Encodable {
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(items)
+    }
+}
+
+extension IdentityMap: Decodable {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let identityItems = try? container.decode([String: [IdentityItem]].self) {
+            items = identityItems
+        }
+    }
+}
+
+/// Identity is used to clearly distinguish people that are interacting with digital experiences.
+struct IdentityItem: Codable {
+    let id: String?
+    let authenticationState: XDMAuthenticationState?
+    let primary: Bool?
+}
+
+/// Defines two `IdentityItem` objects are equal if they have the same `id`.
+extension IdentityItem: Equatable {
+    static func == (lhs: IdentityItem, rhs: IdentityItem) -> Bool {
+        return lhs.id == rhs.id
+    }
+}

--- a/AEPIdentity/Sources/IdentityMap.swift
+++ b/AEPIdentity/Sources/IdentityMap.swift
@@ -9,6 +9,8 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 //
+
+import AEPServices
 import Foundation
 
 enum XDMAuthenticationState: String, Codable {
@@ -32,6 +34,7 @@ enum XDMAuthenticationState: String, Codable {
 /// Within each namespace, the identity is unique. The values of the map are an array, meaning that more than one identity of each namespace may be carried.
 struct IdentityMap: Equatable {
     private var items: [String: [IdentityItem]] = [:]
+    private let LOG_TAG = "IdentityMap"
 
     /// Adds an `IdentityItem` to this map. If an item is added which shares the same `namespace` and `id` as an item
     /// already in the map, then the new item replaces the existing item.
@@ -44,6 +47,11 @@ struct IdentityMap: Equatable {
                           id: String,
                           authenticationState: XDMAuthenticationState? = nil,
                           primary: Bool? = nil) {
+        guard !namespace.isEmpty, !id.isEmpty else {
+            // cannot have empty namespace and id
+            Log.debug(label: "\(LOG_TAG): addItem", "Dropping identity item, namespace or id is empty.")
+            return
+        }
         let item = IdentityItem(id: id,
                                 authenticationState: authenticationState, primary: primary)
 

--- a/AEPIdentity/Sources/IdentityProperties.swift
+++ b/AEPIdentity/Sources/IdentityProperties.swift
@@ -75,7 +75,8 @@ struct IdentityProperties: Codable {
 
         for customerId in customerIds ?? [] {
             guard let type = customerId.type, let id = customerId.identifier else { continue }
-            identityMap.addItem(namespace: type, id: id, authenticationState: customerId.authenticationState, primary: false)
+            let xdmAuthState = XDMAuthenticationState.authStateFromMobileAuthState(authState: customerId.authenticationState)
+            identityMap.addItem(namespace: type, id: id, authenticationState: xdmAuthState, primary: false)
         }
 
         return [IdentityConstants.XDM.Keys.IDENTITY_MAP: identityMap.asDictionary() as Any]

--- a/AEPIdentity/Sources/IdentityProperties.swift
+++ b/AEPIdentity/Sources/IdentityProperties.swift
@@ -63,6 +63,24 @@ struct IdentityProperties: Codable {
         return eventData
     }
 
+    /// Converts `IdentityProperties` into an XDM data representation
+    /// - Returns: A dictionary representing this `IdentityProperties` in XDM data format
+    func toXDMData() -> [String: Any] {
+        var identityMap = IdentityMap()
+
+        // Add ECID
+        if let ecidString = ecid?.ecidString {
+            identityMap.addItem(namespace: IdentityConstants.XDM.Keys.ECID, id: ecidString)
+        }
+
+        for customerId in customerIds ?? [] {
+            guard let type = customerId.type, let id = customerId.identifier else { continue }
+            identityMap.addItem(namespace: type, id: id, authenticationState: customerId.authenticationState, primary: false)
+        }
+
+        return [IdentityConstants.XDM.Keys.IDENTITY_MAP: identityMap.asDictionary() as Any]
+    }
+
     /// Populates the fields with values stored in the Identity data store
     mutating func loadFromPersistence() {
         let dataStore = NamedCollectionDataStore(name: IdentityConstants.DATASTORE_NAME)

--- a/AEPIdentity/Sources/IdentityState.swift
+++ b/AEPIdentity/Sources/IdentityState.swift
@@ -145,17 +145,14 @@ class IdentityState {
     ///   - response: the response data if any
     ///   - eventDispatcher: a function which when invoked dispatches an `Event` to the `EventHub`
     ///   - createSharedState: a function which when invoked creates a shared state for the Identity extension
-    ///   - createXDMSharedState: a function which when invoked creates a XDM shared state for the Identity extension
-    func handleHitResponse(hit: IdentityHit, response: Data?, eventDispatcher: (Event) -> Void, createSharedState: ([String: Any], Event?) -> Void,
-                           createXDMSharedState: ([String: Any], Event?) -> Void) {
+    func handleHitResponse(hit: IdentityHit, response: Data?, eventDispatcher: (Event) -> Void, createSharedState: ([String: Any], Event?) -> Void) {
         // regardless of response, update last sync time
         identityProperties.lastSync = Date()
 
         // check privacy here in case the status changed while response was in-flight
         if identityProperties.privacyStatus != .optedOut {
             // update properties
-            handleNetworkResponse(response: response, eventDispatcher: eventDispatcher, createSharedState: createSharedState,
-                                  createXDMSharedState: createXDMSharedState, event: hit.event)
+            handleNetworkResponse(response: response, eventDispatcher: eventDispatcher, createSharedState: createSharedState, event: hit.event)
 
             // save
             identityProperties.saveToPersistence()
@@ -323,10 +320,8 @@ class IdentityState {
     ///   - response: the network response
     ///   - eventDispatcher: a function which when invoked dispatches an `Event` to the `EventHub`
     ///   - createSharedState: a function which when invoked creates a shared state for the Identity extension
-    ///   - createXDMSharedState: a function which when invoked creates a XDM shared state for the Identity extension
     ///   - event: The event responsible for the network response
-    private func handleNetworkResponse(response: Data?, eventDispatcher: (Event) -> Void, createSharedState: (([String: Any], Event?) -> Void),
-                                       createXDMSharedState: (([String: Any], Event?) -> Void), event: Event) {
+    private func handleNetworkResponse(response: Data?, eventDispatcher: (Event) -> Void, createSharedState: (([String: Any], Event?) -> Void), event: Event) {
         guard let data = response, let identityResponse = try? JSONDecoder().decode(IdentityHitResponse.self, from: data) else {
             Log.debug(label: "\(LOG_TAG):\(#function)", "Failed to decode Identity hit response")
             return
@@ -349,7 +344,6 @@ class IdentityState {
             identityProperties.ecid = identityProperties.ecid ?? ECID()
             Log.error(label: "\(LOG_TAG):\(#function)", "Identity response returned error: \(error)")
             createSharedState(identityProperties.toEventData(), event)
-            createXDMSharedState(identityProperties.toXDMData(), event)
             return
         }
 
@@ -361,7 +355,6 @@ class IdentityState {
             identityProperties.ttl = identityResponse.ttl ?? IdentityConstants.Default.TTL
             if shouldShareState {
                 createSharedState(identityProperties.toEventData(), event)
-                createXDMSharedState(identityProperties.toXDMData(), event)
             }
         }
     }

--- a/AEPIdentity/Tests/IdentityMapTests.swift
+++ b/AEPIdentity/Tests/IdentityMapTests.swift
@@ -22,7 +22,7 @@ class IdentityMapTests: XCTestCase {
     // MARK: getItemsFor tests
     func testGetItemsFor() {
         var identityMap = IdentityMap()
-        identityMap.addItem(namespace: "space", id: "id", authenticationState: MobileVisitorAuthenticationState.unknown, primary: false)
+        identityMap.addItem(namespace: "space", id: "id", authenticationState: XDMAuthenticationState.ambiguous, primary: false)
 
         let spaceItems = identityMap.getItemsFor(namespace: "space")
         XCTAssertNotNil(spaceItems)
@@ -37,9 +37,9 @@ class IdentityMapTests: XCTestCase {
 
     func testAddItems() {
         var identityMap = IdentityMap()
-        identityMap.addItem(namespace: "space", id: "id", authenticationState: MobileVisitorAuthenticationState.unknown, primary: false)
+        identityMap.addItem(namespace: "space", id: "id", authenticationState: XDMAuthenticationState.ambiguous, primary: false)
         identityMap.addItem(namespace: "email", id: "example@adobe.com")
-        identityMap.addItem(namespace: "space", id: "custom", authenticationState: MobileVisitorAuthenticationState.unknown, primary: true)
+        identityMap.addItem(namespace: "space", id: "custom", authenticationState: XDMAuthenticationState.ambiguous, primary: true)
 
         guard let spaceItems = identityMap.getItemsFor(namespace: "space") else {
             XCTFail("Namespace 'space' is nil but expected not nil.")
@@ -65,8 +65,8 @@ class IdentityMapTests: XCTestCase {
 
     func testAddItems_overwrite() {
         var identityMap = IdentityMap()
-        identityMap.addItem(namespace: "space", id: "id", authenticationState: MobileVisitorAuthenticationState.unknown, primary: false)
-        identityMap.addItem(namespace: "space", id: "id", authenticationState: MobileVisitorAuthenticationState.authenticated)
+        identityMap.addItem(namespace: "space", id: "id", authenticationState: XDMAuthenticationState.ambiguous, primary: false)
+        identityMap.addItem(namespace: "space", id: "id", authenticationState: XDMAuthenticationState.authenticated)
 
         guard let spaceItems = identityMap.getItemsFor(namespace: "space") else {
             XCTFail("Namespace 'space' is nil but expected not nil.")
@@ -82,7 +82,7 @@ class IdentityMapTests: XCTestCase {
     // MARK: encoder tests
     func testEncode_oneItem() {
         var identityMap = IdentityMap()
-        identityMap.addItem(namespace: "space", id: "id", authenticationState: MobileVisitorAuthenticationState.unknown, primary: false)
+        identityMap.addItem(namespace: "space", id: "id", authenticationState: XDMAuthenticationState.ambiguous, primary: false)
 
         let encodedIdentityMap = try! JSONEncoder().encode(identityMap)
         let decodedIdentityMap = try! JSONDecoder().decode(IdentityMap.self, from: encodedIdentityMap)
@@ -93,7 +93,7 @@ class IdentityMapTests: XCTestCase {
 
     func testEncode_twoItems() {
         var identityMap = IdentityMap()
-        identityMap.addItem(namespace: "space", id: "id", authenticationState: MobileVisitorAuthenticationState.unknown, primary: false)
+        identityMap.addItem(namespace: "space", id: "id", authenticationState: XDMAuthenticationState.ambiguous, primary: false)
         identityMap.addItem(namespace: "A", id: "123")
 
         let encodedIdentityMap = try! JSONEncoder().encode(identityMap)
@@ -105,7 +105,7 @@ class IdentityMapTests: XCTestCase {
 
     func testEncode_twoItemsSameNamespace() {
         var identityMap = IdentityMap()
-        identityMap.addItem(namespace: "space", id: "id", authenticationState: MobileVisitorAuthenticationState.unknown, primary: false)
+        identityMap.addItem(namespace: "space", id: "id", authenticationState: XDMAuthenticationState.ambiguous, primary: false)
         identityMap.addItem(namespace: "space", id: "123")
 
         let encodedIdentityMap = try! JSONEncoder().encode(identityMap)

--- a/AEPIdentity/Tests/IdentityMapTests.swift
+++ b/AEPIdentity/Tests/IdentityMapTests.swift
@@ -63,6 +63,39 @@ class IdentityMapTests: XCTestCase {
         XCTAssertEqual("example@adobe.com", emailItems[0].id)
     }
 
+    func testAddItems_emptyNamespace() {
+        var identityMap = IdentityMap()
+        identityMap.addItem(namespace: "", id: "example@adobe.com")
+
+        guard let _ = identityMap.getItemsFor(namespace: "email") else {
+            return
+        }
+
+        XCTFail("Namespace 'email' is not nil but expected nil.")
+    }
+
+    func testAddItems_emptyIdentifier() {
+        var identityMap = IdentityMap()
+        identityMap.addItem(namespace: "email", id: "")
+
+        guard let _ = identityMap.getItemsFor(namespace: "email") else {
+            return
+        }
+
+        XCTFail("Namespace 'email' is not nil but expected nil.")
+    }
+
+    func testAddItems_emptyNamespace_andEmptyId() {
+        var identityMap = IdentityMap()
+        identityMap.addItem(namespace: "", id: "")
+
+        guard let _ = identityMap.getItemsFor(namespace: "email") else {
+            return
+        }
+
+        XCTFail("Namespace 'email' is not nil but expected nil.")
+    }
+
     func testAddItems_overwrite() {
         var identityMap = IdentityMap()
         identityMap.addItem(namespace: "space", id: "id", authenticationState: XDMAuthenticationState.ambiguous, primary: false)

--- a/AEPIdentity/Tests/IdentityMapTests.swift
+++ b/AEPIdentity/Tests/IdentityMapTests.swift
@@ -1,0 +1,274 @@
+//
+// Copyright 2020 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+@testable import AEPIdentity
+import XCTest
+
+class IdentityMapTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        continueAfterFailure = false // fail so nil checks stop execution
+    }
+
+    // MARK: getItemsFor tests
+    func testGetItemsFor() {
+        var identityMap = IdentityMap()
+        identityMap.addItem(namespace: "space", id: "id", authenticationState: MobileVisitorAuthenticationState.unknown, primary: false)
+
+        let spaceItems = identityMap.getItemsFor(namespace: "space")
+        XCTAssertNotNil(spaceItems)
+        XCTAssertEqual(1, spaceItems?.count)
+        XCTAssertEqual("id", spaceItems?[0].id)
+        XCTAssertEqual("ambiguous", spaceItems?[0].authenticationState?.rawValue)
+        XCTAssertFalse(spaceItems?[0].primary ?? true)
+
+        let unknown = identityMap.getItemsFor(namespace: "unknown")
+        XCTAssertNil(unknown)
+    }
+
+    func testAddItems() {
+        var identityMap = IdentityMap()
+        identityMap.addItem(namespace: "space", id: "id", authenticationState: MobileVisitorAuthenticationState.unknown, primary: false)
+        identityMap.addItem(namespace: "email", id: "example@adobe.com")
+        identityMap.addItem(namespace: "space", id: "custom", authenticationState: MobileVisitorAuthenticationState.unknown, primary: true)
+
+        guard let spaceItems = identityMap.getItemsFor(namespace: "space") else {
+            XCTFail("Namespace 'space' is nil but expected not nil.")
+            return
+        }
+
+        XCTAssertEqual(2, spaceItems.count)
+        XCTAssertEqual("id", spaceItems[0].id)
+        XCTAssertEqual(XDMAuthenticationState.ambiguous, spaceItems[0].authenticationState)
+        XCTAssertFalse(spaceItems[0].primary ?? true)
+        XCTAssertEqual("custom", spaceItems[1].id)
+        XCTAssertEqual(XDMAuthenticationState.ambiguous, spaceItems[1].authenticationState)
+        XCTAssertTrue(spaceItems[1].primary ?? false)
+
+        guard let emailItems = identityMap.getItemsFor(namespace: "email") else {
+            XCTFail("Namespace 'email' is nil but expected not nil.")
+            return
+        }
+
+        XCTAssertEqual(1, emailItems.count)
+        XCTAssertEqual("example@adobe.com", emailItems[0].id)
+    }
+
+    func testAddItems_overwrite() {
+        var identityMap = IdentityMap()
+        identityMap.addItem(namespace: "space", id: "id", authenticationState: MobileVisitorAuthenticationState.unknown, primary: false)
+        identityMap.addItem(namespace: "space", id: "id", authenticationState: MobileVisitorAuthenticationState.authenticated)
+
+        guard let spaceItems = identityMap.getItemsFor(namespace: "space") else {
+            XCTFail("Namespace 'space' is nil but expected not nil.")
+            return
+        }
+
+        XCTAssertEqual(1, spaceItems.count)
+        XCTAssertEqual("id", spaceItems[0].id)
+        XCTAssertEqual(XDMAuthenticationState.authenticated, spaceItems[0].authenticationState)
+        XCTAssertNil(spaceItems[0].primary)
+    }
+
+    // MARK: encoder tests
+    func testEncode_oneItem() {
+        var identityMap = IdentityMap()
+        identityMap.addItem(namespace: "space", id: "id", authenticationState: MobileVisitorAuthenticationState.unknown, primary: false)
+
+        let encodedIdentityMap = try! JSONEncoder().encode(identityMap)
+        let decodedIdentityMap = try! JSONDecoder().decode(IdentityMap.self, from: encodedIdentityMap)
+
+        // verify
+        XCTAssertEqual(identityMap, decodedIdentityMap)
+    }
+
+    func testEncode_twoItems() {
+        var identityMap = IdentityMap()
+        identityMap.addItem(namespace: "space", id: "id", authenticationState: MobileVisitorAuthenticationState.unknown, primary: false)
+        identityMap.addItem(namespace: "A", id: "123")
+
+        let encodedIdentityMap = try! JSONEncoder().encode(identityMap)
+        let decodedIdentityMap = try! JSONDecoder().decode(IdentityMap.self, from: encodedIdentityMap)
+
+        // verify
+        XCTAssertEqual(identityMap, decodedIdentityMap)
+    }
+
+    func testEncode_twoItemsSameNamespace() {
+        var identityMap = IdentityMap()
+        identityMap.addItem(namespace: "space", id: "id", authenticationState: MobileVisitorAuthenticationState.unknown, primary: false)
+        identityMap.addItem(namespace: "space", id: "123")
+
+        let encodedIdentityMap = try! JSONEncoder().encode(identityMap)
+        let decodedIdentityMap = try! JSONDecoder().decode(IdentityMap.self, from: encodedIdentityMap)
+
+        // verify
+        XCTAssertEqual(identityMap, decodedIdentityMap)
+    }
+
+    // MARK: decoder tests
+    func testDecode_oneItem() {
+        guard let data = """
+            {
+              "space" : [
+                {
+                  "authenticationState" : "ambiguous",
+                  "id" : "id",
+                  "primary" : false
+                }
+              ]
+            }
+        """.data(using: .utf8) else {
+            XCTFail("Failed to convert json string to data")
+            return
+        }
+        let decoder = JSONDecoder()
+
+        let identityMap = try? decoder.decode(IdentityMap.self, from: data)
+        XCTAssertNotNil(identityMap)
+        guard let items = identityMap?.getItemsFor(namespace: "space") else {
+            XCTFail("Namespace 'space' is nil but expected not nil.")
+            return
+        }
+
+        XCTAssertEqual(1, items.count)
+        XCTAssertEqual("id", items[0].id)
+        XCTAssertEqual("ambiguous", items[0].authenticationState?.rawValue)
+        XCTAssertFalse(items[0].primary ?? true)
+    }
+
+    func testDecode_twoItems() {
+        guard let data = """
+            {
+              "A" : [
+                {
+                  "id" : "123"
+                }
+              ],
+              "space" : [
+                {
+                  "authenticationState" : "ambiguous",
+                  "id" : "id",
+                  "primary" : false
+                }
+              ]
+            }
+        """.data(using: .utf8) else {
+            XCTFail("Failed to convert json string to data")
+            return
+        }
+        let decoder = JSONDecoder()
+
+        let identityMap = try? decoder.decode(IdentityMap.self, from: data)
+        XCTAssertNotNil(identityMap)
+        guard let spaceItems = identityMap?.getItemsFor(namespace: "space") else {
+            XCTFail("Namespace 'space' is nil but expected not nil.")
+            return
+        }
+
+        XCTAssertEqual(1, spaceItems.count)
+        XCTAssertEqual("id", spaceItems[0].id)
+        XCTAssertEqual("ambiguous", spaceItems[0].authenticationState?.rawValue)
+        XCTAssertFalse(spaceItems[0].primary ?? true)
+
+        guard let aItems = identityMap?.getItemsFor(namespace: "A") else {
+            XCTFail("Namespace 'A' is nil but expected not nil.")
+            return
+        }
+
+        XCTAssertEqual("123", aItems[0].id)
+        XCTAssertNil(aItems[0].authenticationState)
+        XCTAssertNil(aItems[0].primary)
+    }
+
+    func testDecode_twoItemsSameNamespace() {
+        guard let data = """
+            {
+              "space" : [
+                {
+                  "authenticationState" : "ambiguous",
+                  "id" : "id",
+                  "primary" : false
+                },
+                {
+                  "id" : "123"
+                }
+              ]
+            }
+        """.data(using: .utf8) else {
+            XCTFail("Failed to convert json to data")
+            return
+        }
+        let decoder = JSONDecoder()
+
+        let identityMap = try? decoder.decode(IdentityMap.self, from: data)
+        XCTAssertNotNil(identityMap)
+
+        guard let spaceItems = identityMap?.getItemsFor(namespace: "space") else {
+            XCTFail("Namespace 'space' is nil but expected not nil.")
+            return
+        }
+
+        XCTAssertEqual(2, spaceItems.count)
+        XCTAssertEqual("id", spaceItems[0].id)
+        XCTAssertEqual("ambiguous", spaceItems[0].authenticationState?.rawValue)
+        XCTAssertFalse(spaceItems[0].primary ?? true)
+
+        XCTAssertEqual("123", spaceItems[1].id)
+        XCTAssertNil(spaceItems[1].authenticationState)
+        XCTAssertNil(spaceItems[1].primary)
+    }
+
+    func testDecode_unknownParamsInIdentityItem() {
+        guard let data = """
+            {
+              "space" : [
+                {
+                  "authenticationState" : "ambiguous",
+                  "id" : "id",
+                  "unknown" : true,
+                  "primary" : false
+                }
+              ]
+            }
+        """.data(using: .utf8) else {
+            XCTFail("Failed to convert json to data")
+            return
+        }
+        let decoder = JSONDecoder()
+
+        let identityMap = try? decoder.decode(IdentityMap.self, from: data)
+        XCTAssertNotNil(identityMap)
+
+        guard let spaceItems = identityMap?.getItemsFor(namespace: "space") else {
+            XCTFail("Namespace 'space' is nil but expected not nil.")
+            return
+        }
+
+        XCTAssertEqual(1, spaceItems.count)
+        XCTAssertEqual("id", spaceItems[0].id)
+        XCTAssertEqual("ambiguous", spaceItems[0].authenticationState?.rawValue)
+        XCTAssertFalse(spaceItems[0].primary ?? true)
+    }
+
+    func testDecode_emptyJson() {
+        guard let data = "{ }".data(using: .utf8)  else {
+            XCTFail("Failed to convert json to data")
+            return
+        }
+        let decoder = JSONDecoder()
+
+        let identityMap = try? decoder.decode(IdentityMap.self, from: data)
+        XCTAssertNotNil(identityMap)
+    }
+
+}

--- a/AEPIdentity/Tests/IdentityStateTests.swift
+++ b/AEPIdentity/Tests/IdentityStateTests.swift
@@ -607,6 +607,8 @@ class IdentityStateTests: XCTestCase {
         dispatchedEventExpectation.assertForOverFulfill = true
         let sharedStateExpectation = XCTestExpectation(description: "Shared state should be updated since the blob/hint are updated.")
         sharedStateExpectation.assertForOverFulfill = true
+        let xdmSharedStateExpectation = XCTestExpectation(description: "XDM Shared state should be updated since the blob/hint are updated.")
+        xdmSharedStateExpectation.assertForOverFulfill = true
 
         var props = IdentityProperties()
         props.lastSync = Date()
@@ -622,6 +624,8 @@ class IdentityStateTests: XCTestCase {
             dispatchedEventExpectation.fulfill()
         }) { _, _ in
             sharedStateExpectation.fulfill()
+        } createXDMSharedState: { _, _ in
+            xdmSharedStateExpectation.fulfill()
         }
 
         // verify
@@ -640,6 +644,8 @@ class IdentityStateTests: XCTestCase {
         dispatchedEventExpectation.assertForOverFulfill = true
         let sharedStateExpectation = XCTestExpectation(description: "Shared state should not be updated")
         sharedStateExpectation.isInverted = true
+        let xdmSharedStateExpectation = XCTestExpectation(description: "XDM Shared state should not be updated")
+        xdmSharedStateExpectation.isInverted = true
 
         var props = IdentityProperties()
         props.lastSync = Date()
@@ -654,6 +660,8 @@ class IdentityStateTests: XCTestCase {
             dispatchedEventExpectation.fulfill()
         }) { _, _ in
             sharedStateExpectation.fulfill()
+        } createXDMSharedState: { _, _ in
+            xdmSharedStateExpectation.fulfill()
         }
 
         // verify
@@ -672,6 +680,8 @@ class IdentityStateTests: XCTestCase {
         dispatchedEventExpectation.assertForOverFulfill = true
         let sharedStateExpectation = XCTestExpectation(description: "Shared state should not be updated")
         sharedStateExpectation.isInverted = true
+        let xdmSharedStateExpectation = XCTestExpectation(description: "XDM Shared state should not be updated")
+        xdmSharedStateExpectation.isInverted = true
 
         var props = IdentityProperties()
         props.lastSync = Date()
@@ -686,6 +696,8 @@ class IdentityStateTests: XCTestCase {
             dispatchedEventExpectation.fulfill()
         }) { _, _ in
             sharedStateExpectation.fulfill()
+        } createXDMSharedState: { _, _ in
+            xdmSharedStateExpectation.fulfill()
         }
 
         // verify
@@ -704,6 +716,8 @@ class IdentityStateTests: XCTestCase {
         dispatchedEventExpectation.assertForOverFulfill = true
         let sharedStateExpectation = XCTestExpectation(description: "Shared state should not be updated as we are opted-out")
         sharedStateExpectation.isInverted = true
+        let xdmSharedStateExpectation = XCTestExpectation(description: "XDM Shared state should not be updated as we are opted-out")
+        xdmSharedStateExpectation.isInverted = true
 
         var props = IdentityProperties()
         props.lastSync = Date()
@@ -718,6 +732,8 @@ class IdentityStateTests: XCTestCase {
             dispatchedEventExpectation.fulfill()
         }) { _, _ in
             sharedStateExpectation.fulfill()
+        } createXDMSharedState: { _, _ in
+            xdmSharedStateExpectation.fulfill()
         }
 
         // verify
@@ -736,6 +752,9 @@ class IdentityStateTests: XCTestCase {
         dispatchedEventExpectation.expectedFulfillmentCount = 2
         let sharedStateExpectation = XCTestExpectation(description: "Shared state should not be updated as the response was empty")
         sharedStateExpectation.isInverted = true
+        let xdmSharedStateExpectation = XCTestExpectation(description: "XDM Shared state should not be updated as the response was empty")
+        xdmSharedStateExpectation.isInverted = true
+
 
         var props = IdentityProperties()
         props.lastSync = Date()
@@ -748,6 +767,8 @@ class IdentityStateTests: XCTestCase {
             dispatchedEventExpectation.fulfill()
         }) { _, _ in
             sharedStateExpectation.fulfill()
+        } createXDMSharedState: { _, _ in
+            xdmSharedStateExpectation.fulfill()
         }
 
         // verify
@@ -770,6 +791,8 @@ class IdentityStateTests: XCTestCase {
         // test
         state.processPrivacyChange(event: event, createSharedState: { (data, event) in
             XCTFail("Shared state should not be updated")
+        }, createXDMSharedState: { _,_ in
+            XCTFail("XDM Shared state should not be updated")
         })
 
         // verify
@@ -792,6 +815,8 @@ class IdentityStateTests: XCTestCase {
         // test
         state.processPrivacyChange(event: event, createSharedState: { (_, _) in
             XCTFail("Shared state should not be updated")
+        }, createXDMSharedState: { _,_ in
+            XCTFail("XDM Shared state should not be updated")
         })
 
         // verify
@@ -805,6 +830,7 @@ class IdentityStateTests: XCTestCase {
     func testProcessPrivacyChangeToOptOut() {
         // setup
         let sharedStateExpectation = XCTestExpectation(description: "Shared state should be updated once")
+        let xdmSharedStateExpectation = XCTestExpectation(description: "XDM Shared state should be updated once")
         var props = IdentityProperties()
         props.privacyStatus = .unknown
         props.ecid = ECID()
@@ -815,6 +841,8 @@ class IdentityStateTests: XCTestCase {
         // test
         state.processPrivacyChange(event: event, createSharedState: { (data, event) in
             sharedStateExpectation.fulfill()
+        }, createXDMSharedState: { _, _ in
+            xdmSharedStateExpectation.fulfill()
         })
 
         // verify
@@ -829,6 +857,7 @@ class IdentityStateTests: XCTestCase {
     func testProcessPrivacyChangeFromOptOutToOptIn() {
         // setup
         let sharedStateExpectation = XCTestExpectation(description: "Shared state should be updated once")
+        let xdmSharedStateExpectation = XCTestExpectation(description: "XDM Shared state should be updated once")
         var props = IdentityProperties()
         props.privacyStatus = .optedOut
 
@@ -842,6 +871,8 @@ class IdentityStateTests: XCTestCase {
         // test
         state.processPrivacyChange(event: event, createSharedState: { (_, _) in
             sharedStateExpectation.fulfill()
+        }, createXDMSharedState: { _, _ in
+            xdmSharedStateExpectation.fulfill()
         })
 
         // verify
@@ -855,6 +886,7 @@ class IdentityStateTests: XCTestCase {
     func testProcessPrivacyChangeFromOptOutToUnknown() {
         // setup
         let sharedStateExpectation = XCTestExpectation(description: "A force sync event should be dispatched")
+        let xdmSharedStateExpectation = XCTestExpectation(description: "Force sync should cause XDM shared state to be updated")
         var props = IdentityProperties()
         props.privacyStatus = .optedOut
 
@@ -868,6 +900,8 @@ class IdentityStateTests: XCTestCase {
         // test
         state.processPrivacyChange(event: event, createSharedState: { _, _ in
             sharedStateExpectation.fulfill()
+        }, createXDMSharedState: { _, _ in
+            xdmSharedStateExpectation.fulfill()
         })
 
         // verify

--- a/AEPIdentity/Tests/IdentityStateTests.swift
+++ b/AEPIdentity/Tests/IdentityStateTests.swift
@@ -622,11 +622,11 @@ class IdentityStateTests: XCTestCase {
         state.handleHitResponse(hit: hit, response: try! JSONEncoder().encode(hitResponse), eventDispatcher: { event in
             XCTAssertEqual(state.identityProperties.toEventData().count, event.data?.count) // event should contain the identity properties in the event data
             dispatchedEventExpectation.fulfill()
-        }) { _, _ in
+        }, createSharedState: { _, _ in
             sharedStateExpectation.fulfill()
-        } createXDMSharedState: { _, _ in
+        }, createXDMSharedState: { _, _ in
             xdmSharedStateExpectation.fulfill()
-        }
+        })
 
         // verify
         wait(for: [dispatchedEventExpectation], timeout: 1)
@@ -658,11 +658,11 @@ class IdentityStateTests: XCTestCase {
         // test
         state.handleHitResponse(hit: hit, response: try! JSONEncoder().encode(hitResponse), eventDispatcher: { _ in
             dispatchedEventExpectation.fulfill()
-        }) { _, _ in
+        }, createSharedState: { _, _ in
             sharedStateExpectation.fulfill()
-        } createXDMSharedState: { _, _ in
+        }, createXDMSharedState: { _, _ in
             xdmSharedStateExpectation.fulfill()
-        }
+        })
 
         // verify
         wait(for: [dispatchedEventExpectation], timeout: 1)
@@ -694,11 +694,11 @@ class IdentityStateTests: XCTestCase {
         // test
         state.handleHitResponse(hit: hit, response: try! JSONEncoder().encode(hitResponse), eventDispatcher: { _ in
             dispatchedEventExpectation.fulfill()
-        }) { _, _ in
+        }, createSharedState: { _, _ in
             sharedStateExpectation.fulfill()
-        } createXDMSharedState: { _, _ in
+        }, createXDMSharedState: { _, _ in
             xdmSharedStateExpectation.fulfill()
-        }
+        })
 
         // verify
         wait(for: [dispatchedEventExpectation], timeout: 1)
@@ -730,11 +730,11 @@ class IdentityStateTests: XCTestCase {
         // test
         state.handleHitResponse(hit: hit, response: try! JSONEncoder().encode(hitResponse), eventDispatcher: { _ in
             dispatchedEventExpectation.fulfill()
-        }) { _, _ in
+        }, createSharedState: { _, _ in
             sharedStateExpectation.fulfill()
-        } createXDMSharedState: { _, _ in
+        }, createXDMSharedState: { _, _ in
             xdmSharedStateExpectation.fulfill()
-        }
+        })
 
         // verify
         wait(for: [dispatchedEventExpectation], timeout: 1)
@@ -765,11 +765,11 @@ class IdentityStateTests: XCTestCase {
         // test
         state.handleHitResponse(hit: IdentityHit.fakeHit(), response: nil, eventDispatcher: { _ in
             dispatchedEventExpectation.fulfill()
-        }) { _, _ in
+        }, createSharedState: { _, _ in
             sharedStateExpectation.fulfill()
-        } createXDMSharedState: { _, _ in
+        }, createXDMSharedState: { _, _ in
             xdmSharedStateExpectation.fulfill()
-        }
+        })
 
         // verify
         wait(for: [dispatchedEventExpectation], timeout: 1)

--- a/AEPIdentity/Tests/IdentityStateTests.swift
+++ b/AEPIdentity/Tests/IdentityStateTests.swift
@@ -607,8 +607,6 @@ class IdentityStateTests: XCTestCase {
         dispatchedEventExpectation.assertForOverFulfill = true
         let sharedStateExpectation = XCTestExpectation(description: "Shared state should be updated since the blob/hint are updated.")
         sharedStateExpectation.assertForOverFulfill = true
-        let xdmSharedStateExpectation = XCTestExpectation(description: "XDM Shared state should be updated since the blob/hint are updated.")
-        xdmSharedStateExpectation.assertForOverFulfill = true
 
         var props = IdentityProperties()
         props.lastSync = Date()
@@ -624,8 +622,6 @@ class IdentityStateTests: XCTestCase {
             dispatchedEventExpectation.fulfill()
         }, createSharedState: { _, _ in
             sharedStateExpectation.fulfill()
-        }, createXDMSharedState: { _, _ in
-            xdmSharedStateExpectation.fulfill()
         })
 
         // verify
@@ -644,8 +640,6 @@ class IdentityStateTests: XCTestCase {
         dispatchedEventExpectation.assertForOverFulfill = true
         let sharedStateExpectation = XCTestExpectation(description: "Shared state should not be updated")
         sharedStateExpectation.isInverted = true
-        let xdmSharedStateExpectation = XCTestExpectation(description: "XDM Shared state should not be updated")
-        xdmSharedStateExpectation.isInverted = true
 
         var props = IdentityProperties()
         props.lastSync = Date()
@@ -660,8 +654,6 @@ class IdentityStateTests: XCTestCase {
             dispatchedEventExpectation.fulfill()
         }, createSharedState: { _, _ in
             sharedStateExpectation.fulfill()
-        }, createXDMSharedState: { _, _ in
-            xdmSharedStateExpectation.fulfill()
         })
 
         // verify
@@ -680,8 +672,6 @@ class IdentityStateTests: XCTestCase {
         dispatchedEventExpectation.assertForOverFulfill = true
         let sharedStateExpectation = XCTestExpectation(description: "Shared state should not be updated")
         sharedStateExpectation.isInverted = true
-        let xdmSharedStateExpectation = XCTestExpectation(description: "XDM Shared state should not be updated")
-        xdmSharedStateExpectation.isInverted = true
 
         var props = IdentityProperties()
         props.lastSync = Date()
@@ -696,8 +686,6 @@ class IdentityStateTests: XCTestCase {
             dispatchedEventExpectation.fulfill()
         }, createSharedState: { _, _ in
             sharedStateExpectation.fulfill()
-        }, createXDMSharedState: { _, _ in
-            xdmSharedStateExpectation.fulfill()
         })
 
         // verify
@@ -716,8 +704,6 @@ class IdentityStateTests: XCTestCase {
         dispatchedEventExpectation.assertForOverFulfill = true
         let sharedStateExpectation = XCTestExpectation(description: "Shared state should not be updated as we are opted-out")
         sharedStateExpectation.isInverted = true
-        let xdmSharedStateExpectation = XCTestExpectation(description: "XDM Shared state should not be updated as we are opted-out")
-        xdmSharedStateExpectation.isInverted = true
 
         var props = IdentityProperties()
         props.lastSync = Date()
@@ -732,8 +718,6 @@ class IdentityStateTests: XCTestCase {
             dispatchedEventExpectation.fulfill()
         }, createSharedState: { _, _ in
             sharedStateExpectation.fulfill()
-        }, createXDMSharedState: { _, _ in
-            xdmSharedStateExpectation.fulfill()
         })
 
         // verify
@@ -752,9 +736,6 @@ class IdentityStateTests: XCTestCase {
         dispatchedEventExpectation.expectedFulfillmentCount = 2
         let sharedStateExpectation = XCTestExpectation(description: "Shared state should not be updated as the response was empty")
         sharedStateExpectation.isInverted = true
-        let xdmSharedStateExpectation = XCTestExpectation(description: "XDM Shared state should not be updated as the response was empty")
-        xdmSharedStateExpectation.isInverted = true
-
 
         var props = IdentityProperties()
         props.lastSync = Date()
@@ -767,8 +748,6 @@ class IdentityStateTests: XCTestCase {
             dispatchedEventExpectation.fulfill()
         }, createSharedState: { _, _ in
             sharedStateExpectation.fulfill()
-        }, createXDMSharedState: { _, _ in
-            xdmSharedStateExpectation.fulfill()
         })
 
         // verify


### PR DESCRIPTION
This PR adds support for sharing the `identityMap` as part of Identity's shared state. Any time that we update the standard shared state we also update the XDM shared state with a XDM representation of the current Identity data.

Sample Identity XDM shared state:
```json
{
  "identityMap" : {
    "ECID" : [
      {
        "id" : "59725191566662510105001351686447723202",
        "authenticationState" : "ambiguous"
      }
    ],
    "test-type" : [
      {
        "id" : "test-identifier",
        "authenticationState" : "authenticated",
        "primary" : false
      }
    ]
  }
}
```