### PR TITLE
Adding UI services

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -303,6 +303,7 @@
 		78AA4ECB2513AF4200205AE9 /* ConfigurationAppIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AA4ECA2513AF4200205AE9 /* ConfigurationAppIDTests.swift */; };
 		921EE1D3257A337D00A119FA /* UIServiceInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921EE199257A287A00A119FA /* UIServiceInterface.swift */; };
 		921EE1F0257A338100A119FA /* UIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921EE189257A284800A119FA /* UIService.swift */; };
+		92490BE7258BE23A00762B04 /* UIServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92490BE6258BE23A00762B04 /* UIServiceTests.swift */; };
 		92EEA57025885C1C00DBA3EE /* FullscreenMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EEA56F25885C1C00DBA3EE /* FullscreenMessage.swift */; };
 		92EEA58025885C6900DBA3EE /* FullScreenMessageUiInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EEA57F25885C6900DBA3EE /* FullScreenMessageUiInterface.swift */; };
 		92EEA59E25885CD600DBA3EE /* FullScreenUIHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EEA59D25885CD600DBA3EE /* FullScreenUIHandler.swift */; };
@@ -853,6 +854,7 @@
 		78AA4ECA2513AF4200205AE9 /* ConfigurationAppIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationAppIDTests.swift; sourceTree = "<group>"; };
 		921EE189257A284800A119FA /* UIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIService.swift; sourceTree = "<group>"; };
 		921EE199257A287A00A119FA /* UIServiceInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIServiceInterface.swift; sourceTree = "<group>"; };
+		92490BE6258BE23A00762B04 /* UIServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIServiceTests.swift; sourceTree = "<group>"; };
 		92EEA56F25885C1C00DBA3EE /* FullscreenMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenMessage.swift; sourceTree = "<group>"; };
 		92EEA57F25885C6900DBA3EE /* FullScreenMessageUiInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenMessageUiInterface.swift; sourceTree = "<group>"; };
 		92EEA59D25885CD600DBA3EE /* FullScreenUIHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenUIHandler.swift; sourceTree = "<group>"; };
@@ -1416,6 +1418,7 @@
 				78AA4EBF2509731A00205AE9 /* FileManager+ZipTests.swift */,
 				3F03980524BE61520019F095 /* URLServiceTest.swift */,
 				3F03980724BE61520019F095 /* UserDefaultsNamedCollectionTest.swift */,
+				92490BE6258BE23A00762B04 /* UIServiceTests.swift */,
 			);
 			path = services;
 			sourceTree = "<group>";
@@ -2633,6 +2636,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F03981624BE61520019F095 /* SystemInfoServiceTest.swift in Sources */,
+				92490BE7258BE23A00762B04 /* UIServiceTests.swift in Sources */,
 				249498E2254A0C920045E392 /* Date+FormatTests.swift in Sources */,
 				3F03981E24BE61520019F095 /* DataQueueTests.swift in Sources */,
 				3F03981524BE61520019F095 /* UnzipperTest.swift in Sources */,

--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -301,6 +301,13 @@
 		78AA4EC62513AE3900205AE9 /* ConfigurationLifecycleResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AA4EC52513AE3900205AE9 /* ConfigurationLifecycleResponseTests.swift */; };
 		78AA4EC92513AEBD00205AE9 /* ConfigurationPrivacyStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AA4EC82513AEBD00205AE9 /* ConfigurationPrivacyStatusTests.swift */; };
 		78AA4ECB2513AF4200205AE9 /* ConfigurationAppIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AA4ECA2513AF4200205AE9 /* ConfigurationAppIDTests.swift */; };
+		921EE1D3257A337D00A119FA /* UIServiceInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921EE199257A287A00A119FA /* UIServiceInterface.swift */; };
+		921EE1F0257A338100A119FA /* UIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921EE189257A284800A119FA /* UIService.swift */; };
+		92EEA57025885C1C00DBA3EE /* FullscreenMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EEA56F25885C1C00DBA3EE /* FullscreenMessage.swift */; };
+		92EEA58025885C6900DBA3EE /* FullScreenMessageUiInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EEA57F25885C6900DBA3EE /* FullScreenMessageUiInterface.swift */; };
+		92EEA59E25885CD600DBA3EE /* FullScreenUIHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EEA59D25885CD600DBA3EE /* FullScreenUIHandler.swift */; };
+		92EEA5F6258933A600DBA3EE /* FullscreenListenerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EEA5F5258933A600DBA3EE /* FullscreenListenerInterface.swift */; };
+		92EEA6062589343700DBA3EE /* MessageMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EEA6052589343700DBA3EE /* MessageMonitor.swift */; };
 		BB00E26824D8C94600C578C1 /* TokenFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00E26624D8C94600C578C1 /* TokenFinder.swift */; };
 		BB00E26924D8C94600C578C1 /* Dictionary+Flatten.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00E26724D8C94600C578C1 /* Dictionary+Flatten.swift */; };
 		BB00E26B24D8C9A600C578C1 /* Date+Format.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00E26A24D8C9A600C578C1 /* Date+Format.swift */; };
@@ -844,6 +851,13 @@
 		78AA4EC52513AE3900205AE9 /* ConfigurationLifecycleResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationLifecycleResponseTests.swift; sourceTree = "<group>"; };
 		78AA4EC82513AEBD00205AE9 /* ConfigurationPrivacyStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationPrivacyStatusTests.swift; sourceTree = "<group>"; };
 		78AA4ECA2513AF4200205AE9 /* ConfigurationAppIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationAppIDTests.swift; sourceTree = "<group>"; };
+		921EE189257A284800A119FA /* UIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIService.swift; sourceTree = "<group>"; };
+		921EE199257A287A00A119FA /* UIServiceInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIServiceInterface.swift; sourceTree = "<group>"; };
+		92EEA56F25885C1C00DBA3EE /* FullscreenMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenMessage.swift; sourceTree = "<group>"; };
+		92EEA57F25885C6900DBA3EE /* FullScreenMessageUiInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenMessageUiInterface.swift; sourceTree = "<group>"; };
+		92EEA59D25885CD600DBA3EE /* FullScreenUIHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenUIHandler.swift; sourceTree = "<group>"; };
+		92EEA5F5258933A600DBA3EE /* FullscreenListenerInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenListenerInterface.swift; sourceTree = "<group>"; };
+		92EEA6052589343700DBA3EE /* MessageMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageMonitor.swift; sourceTree = "<group>"; };
 		BB00E26624D8C94600C578C1 /* TokenFinder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenFinder.swift; sourceTree = "<group>"; };
 		BB00E26724D8C94600C578C1 /* Dictionary+Flatten.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Flatten.swift"; sourceTree = "<group>"; };
 		BB00E26A24D8C9A600C578C1 /* Date+Format.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+Format.swift"; sourceTree = "<group>"; };
@@ -1200,6 +1214,7 @@
 		24B4934824D337B300AA38D9 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				921EE17A2579E89E00A119FA /* ui */,
 				3F03979F24BE5FF30019F095 /* cache */,
 				3F0397B224BE5FF30019F095 /* dataqueue */,
 				3F0397A624BE5FF30019F095 /* log */,
@@ -1702,6 +1717,28 @@
 				78AA4ECA2513AF4200205AE9 /* ConfigurationAppIDTests.swift */,
 			);
 			path = Configuration;
+			sourceTree = "<group>";
+		};
+		921EE17A2579E89E00A119FA /* ui */ = {
+			isa = PBXGroup;
+			children = (
+				92EEA64D258956FE00DBA3EE /* fullscreen */,
+				921EE189257A284800A119FA /* UIService.swift */,
+				921EE199257A287A00A119FA /* UIServiceInterface.swift */,
+				92EEA6052589343700DBA3EE /* MessageMonitor.swift */,
+			);
+			path = ui;
+			sourceTree = "<group>";
+		};
+		92EEA64D258956FE00DBA3EE /* fullscreen */ = {
+			isa = PBXGroup;
+			children = (
+				92EEA5F5258933A600DBA3EE /* FullscreenListenerInterface.swift */,
+				92EEA59D25885CD600DBA3EE /* FullScreenUIHandler.swift */,
+				92EEA57F25885C6900DBA3EE /* FullScreenMessageUiInterface.swift */,
+				92EEA56F25885C1C00DBA3EE /* FullscreenMessage.swift */,
+			);
+			path = fullscreen;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2538,6 +2575,7 @@
 				3F0397C924BE5FF30019F095 /* Logging.swift in Sources */,
 				3F0397D224BE5FF30019F095 /* NetworkRequest.swift in Sources */,
 				3F0397F224BE60910019F095 /* HitProcessing.swift in Sources */,
+				92EEA57025885C1C00DBA3EE /* FullscreenMessage.swift in Sources */,
 				3F0397FB24BE60910019F095 /* ThreadSafeArray.swift in Sources */,
 				3F0397DF24BE5FF30019F095 /* URLOpening.swift in Sources */,
 				3F0397CC24BE5FF30019F095 /* NetworkService.swift in Sources */,
@@ -2548,6 +2586,7 @@
 				3F0397C724BE5FF30019F095 /* CacheExpiry.swift in Sources */,
 				3F0397C624BE5FF30019F095 /* DiskCacheService.swift in Sources */,
 				3F0397FC24BE60910019F095 /* OperationOrderer.swift in Sources */,
+				921EE1D3257A337D00A119FA /* UIServiceInterface.swift in Sources */,
 				3F0397D324BE5FF30019F095 /* SQLiteDataQueue.swift in Sources */,
 				3F0397C324BE5FF30019F095 /* Caching.swift in Sources */,
 				3F0397F924BE60910019F095 /* FileManager+ZIP.swift in Sources */,
@@ -2556,15 +2595,19 @@
 				3F0397F424BE60910019F095 /* HitQueuing.swift in Sources */,
 				3F0397DB24BE5FF30019F095 /* NamedCollectionDataStore.swift in Sources */,
 				2107F02E24C9FF88002935CF /* SHA256.swift in Sources */,
+				92EEA58025885C6900DBA3EE /* FullScreenMessageUiInterface.swift in Sources */,
 				3F0397C524BE5FF30019F095 /* CacheEntry.swift in Sources */,
 				3F0397F524BE60910019F095 /* AtomicCounter.swift in Sources */,
+				92EEA59E25885CD600DBA3EE /* FullScreenUIHandler.swift in Sources */,
 				3F0397DA24BE5FF30019F095 /* NamedCollectionProcessing.swift in Sources */,
+				92EEA5F6258933A600DBA3EE /* FullscreenListenerInterface.swift in Sources */,
 				3F0397FE24BE60910019F095 /* URLEncoder.swift in Sources */,
 				3F0397FF24BE60910019F095 /* AnyCodable.swift in Sources */,
 				3F0397D124BE5FF30019F095 /* HttpConnection.swift in Sources */,
 				3F0397D824BE5FF30019F095 /* DataQueuing.swift in Sources */,
 				3F0397E024BE5FF30019F095 /* URLService.swift in Sources */,
 				3F0397CA24BE5FF30019F095 /* Log.swift in Sources */,
+				92EEA6062589343700DBA3EE /* MessageMonitor.swift in Sources */,
 				3F0397DC24BE5FF30019F095 /* UserDefaultsNamedCollection.swift in Sources */,
 				3F0397D524BE5FF30019F095 /* DataQueue.swift in Sources */,
 				BB00E26D24D9BF6C00C578C1 /* URLUtility.swift in Sources */,
@@ -2581,6 +2624,7 @@
 				3F0397C824BE5FF30019F095 /* ServiceProvider.swift in Sources */,
 				2467E43A24CA4DE20022F6BE /* Unzipping.swift in Sources */,
 				3F0397F724BE60910019F095 /* ZipArchive.swift in Sources */,
+				921EE1F0257A338100A119FA /* UIService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AEPServices/Sources/ServiceProvider.swift
+++ b/AEPServices/Sources/ServiceProvider.swift
@@ -113,7 +113,7 @@ public class ServiceProvider {
             return defaultLoggingService
         }
     }
-    
+
     public var uiService: UIServiceInterface {
         get {
             return queue.sync {

--- a/AEPServices/Sources/ServiceProvider.swift
+++ b/AEPServices/Sources/ServiceProvider.swift
@@ -30,6 +30,8 @@ public class ServiceProvider {
     private var overrideURLService: URLOpening?
     private var defaultURLService = URLService()
     private var defaultLoggingService = LoggingService()
+    private var overrideFullscreenUIService: UIServiceInterface?
+    private var defaultFullscreenUIService = UIService()
 
     // Don't allow init of ServiceProvider outside the class
     private init() {}
@@ -111,6 +113,19 @@ public class ServiceProvider {
             return defaultLoggingService
         }
     }
+    
+    public var uiService: UIServiceInterface {
+        get {
+            return queue.sync {
+                return overrideFullscreenUIService ?? defaultFullscreenUIService
+            }
+        }
+        set {
+            queue.async {
+                self.overrideFullscreenUIService = newValue
+            }
+        }
+    }
 
     internal func reset() {
         defaultSystemInfoService = ApplicationSystemInfoService()
@@ -120,11 +135,13 @@ public class ServiceProvider {
         defaultCacheService = DiskCacheService()
         defaultURLService = URLService()
         defaultLoggingService = LoggingService()
+        defaultFullscreenUIService = UIService()
 
         overrideSystemInfoService = nil
         overrideKeyValueService = nil
         overrideNetworkService = nil
         overrideCacheService = nil
         overrideURLService = nil
+        overrideFullscreenUIService = nil
     }
 }

--- a/AEPServices/Sources/ui/MessageMonitor.swift
+++ b/AEPServices/Sources/ui/MessageMonitor.swift
@@ -1,0 +1,55 @@
+/*
+ Copyright 2020 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+
+/*
+ This class is used to monitor if an UI message is displayed at some point in time,
+ currently this applies for full screen and alert messages.
+ The status will be exposed to the core through the UIService.
+ @see UIHandling.isMessageDisplayed()
+ */
+
+import Foundation
+
+public class MessageMonitor {
+
+    private var isMessageDisplayed = false
+    private let messageQueue = DispatchQueue(label: "com.adobe.uiservice.messagemonitor")
+
+    /*
+     Sets the isMessageDisplayed flag on true so other UI messages will not be displayed
+     in the same time.
+     */
+    func displayed() {
+        messageQueue.async {
+            self.isMessageDisplayed = true
+        }
+    }
+
+    /*
+     Sets the isMessageDisplayed flag on false enabling other messages to be displayed
+     */
+    func dismissed() {
+        messageQueue.async {
+            self.isMessageDisplayed = false
+        }
+    }
+
+    /*
+     Returns current status of the isMessageDisplayed flag
+     */
+    func isDisplayed() -> Bool {
+        return messageQueue.sync {
+            isMessageDisplayed
+        }
+    }
+}

--- a/AEPServices/Sources/ui/MessageMonitor.swift
+++ b/AEPServices/Sources/ui/MessageMonitor.swift
@@ -10,43 +10,34 @@
  governing permissions and limitations under the License.
  */
 
-
+import Foundation
 
 ///This class is used to monitor if an UI message is displayed at some point in time,
 ///currently this applies for full screen and alert messages.
- The status will be exposed to the core through the UIService.
- @see UIHandling.isMessageDisplayed()
- */
-
-import Foundation
-
+///The status will be exposed to the core through the UIService.
+///@see UIService.isMessageDisplayed()
 public class MessageMonitor {
 
     private var isMessageDisplayed = false
     private let messageQueue = DispatchQueue(label: "com.adobe.uiservice.messagemonitor")
 
-    /*
-     Sets the isMessageDisplayed flag on true so other UI messages will not be displayed
-     in the same time.
-     */
+    /// Sets the isMessageDisplayed flag on true so other UI messages will not be displayed
+    /// in the same time.
     func displayed() {
         messageQueue.async {
             self.isMessageDisplayed = true
         }
     }
 
-    /*
-     Sets the isMessageDisplayed flag on false enabling other messages to be displayed
-     */
+    
+    /// Sets the isMessageDisplayed flag on false enabling other messages to be displayed
     func dismissed() {
         messageQueue.async {
             self.isMessageDisplayed = false
         }
     }
 
-    /*
-     Returns current status of the isMessageDisplayed flag
-     */
+    /// Returns current status of the isMessageDisplayed flag
     func isDisplayed() -> Bool {
         return messageQueue.sync {
             isMessageDisplayed

--- a/AEPServices/Sources/ui/MessageMonitor.swift
+++ b/AEPServices/Sources/ui/MessageMonitor.swift
@@ -3,7 +3,7 @@
  This file is licensed to you under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License. You may obtain a copy
  of the License at http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software distributed under
  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  OF ANY KIND, either express or implied. See the License for the specific language
@@ -29,7 +29,7 @@ public class MessageMonitor {
         }
     }
 
-    
+
     /// Sets the isMessageDisplayed flag on false enabling other messages to be displayed
     func dismissed() {
         messageQueue.async {

--- a/AEPServices/Sources/ui/MessageMonitor.swift
+++ b/AEPServices/Sources/ui/MessageMonitor.swift
@@ -11,9 +11,9 @@
  */
 
 
-/*
- This class is used to monitor if an UI message is displayed at some point in time,
- currently this applies for full screen and alert messages.
+
+///This class is used to monitor if an UI message is displayed at some point in time,
+///currently this applies for full screen and alert messages.
  The status will be exposed to the core through the UIService.
  @see UIHandling.isMessageDisplayed()
  */

--- a/AEPServices/Sources/ui/MessageMonitor.swift
+++ b/AEPServices/Sources/ui/MessageMonitor.swift
@@ -29,7 +29,6 @@ public class MessageMonitor {
         }
     }
 
-
     /// Sets the isMessageDisplayed flag on false enabling other messages to be displayed
     func dismissed() {
         messageQueue.async {

--- a/AEPServices/Sources/ui/UIService.swift
+++ b/AEPServices/Sources/ui/UIService.swift
@@ -1,0 +1,31 @@
+/*
+ Copyright 2020 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+import UIKit
+
+public class UIService: NSObject, UIServiceInterface {
+    var messageMonitor: MessageMonitor
+    override init() {
+        self.messageMonitor = MessageMonitor()
+    }
+    
+    public func createFullscreenMessage(html: String, fullscreenMessageListener: FullscreenListenerInterface) -> FullScreenMessageUiInterface? {
+        let fullscreenMessage = FullScreenMessage.createFullscreenMessage(html: html, fullscreenMessageListener, messageMonitor, false)
+        return fullscreenMessage
+    }
+    
+    public func createFullscreenMessage(html: String, fullscreenMessageListener: FullscreenListenerInterface, isLocalImageUsed: Bool) -> FullScreenMessageUiInterface? {
+        let fullscreenMessage = FullScreenMessage.createFullscreenMessage(html: html, fullscreenMessageListener, messageMonitor, isLocalImageUsed)
+        return fullscreenMessage
+    }
+}

--- a/AEPServices/Sources/ui/UIService.swift
+++ b/AEPServices/Sources/ui/UIService.swift
@@ -21,11 +21,13 @@ public class UIService: NSObject, UIServiceInterface {
     
     public func createFullscreenMessage(html: String, fullscreenListener: FullscreenListenerInterface) -> FullScreenMessageUiInterface? {
         let fullscreenMessage = FullScreenMessage.createFullscreenMessage(html: html, fullscreenListener, messageMonitor, false)
+        fullscreenMessage?.initMessage(html: html, fullscreenListener, messageMonitor, false)
         return fullscreenMessage
     }
     
     public func createFullscreenMessage(html: String, fullscreenListener: FullscreenListenerInterface, isLocalImageUsed: Bool) -> FullScreenMessageUiInterface? {
         let fullscreenMessage = FullScreenMessage.createFullscreenMessage(html: html, fullscreenListener, messageMonitor, isLocalImageUsed)
+        fullscreenMessage?.initMessage(html: html, fullscreenListener, messageMonitor, isLocalImageUsed)
         return fullscreenMessage
     }
     

--- a/AEPServices/Sources/ui/UIService.swift
+++ b/AEPServices/Sources/ui/UIService.swift
@@ -18,19 +18,17 @@ public class UIService: NSObject, UIServiceInterface {
     override init() {
         self.messageMonitor = MessageMonitor()
     }
-    
-    public func createFullscreenMessage(html: String, fullscreenListener: FullscreenListenerInterface) -> FullScreenMessageUiInterface? {
+
+    public func createFullscreenMessage(html: String, fullscreenListener: FullscreenListenerInterface?) -> FullScreenMessageUiInterface? {
         let fullscreenMessage = FullScreenMessage.createFullscreenMessage(html: html, fullscreenListener, messageMonitor, false)
-        fullscreenMessage?.initMessage(html: html, fullscreenListener, messageMonitor, false)
         return fullscreenMessage
     }
-    
-    public func createFullscreenMessage(html: String, fullscreenListener: FullscreenListenerInterface, isLocalImageUsed: Bool) -> FullScreenMessageUiInterface? {
+
+    public func createFullscreenMessage(html: String, fullscreenListener: FullscreenListenerInterface?, isLocalImageUsed: Bool) -> FullScreenMessageUiInterface? {
         let fullscreenMessage = FullScreenMessage.createFullscreenMessage(html: html, fullscreenListener, messageMonitor, isLocalImageUsed)
-        fullscreenMessage?.initMessage(html: html, fullscreenListener, messageMonitor, isLocalImageUsed)
         return fullscreenMessage
     }
-    
+
     public func isMessageDisplayed() -> Bool {
         return self.messageMonitor.isDisplayed()
     }

--- a/AEPServices/Sources/ui/UIService.swift
+++ b/AEPServices/Sources/ui/UIService.swift
@@ -20,12 +20,16 @@ public class UIService: NSObject, UIServiceInterface {
     }
     
     public func createFullscreenMessage(html: String, fullscreenListener: FullscreenListenerInterface) -> FullScreenMessageUiInterface? {
-        let fullscreenMessage = FullScreenMessage.createFullscreenMessage(html: html, fullscreenMessageListener, messageMonitor, false)
+        let fullscreenMessage = FullScreenMessage.createFullscreenMessage(html: html, fullscreenListener, messageMonitor, false)
         return fullscreenMessage
     }
     
     public func createFullscreenMessage(html: String, fullscreenListener: FullscreenListenerInterface, isLocalImageUsed: Bool) -> FullScreenMessageUiInterface? {
-        let fullscreenMessage = FullScreenMessage.createFullscreenMessage(html: html, fullscreenMessageListener, messageMonitor, isLocalImageUsed)
+        let fullscreenMessage = FullScreenMessage.createFullscreenMessage(html: html, fullscreenListener, messageMonitor, isLocalImageUsed)
         return fullscreenMessage
+    }
+    
+    public func isMessageDisplayed() -> Bool {
+        return self.messageMonitor.isDisplayed()
     }
 }

--- a/AEPServices/Sources/ui/UIService.swift
+++ b/AEPServices/Sources/ui/UIService.swift
@@ -19,12 +19,12 @@ public class UIService: NSObject, UIServiceInterface {
         self.messageMonitor = MessageMonitor()
     }
     
-    public func createFullscreenMessage(html: String, fullscreenMessageListener: FullscreenListenerInterface) -> FullScreenMessageUiInterface? {
+    public func createFullscreenMessage(html: String, fullscreenListener: FullscreenListenerInterface) -> FullScreenMessageUiInterface? {
         let fullscreenMessage = FullScreenMessage.createFullscreenMessage(html: html, fullscreenMessageListener, messageMonitor, false)
         return fullscreenMessage
     }
     
-    public func createFullscreenMessage(html: String, fullscreenMessageListener: FullscreenListenerInterface, isLocalImageUsed: Bool) -> FullScreenMessageUiInterface? {
+    public func createFullscreenMessage(html: String, fullscreenListener: FullscreenListenerInterface, isLocalImageUsed: Bool) -> FullScreenMessageUiInterface? {
         let fullscreenMessage = FullScreenMessage.createFullscreenMessage(html: html, fullscreenMessageListener, messageMonitor, isLocalImageUsed)
         return fullscreenMessage
     }

--- a/AEPServices/Sources/ui/UIServiceInterface.swift
+++ b/AEPServices/Sources/ui/UIServiceInterface.swift
@@ -12,7 +12,27 @@
 
 import Foundation
 
+/// Interface for displaying alerts, local notifications, and fullscreen web views
 public protocol UIServiceInterface {
-    func createFullscreenMessage(html: String, fullscreenMessageListener: FullscreenListenerInterface) -> FullScreenMessageUiInterface?
-    func createFullscreenMessage(html: String, fullscreenMessageListener: FullscreenListenerInterface, isLocalImageUsed: Bool) -> FullScreenMessageUiInterface?
+    
+    /// Creates a fullscreen message.
+    /// WARNING: This API consumes HTML/CSS/JS using an embedded browser control.
+    /// This means it is subject to all the risks of rendering untrusted web pages and running untrusted JS.
+    /// Treat all calls to this API with caution and make sure input is vetted for safety somewhere.
+    ///
+    /// @param html               String html content to be displayed with the message
+    /// @param fullscreenListener FullscreenListener listener for fullscreen message events
+    /// @return FullScreenMessageUiInterface object if the html is valid, null otherwise
+    func createFullscreenMessage(html: String, fullscreenListener: FullscreenListenerInterface) -> FullScreenMessageUiInterface?
+    
+    /// Creates a fullscreen message.
+    /// WARNING: This API consumes HTML/CSS/JS using an embedded browser control.
+    /// This means it is subject to all the risks of rendering untrusted web pages and running untrusted JS.
+    /// Treat all calls to this API with caution and make sure input is vetted for safety somewhere.
+    ///
+    /// @param html               String html content to be displayed with the message
+    /// @param fullscreenListener FullscreenListener listener for fullscreen message events
+    /// @param isLocalImageUsed   If true, an image from the app bundle will be used for the fullscreen message.
+    /// @return FullScreenMessageUiInterface object if the html is valid, null otherwise
+    func createFullscreenMessage(html: String, fullscreenListener: FullscreenListenerInterface, isLocalImageUsed: Bool) -> FullScreenMessageUiInterface?
 }

--- a/AEPServices/Sources/ui/UIServiceInterface.swift
+++ b/AEPServices/Sources/ui/UIServiceInterface.swift
@@ -1,0 +1,18 @@
+/*
+ Copyright 2020 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+
+public protocol UIServiceInterface {
+    func createFullscreenMessage(html: String, fullscreenMessageListener: FullscreenListenerInterface) -> FullScreenMessageUiInterface?
+    func createFullscreenMessage(html: String, fullscreenMessageListener: FullscreenListenerInterface, isLocalImageUsed: Bool) -> FullScreenMessageUiInterface?
+}

--- a/AEPServices/Sources/ui/UIServiceInterface.swift
+++ b/AEPServices/Sources/ui/UIServiceInterface.swift
@@ -14,7 +14,7 @@ import Foundation
 
 /// Interface for displaying alerts, local notifications, and fullscreen web views
 public protocol UIServiceInterface {
-    
+
     /// Creates a fullscreen message.
     /// WARNING: This API consumes HTML/CSS/JS using an embedded browser control.
     /// This means it is subject to all the risks of rendering untrusted web pages and running untrusted JS.
@@ -23,8 +23,8 @@ public protocol UIServiceInterface {
     /// @param html               String html content to be displayed with the message
     /// @param fullscreenListener FullscreenListener listener for fullscreen message events
     /// @return FullScreenMessageUiInterface object if the html is valid, null otherwise
-    func createFullscreenMessage(html: String, fullscreenListener: FullscreenListenerInterface) -> FullScreenMessageUiInterface?
-    
+    func createFullscreenMessage(html: String, fullscreenListener: FullscreenListenerInterface?) -> FullScreenMessageUiInterface?
+
     /// Creates a fullscreen message.
     /// WARNING: This API consumes HTML/CSS/JS using an embedded browser control.
     /// This means it is subject to all the risks of rendering untrusted web pages and running untrusted JS.
@@ -34,8 +34,8 @@ public protocol UIServiceInterface {
     /// @param fullscreenListener FullscreenListener listener for fullscreen message events
     /// @param isLocalImageUsed   If true, an image from the app bundle will be used for the fullscreen message.
     /// @return FullScreenMessageUiInterface object if the html is valid, null otherwise
-    func createFullscreenMessage(html: String, fullscreenListener: FullscreenListenerInterface, isLocalImageUsed: Bool) -> FullScreenMessageUiInterface?
-    
+    func createFullscreenMessage(html: String, fullscreenListener: FullscreenListenerInterface?, isLocalImageUsed: Bool) -> FullScreenMessageUiInterface?
+
     /// Returns true if there is another message displayed at this time, false otherwise.
     /// The status is collected from the platform messages monitor and it applies if either
     /// an alert message or a full screen message is displayed at some point.

--- a/AEPServices/Sources/ui/UIServiceInterface.swift
+++ b/AEPServices/Sources/ui/UIServiceInterface.swift
@@ -35,4 +35,9 @@ public protocol UIServiceInterface {
     /// @param isLocalImageUsed   If true, an image from the app bundle will be used for the fullscreen message.
     /// @return FullScreenMessageUiInterface object if the html is valid, null otherwise
     func createFullscreenMessage(html: String, fullscreenListener: FullscreenListenerInterface, isLocalImageUsed: Bool) -> FullScreenMessageUiInterface?
+    
+    /// Returns true if there is another message displayed at this time, false otherwise.
+    /// The status is collected from the platform messages monitor and it applies if either
+    /// an alert message or a full screen message is displayed at some point.
+    func isMessageDisplayed() -> Bool
 }

--- a/AEPServices/Sources/ui/fullscreen/FullScreenMessageUiInterface.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullScreenMessageUiInterface.swift
@@ -3,7 +3,7 @@
  This file is licensed to you under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License. You may obtain a copy
  of the License at http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software distributed under
  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  OF ANY KIND, either express or implied. See the License for the specific language

--- a/AEPServices/Sources/ui/fullscreen/FullScreenMessageUiInterface.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullScreenMessageUiInterface.swift
@@ -1,0 +1,19 @@
+/*
+ Copyright 2020 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+
+public protocol FullScreenMessageUiInterface {
+    func show()
+    func openUrl(url: String)
+    func remove()
+}

--- a/AEPServices/Sources/ui/fullscreen/FullScreenMessageUiInterface.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullScreenMessageUiInterface.swift
@@ -12,8 +12,16 @@
 
 import Foundation
 
+/// UI service interface defining a fullscreen message
 public protocol FullScreenMessageUiInterface {
+    
+    /// Display the fullscreen message
     func show()
+    
+    /// Open a url from this message
+    /// @param url String the url to open
     func openUrl(url: String)
+    
+    /// Remove the fullscreen message from view.
     func remove()
 }

--- a/AEPServices/Sources/ui/fullscreen/FullScreenMessageUiInterface.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullScreenMessageUiInterface.swift
@@ -14,14 +14,14 @@ import Foundation
 
 /// UI service interface defining a fullscreen message
 public protocol FullScreenMessageUiInterface {
-    
+
     /// Display the fullscreen message
     func show()
-    
+
     /// Open a url from this message
     /// @param url String the url to open
     func openUrl(url: String)
-    
+
     /// Remove the fullscreen message from view.
     func remove()
 }

--- a/AEPServices/Sources/ui/fullscreen/FullScreenUIHandler.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullScreenUIHandler.swift
@@ -3,7 +3,7 @@
  This file is licensed to you under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License. You may obtain a copy
  of the License at http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software distributed under
  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  OF ANY KIND, either express or implied. See the License for the specific language

--- a/AEPServices/Sources/ui/fullscreen/FullScreenUIHandler.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullScreenUIHandler.swift
@@ -169,16 +169,14 @@ class FullScreenUIHandler: NSObject, WKNavigationDelegate {
     // Get user's cache directory path
     func getCacheDirectoryPath() -> URL? {
         let paths = FileManager.default.urls(for: .cachesDirectory, in: .allDomainsMask)
-        if paths.isEmpty {
+        if (paths.isEmpty) {
             return nil
         }
         let root = paths[0]
-        if !FileManager.default.fileExists(atPath: root.absoluteString) {
-//            do {
-//                FileManager.default.createDirectory(atPath: root.absoluteString, withIntermediateDirectories: true, attributes: nil)
-//            }catch let error as NSError {
-//                // handle error
-//              }
+        var dir: ObjCBool = false
+        
+        if (!FileManager.default.fileExists(atPath: root.path, isDirectory: &dir) && !dir.boolValue) {
+            try! FileManager.default.createDirectory(atPath: root.path, withIntermediateDirectories: true, attributes: nil)
         }
         return root
     }

--- a/AEPServices/Sources/ui/fullscreen/FullScreenUIHandler.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullScreenUIHandler.swift
@@ -20,17 +20,17 @@ class FullScreenUIHandler: NSObject, WKNavigationDelegate {
     private let DOWNLOAD_CACHE = "adbdownloadcache"
     private let HTML_EXTENSION = "html"
     private let TEMP_FILE_NAME = "temp"
-    
+
     let fileManager = FileManager()
 
     var isLocalImageUsed = false
     var payload: String
-    var message: FullScreenMessageUiInterface?
+    let message: FullScreenMessageUiInterface
     var listener: FullscreenListenerInterface?
     var monitor: MessageMonitor
     var webView: UIView!
 
-    init(payload: String, message: FullScreenMessageUiInterface, listener: FullscreenListenerInterface, monitor: MessageMonitor, isLocalImageUsed: Bool) {
+    init(payload: String, message: FullScreenMessageUiInterface, listener: FullscreenListenerInterface?, monitor: MessageMonitor, isLocalImageUsed: Bool) {
         self.payload = payload
         self.message = message
         self.listener = listener
@@ -49,12 +49,12 @@ class FullScreenUIHandler: NSObject, WKNavigationDelegate {
         DispatchQueue.main.async {
             // Change message monitor to display
             self.monitor.displayed()
-            
+
             guard var newFrame: CGRect = self.calcFullScreenFrame() else { return }
             newFrame.origin.y = newFrame.size.height
             if newFrame.size.width > 0.0 && newFrame.size.height > 0.0 {
                 let webViewConfiguration = WKWebViewConfiguration()
-                
+
                 //Fix for media playback.
                 webViewConfiguration.allowsInlineMediaPlayback = true // Plays Media inline
                 webViewConfiguration.mediaTypesRequiringUserActionForPlayback = []
@@ -65,18 +65,18 @@ class FullScreenUIHandler: NSObject, WKNavigationDelegate {
                 wkWebView.backgroundColor = UIColor.clear
                 wkWebView.isOpaque = false
                 wkWebView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-                
+
                 // Fix for iPhone X to display content edge-to-edge
                 if #available(iOS 11, *) {
                     wkWebView.scrollView.contentInsetAdjustmentBehavior = .never
                 }
-                
+
                 // save the HTML payload to a local file if the cached image is being used
                 var useTempHTML = false
                 var cacheFolderURL: URL?
                 var tempHTMLFile: URL?
                 let cacheFolder: URL? = self.fileManager.getCacheDirectoryPath()
-                if (cacheFolder != nil) {
+                if cacheFolder != nil {
                     cacheFolderURL = cacheFolder?.appendingPathComponent(self.DOWNLOAD_CACHE)
                     tempHTMLFile = cacheFolderURL?.appendingPathComponent(self.TEMP_FILE_NAME).appendingPathExtension(self.HTML_EXTENSION)
                     if !self.isLocalImageUsed {
@@ -100,7 +100,7 @@ class FullScreenUIHandler: NSObject, WKNavigationDelegate {
                 } else {
                     wkWebView.loadHTMLString(self.payload, baseURL: Bundle.main.bundleURL)
                 }
-                
+
                 let keyWindow = self.getKeyWindow()
                 keyWindow?.addSubview(wkWebView)
                 UIView.animate(withDuration: 0.3, animations: {
@@ -119,8 +119,7 @@ class FullScreenUIHandler: NSObject, WKNavigationDelegate {
             self.monitor.dismissed()
             self.dismissWithAnimation(animate: true)
             self.listener?.onDismiss(message: self.message)
-            self.message = nil
-            
+
             // remove the temporary html if it exists
             guard var cacheFolder: URL = self.fileManager.getCacheDirectoryPath() else {
                 return
@@ -173,7 +172,7 @@ class FullScreenUIHandler: NSObject, WKNavigationDelegate {
         let keyWindow = getKeyWindow()
         guard let screenBounds: CGSize = keyWindow?.frame.size else { return nil }
         newFrame.size = screenBounds
-        
+
         // y is dependant on visibility and height
         newFrame.origin.y = 0
         return newFrame

--- a/AEPServices/Sources/ui/fullscreen/FullScreenUIHandler.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullScreenUIHandler.swift
@@ -1,0 +1,105 @@
+/*
+ Copyright 2020 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+import UIKit
+import WebKit
+
+func ADBOrientationIsPortrait() -> Bool {
+    UIApplication.shared.statusBarOrientation.isPortrait
+}
+
+class FullScreenUIHandler : NSObject, WKNavigationDelegate {
+    
+    var LOG_TAG = "FullScreenUIHandler"
+    private let DOWNLOAD_CACHE = "adbdownloadcache"
+    private let HTML_EXTENSION = "html"
+    private let TEMP_FILE_NAME = "temp"
+    
+    var isLocalImageUsed = false
+    var payload: String?
+    var message: FullScreenMessageUiInterface?
+    var listener: FullscreenListenerInterface?
+    var monitor: MessageMonitor
+    var webView: UIView
+    
+    init(payload: String, message: FullScreenMessageUiInterface, listener : FullscreenListenerInterface, monitor: MessageMonitor, isLocalImageUsed: Bool) {
+        self.payload = payload
+        self.message = message
+        self.listener = listener
+        self.monitor = monitor
+        self.isLocalImageUsed = isLocalImageUsed
+    }
+    
+    func show() {
+        if monitor.isDisplayed() {
+            return
+        }
+
+        monitor.displayed()
+        DispatchQueue.main.async {
+            guard var newFrame: CGRect = self.calcFullScreenFrame() else { return }
+            newFrame.origin.y = newFrame.size.height
+            do {
+                if (newFrame.size.width > 0.0 && newFrame.size.height > 0.0) {
+                    let webViewConfiguration = WKWebViewConfiguration()
+                    webViewConfiguration.allowsInlineMediaPlayback = true
+                    webViewConfiguration.mediaTypesRequiringUserActionForPlayback = []
+                    let wkWebView = WKWebView(frame: newFrame, configuration: webViewConfiguration)
+                    self.webView = wkWebView
+                    wkWebView.navigationDelegate = self
+                    wkWebView.scrollView.bounces = false
+                    wkWebView.backgroundColor = UIColor.clear
+                    wkWebView.isOpaque = false
+                    wkWebView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+                    if #available(iOS 11, *) {
+                        wkWebView.scrollView.contentInsetAdjustmentBehavior = .never
+                    }
+                    var useTempHTML = false
+                }
+            } catch {
+                
+            }
+        }
+    }
+    
+    func dismiss() {
+        
+    }
+    
+    func openUrl(url: String) {
+        
+    }
+    
+    func calcFullScreenFrame() -> CGRect? {
+        var newFrame = CGRect(x: 0, y: 0, width: 0, height: 0)
+        // x is always 0
+        newFrame.origin.x = 0
+        // for fullscreen, width and height are both full screen
+        let keyWindow = getKeyWindow()
+        guard let screenBounds: CGSize = keyWindow?.frame.size else { return nil }
+        newFrame.size = screenBounds
+        
+        newFrame.origin.y = 0
+        return newFrame
+    }
+    
+    func getKeyWindow() -> UIWindow? {
+        var keyWindow = UIApplication.shared.keyWindow
+
+        if keyWindow == nil {
+            keyWindow = UIApplication.shared.windows.first
+        }
+
+        return keyWindow
+    }
+}

--- a/AEPServices/Sources/ui/fullscreen/FullscreenListenerInterface.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenListenerInterface.swift
@@ -3,7 +3,7 @@
  This file is licensed to you under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License. You may obtain a copy
  of the License at http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software distributed under
  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  OF ANY KIND, either express or implied. See the License for the specific language

--- a/AEPServices/Sources/ui/fullscreen/FullscreenListenerInterface.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenListenerInterface.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 public protocol FullscreenListenerInterface {
-    func onShow(message: FullScreenMessageUiInterface)
-    func OnDismiss(message: FullScreenMessageUiInterface)
-    func OverrideUrlLoad(message: FullScreenMessageUiInterface, url : String)
+    func onShow(message: FullScreenMessageUiInterface?)
+    func onDismiss(message: FullScreenMessageUiInterface?)
+    func overrideUrlLoad(message: FullScreenMessageUiInterface?, url : String?) -> Bool
 }

--- a/AEPServices/Sources/ui/fullscreen/FullscreenListenerInterface.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenListenerInterface.swift
@@ -12,8 +12,20 @@
 
 import Foundation
 
+/// Fullscreen message event listener
 public protocol FullscreenListenerInterface {
+    
+    /// Invoked when the fullscreen message is displayed
+    /// @param message FullScreenMessageUiInterface message that is being displayed
     func onShow(message: FullScreenMessageUiInterface?)
+    
+    /// Invoked when the fullscreen message is dismissed
+    /// @param message FullScreenMessageUiInterface message that is being dismissed
     func onDismiss(message: FullScreenMessageUiInterface?)
+    
+    /// Invoked when the fullscreen message is attempting to load a url
+    /// @param message FullScreenMessageUiInterface message that is attempting to load the url
+    /// @param url     String the url being loaded by the message
+    /// @return True if the core wants to handle the URL (and not the fullscreen message view implementation)
     func overrideUrlLoad(message: FullScreenMessageUiInterface?, url : String?) -> Bool
 }

--- a/AEPServices/Sources/ui/fullscreen/FullscreenListenerInterface.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenListenerInterface.swift
@@ -14,18 +14,18 @@ import Foundation
 
 /// Fullscreen message event listener
 public protocol FullscreenListenerInterface {
-    
+
     /// Invoked when the fullscreen message is displayed
     /// @param message FullScreenMessageUiInterface message that is being displayed
     func onShow(message: FullScreenMessageUiInterface?)
-    
+
     /// Invoked when the fullscreen message is dismissed
     /// @param message FullScreenMessageUiInterface message that is being dismissed
     func onDismiss(message: FullScreenMessageUiInterface?)
-    
+
     /// Invoked when the fullscreen message is attempting to load a url
     /// @param message FullScreenMessageUiInterface message that is attempting to load the url
     /// @param url     String the url being loaded by the message
     /// @return True if the core wants to handle the URL (and not the fullscreen message view implementation)
-    func overrideUrlLoad(message: FullScreenMessageUiInterface?, url : String?) -> Bool
+    func overrideUrlLoad(message: FullScreenMessageUiInterface?, url: String?) -> Bool
 }

--- a/AEPServices/Sources/ui/fullscreen/FullscreenListenerInterface.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenListenerInterface.swift
@@ -1,0 +1,19 @@
+/*
+ Copyright 2020 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+
+public protocol FullscreenListenerInterface {
+    func onShow(message: FullScreenMessageUiInterface)
+    func OnDismiss(message: FullScreenMessageUiInterface)
+    func OverrideUrlLoad(message: FullScreenMessageUiInterface, url : String)
+}

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
@@ -3,7 +3,7 @@
  This file is licensed to you under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License. You may obtain a copy
  of the License at http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software distributed under
  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  OF ANY KIND, either express or implied. See the License for the specific language

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
@@ -10,18 +10,18 @@
  governing permissions and limitations under the License.
  */
 
-
 import Foundation
 
 public class FullScreenMessage {
     var fullScreenMessageHandler: FullScreenUIHandler?
-    
+
     /// @private constructor
     /// @see CreateFullscreenMessage method for construction
     private init() {}
 
-    static func createFullscreenMessage(html: String, _ listener: FullscreenListenerInterface, _ messageMonnitor: MessageMonitor, _ isLocalImageUsed: Bool) -> FullScreenMessage? {
+    static func createFullscreenMessage(html: String, _ listener: FullscreenListenerInterface?, _ messageMonitor: MessageMonitor, _ isLocalImageUsed: Bool) -> FullScreenMessage? {
         let newMessage: FullScreenMessage = FullScreenMessage()
+        newMessage.initMessage(html: html, listener, messageMonitor, false)
         return newMessage
     }
 
@@ -31,13 +31,13 @@ public class FullScreenMessage {
     /// @param listener - listener which will be called on message show/dismiss/openUrl
     /// @param messageMonnitor - MessageMonitor object which determines whether any display is already present
     /// @param isLocalImageUsed If true, an image from the app bundle will be used for the fullscreen message.
-    func initMessage(html: String, _ listener: FullscreenListenerInterface, _ messageMonnitor: MessageMonitor, _ isLocalImageUsed: Bool) {
-        fullScreenMessageHandler = FullScreenUIHandler(payload: html, message: self, listener: listener, monitor: messageMonnitor, isLocalImageUsed: isLocalImageUsed )
+    func initMessage(html: String, _ listener: FullscreenListenerInterface?, _ messageMonitor: MessageMonitor, _ isLocalImageUsed: Bool) {
+        fullScreenMessageHandler = FullScreenUIHandler(payload: html, message: self, listener: listener, monitor: messageMonitor, isLocalImageUsed: isLocalImageUsed )
     }
 }
 
-//MARK: - Protocol Methods
-extension FullScreenMessage : FullScreenMessageUiInterface {
+// MARK: - Protocol Methods
+extension FullScreenMessage: FullScreenMessageUiInterface {
 
     public func show() {
         fullScreenMessageHandler?.show()

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
@@ -1,0 +1,39 @@
+/*
+ Copyright 2020 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+
+import Foundation
+
+public class FullScreenMessage : FullScreenMessageUiInterface {
+    var fullScreenMessageHandler: FullScreenUIHandler? = nil
+    
+    static func createFullscreenMessage(html: String, _ listener: FullscreenListenerInterface, _ messageMonnitor: MessageMonitor, _ isLocalImageUsed: Bool) -> FullScreenMessage? {
+        let newMessage: FullScreenMessage = FullScreenMessage()
+        return newMessage
+    }
+    
+    func initMessage(html: String, _ listener: FullscreenListenerInterface, _ messageMonnitor: MessageMonitor, _ isLocalImageUsed: Bool) {
+        fullScreenMessageHandler = FullScreenUIHandler(payload: html, message: self, listener: listener, monitor: messageMonnitor, isLocalImageUsed: isLocalImageUsed )
+    }
+    
+    public func show() {
+        fullScreenMessageHandler?.show()
+    }
+    
+    public func openUrl(url: String) {
+        fullScreenMessageHandler?.openUrl(url: url)
+    }
+    
+    public func remove() {
+        fullScreenMessageHandler?.dismiss()
+    }
+}

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
@@ -13,26 +13,26 @@
 
 import Foundation
 
-public class FullScreenMessage : FullScreenMessageUiInterface {
-    var fullScreenMessageHandler: FullScreenUIHandler? = nil
-    
+public class FullScreenMessage: FullScreenMessageUiInterface {
+    var fullScreenMessageHandler: FullScreenUIHandler?
+
     static func createFullscreenMessage(html: String, _ listener: FullscreenListenerInterface, _ messageMonnitor: MessageMonitor, _ isLocalImageUsed: Bool) -> FullScreenMessage? {
         let newMessage: FullScreenMessage = FullScreenMessage()
         return newMessage
     }
-    
+
     func initMessage(html: String, _ listener: FullscreenListenerInterface, _ messageMonnitor: MessageMonitor, _ isLocalImageUsed: Bool) {
         fullScreenMessageHandler = FullScreenUIHandler(payload: html, message: self, listener: listener, monitor: messageMonnitor, isLocalImageUsed: isLocalImageUsed )
     }
-    
+
     public func show() {
         fullScreenMessageHandler?.show()
     }
-    
+
     public func openUrl(url: String) {
         fullScreenMessageHandler?.openUrl(url: url)
     }
-    
+
     public func remove() {
         fullScreenMessageHandler?.dismiss()
     }

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
@@ -15,12 +15,22 @@ import Foundation
 
 public class FullScreenMessage: FullScreenMessageUiInterface {
     var fullScreenMessageHandler: FullScreenUIHandler?
+    
+    /// @private constructor
+    /// @see CreateFullscreenMessage method for construction
+    private init() {}
 
     static func createFullscreenMessage(html: String, _ listener: FullscreenListenerInterface, _ messageMonnitor: MessageMonitor, _ isLocalImageUsed: Bool) -> FullScreenMessage? {
         let newMessage: FullScreenMessage = FullScreenMessage()
         return newMessage
     }
 
+    /// Initializes the platform message handler after the full screen message instance was created.
+    /// Note: we cannot do this step is done in the constructor, as the instance for FullscreenMessage is not created at that time
+    /// @param html - html content that will be loaded on message show
+    /// @param listener - listener which will be called on message show/dismiss/openUrl
+    /// @param messageMonnitor - MessageMonitor object which determines whether any display is already present
+    /// @param isLocalImageUsed If true, an image from the app bundle will be used for the fullscreen message.
     func initMessage(html: String, _ listener: FullscreenListenerInterface, _ messageMonnitor: MessageMonitor, _ isLocalImageUsed: Bool) {
         fullScreenMessageHandler = FullScreenUIHandler(payload: html, message: self, listener: listener, monitor: messageMonnitor, isLocalImageUsed: isLocalImageUsed )
     }

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
@@ -13,7 +13,7 @@
 
 import Foundation
 
-public class FullScreenMessage: FullScreenMessageUiInterface {
+public class FullScreenMessage {
     var fullScreenMessageHandler: FullScreenUIHandler?
     
     /// @private constructor
@@ -34,6 +34,10 @@ public class FullScreenMessage: FullScreenMessageUiInterface {
     func initMessage(html: String, _ listener: FullscreenListenerInterface, _ messageMonnitor: MessageMonitor, _ isLocalImageUsed: Bool) {
         fullScreenMessageHandler = FullScreenUIHandler(payload: html, message: self, listener: listener, monitor: messageMonnitor, isLocalImageUsed: isLocalImageUsed )
     }
+}
+
+//MARK: - Protocol Methods
+extension FullScreenMessage : FullScreenMessageUiInterface {
 
     public func show() {
         fullScreenMessageHandler?.show()

--- a/AEPServices/Sources/utility/unzip/FileManager+ZIP.swift
+++ b/AEPServices/Sources/utility/unzip/FileManager+ZIP.swift
@@ -32,6 +32,27 @@ extension FileManager {
         let parentDirectoryURL = url.deletingLastPathComponent()
         try createDirectory(at: parentDirectoryURL, withIntermediateDirectories: true, attributes: nil)
     }
+    
+    /// Get user's cache directory path
+    /// - Return: Cache path URL
+    func getCacheDirectoryPath() -> URL? {
+        let paths = FileManager.default.urls(for: .cachesDirectory, in: .allDomainsMask)
+        if (paths.isEmpty) {
+            return nil
+        }
+        let root = paths[0]
+        var dir: ObjCBool = false
+        
+        do {
+            if (!FileManager.default.fileExists(atPath: root.path, isDirectory: &dir) && !dir.boolValue) {
+                try FileManager.default.createDirectory(atPath: root.path, withIntermediateDirectories: true, attributes: nil)
+            }
+        } catch {
+            Log.debug(label: "FileManager", "Error while retrieving the cache directory path.")
+            return nil
+        }
+        return root
+    }
 
     ///
     /// Returns the File attributes for the given ZipEntry

--- a/AEPServices/Sources/utility/unzip/FileManager+ZIP.swift
+++ b/AEPServices/Sources/utility/unzip/FileManager+ZIP.swift
@@ -32,19 +32,19 @@ extension FileManager {
         let parentDirectoryURL = url.deletingLastPathComponent()
         try createDirectory(at: parentDirectoryURL, withIntermediateDirectories: true, attributes: nil)
     }
-    
+
     /// Get user's cache directory path
     /// - Return: Cache path URL
     func getCacheDirectoryPath() -> URL? {
         let paths = FileManager.default.urls(for: .cachesDirectory, in: .allDomainsMask)
-        if (paths.isEmpty) {
+        if paths.isEmpty {
             return nil
         }
         let root = paths[0]
         var dir: ObjCBool = false
-        
+
         do {
-            if (!FileManager.default.fileExists(atPath: root.path, isDirectory: &dir) && !dir.boolValue) {
+            if !FileManager.default.fileExists(atPath: root.path, isDirectory: &dir) && !dir.boolValue {
                 try FileManager.default.createDirectory(atPath: root.path, withIntermediateDirectories: true, attributes: nil)
             }
         } catch {

--- a/AEPServices/Tests/services/FileManager+ZipTests.swift
+++ b/AEPServices/Tests/services/FileManager+ZipTests.swift
@@ -69,4 +69,12 @@ class FileManagerZipTests: XCTestCase {
         permissions = FileManager.permissions(for: UInt32(0), osType: .msdos, entryType: .directory)
         XCTAssert(permissions == FileUnzipperConstants.defaultDirectoryPermissions)
     }
+    
+    func testGetCacheDirectoryPath() {
+        let fileManager = FileManager()
+        guard let url = fileManager.getCacheDirectoryPath() else {
+            XCTFail("Failed to read central directory structure."); return
+        }
+        XCTAssertNotNil(url)
+    }
 }

--- a/AEPServices/Tests/services/FileManager+ZipTests.swift
+++ b/AEPServices/Tests/services/FileManager+ZipTests.swift
@@ -69,7 +69,7 @@ class FileManagerZipTests: XCTestCase {
         permissions = FileManager.permissions(for: UInt32(0), osType: .msdos, entryType: .directory)
         XCTAssert(permissions == FileUnzipperConstants.defaultDirectoryPermissions)
     }
-    
+
     func testGetCacheDirectoryPath() {
         let fileManager = FileManager()
         guard let url = fileManager.getCacheDirectoryPath() else {

--- a/AEPServices/Tests/services/UIServiceTests.swift
+++ b/AEPServices/Tests/services/UIServiceTests.swift
@@ -1,10 +1,14 @@
-//
-//  UIService.swift
-//  AEPServicesTests
-//
-//  Created by ravjain on 12/17/20.
-//  Copyright © 2020 Adobe. All rights reserved.
-//
+/*
+ Copyright 2020 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
 
 import Foundation
 @testable import AEPServices
@@ -13,34 +17,34 @@ import XCTest
 
 
 class UIServiceTests : XCTestCase {
-    
+
     let mockHtml = "somehtml"
     static var onShowCall = false
     static var onDismissCall = false
-    
+
     func reset() {
         UIServiceTests.onShowCall = false
         UIServiceTests.onDismissCall = false
     }
-    
+
     func test_CreateFullscreenMessage_whenValidMessage() {
         let uiService = UIService()
         let message = uiService.createFullscreenMessage(html: mockHtml, fullscreenListener: MockFullscreenListener())
         XCTAssertNotNil(message)
     }
-    
+
     func test_CreateFullscreenMessage_whenListenerIsNil() {
         let uiService = UIService()
         let message = uiService.createFullscreenMessage(html: mockHtml, fullscreenListener: nil)
         XCTAssertNotNil(message)
     }
-    
+
     func test_CreateFullscreenMessage_whenIsLocalImageTrue() {
         let uiService = UIService()
         let message = uiService.createFullscreenMessage(html: mockHtml, fullscreenListener: MockFullscreenListener(), isLocalImageUsed: true)
         XCTAssertNotNil(message)
     }
-    
+
     func test_CreateFullscreenMessage_whenIsLocalImageFalse() {
         let uiService = UIService()
         let message = uiService.createFullscreenMessage(html: mockHtml, fullscreenListener: MockFullscreenListener(), isLocalImageUsed: true)
@@ -52,7 +56,7 @@ class UIServiceTests : XCTestCase {
         let isDisplayed = uiService.isMessageDisplayed()
         XCTAssertFalse(isDisplayed)
     }
-    
+
     func test_ListenerOnShow_IsCalled() {
         let uiService = UIService()
         let message = uiService.createFullscreenMessage(html: mockHtml, fullscreenListener: MockFullscreenListener(), isLocalImageUsed: true)

--- a/AEPServices/Tests/services/UIServiceTests.swift
+++ b/AEPServices/Tests/services/UIServiceTests.swift
@@ -1,0 +1,78 @@
+//
+//  UIService.swift
+//  AEPServicesTests
+//
+//  Created by ravjain on 12/17/20.
+//  Copyright © 2020 Adobe. All rights reserved.
+//
+
+import Foundation
+@testable import AEPServices
+import XCTest
+
+
+
+class UIServiceTests : XCTestCase {
+    
+    let mockHtml = "somehtml"
+    static var onShowCall = false
+    static var onDismissCall = false
+    
+    func reset() {
+        UIServiceTests.onShowCall = false
+        UIServiceTests.onDismissCall = false
+    }
+    
+    func test_CreateFullscreenMessage_whenValidMessage() {
+        let uiService = UIService()
+        let message = uiService.createFullscreenMessage(html: mockHtml, fullscreenListener: MockFullscreenListener())
+        XCTAssertNotNil(message)
+    }
+    
+    func test_CreateFullscreenMessage_whenListenerIsNil() {
+        let uiService = UIService()
+        let message = uiService.createFullscreenMessage(html: mockHtml, fullscreenListener: nil)
+        XCTAssertNotNil(message)
+    }
+    
+    func test_CreateFullscreenMessage_whenIsLocalImageTrue() {
+        let uiService = UIService()
+        let message = uiService.createFullscreenMessage(html: mockHtml, fullscreenListener: MockFullscreenListener(), isLocalImageUsed: true)
+        XCTAssertNotNil(message)
+    }
+    
+    func test_CreateFullscreenMessage_whenIsLocalImageFalse() {
+        let uiService = UIService()
+        let message = uiService.createFullscreenMessage(html: mockHtml, fullscreenListener: MockFullscreenListener(), isLocalImageUsed: true)
+        XCTAssertNotNil(message)
+    }
+
+    func test_isMessageDisplayed_DefaultIsFalse() {
+        let uiService = UIService()
+        let isDisplayed = uiService.isMessageDisplayed()
+        XCTAssertFalse(isDisplayed)
+    }
+    
+    func test_ListenerOnShow_IsCalled() {
+        let uiService = UIService()
+        let message = uiService.createFullscreenMessage(html: mockHtml, fullscreenListener: MockFullscreenListener(), isLocalImageUsed: true)
+        XCTAssertNotNil(message)
+        message?.show()
+        XCTAssertTrue(UIServiceTests.onShowCall)
+        reset()
+    }
+
+    class MockFullscreenListener: FullscreenListenerInterface {
+        func onShow(message: FullScreenMessageUiInterface?) {
+            UIServiceTests.onShowCall = true
+        }
+
+        func onDismiss(message: FullScreenMessageUiInterface?) {
+            UIServiceTests.onDismissCall = true
+        }
+
+        func overrideUrlLoad(message: FullScreenMessageUiInterface?, url: String?) -> Bool {
+            return true
+        }
+    }
+}


### PR DESCRIPTION

## Description

- Adding UIServices with FullscreenMessage.
- Added `createFullscreenMessage` function to create the message with protocol `FullScreenMessageUiInterface`
- Added `MessageMonitor` object in UIService to handle whether any message is displayed or not.
- `FullScreenMessage` uses `FullscreenUIHandler` to handle `show`, `dismiss` and `openUrl`
- `FullscreenListenerInterface` is used to listen for callbacks from `FullscreenMessage`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
