### PR TITLE
Revert "Don't print entire URL string for Identity and Signal hits"

### DIFF
--- a/AEPIdentity/Sources/IdentityHitProcessor.swift
+++ b/AEPIdentity/Sources/IdentityHitProcessor.swift
@@ -52,7 +52,6 @@ class IdentityHitProcessor: HitProcessing {
     ///   - connection: the connection returned after we make the network request
     ///   - completion: a completion block to invoke after we have handled the network response with true for success and false for failure (retry)
     private func handleNetworkResponse(hit: IdentityHit, connection: HttpConnection, completion: @escaping (Bool) -> Void) {
-        let urlString = "\(String(describing: hit.url.host))\(String(describing: hit.url.path))"
         if connection.responseCode == 200 {
             // hit sent successfully
             Log.debug(label: "\(LOG_TAG):\(#function)", "Identity hit request with url \(hit.url.absoluteString) sent successfully")
@@ -60,11 +59,11 @@ class IdentityHitProcessor: HitProcessing {
             completion(true)
         } else if NetworkServiceConstants.RECOVERABLE_ERROR_CODES.contains(connection.responseCode ?? -1) {
             // retry this hit later
-            Log.debug(label: "\(LOG_TAG):\(#function)", "Retrying Identity hit, request with url \(hit.url.absoluteString) failed with error \(connection.error?.localizedDescription ?? "") and recoverable status code \(connection.responseCode ?? -1)")
+            Log.warning(label: "\(LOG_TAG):\(#function)", "Retrying Identity hit, request with url \(hit.url.absoluteString) failed with error \(connection.error?.localizedDescription ?? "") and recoverable status code \(connection.responseCode ?? -1)")
             completion(false)
         } else {
             // unrecoverable error. delete the hit from the database and continue
-            Log.warning(label: "\(LOG_TAG):\(#function)", "Dropping Identity hit, request with url \(urlString) failed with error \(connection.error?.localizedDescription ?? "") and unrecoverable status code \(connection.responseCode ?? -1)")
+            Log.warning(label: "\(LOG_TAG):\(#function)", "Dropping Identity hit, request with url \(hit.url.absoluteString) failed with error \(connection.error?.localizedDescription ?? "") and unrecoverable status code \(connection.responseCode ?? -1)")
             responseHandler(hit, connection.data)
             completion(true)
         }

--- a/AEPSignal/Sources/SignalHitProcessor.swift
+++ b/AEPSignal/Sources/SignalHitProcessor.swift
@@ -59,18 +59,17 @@ class SignalHitProcessor: HitProcessing {
     ///   - connection: the connection returned after we make the network request
     ///   - completion: a completion block to invoke after we have handled the network response with true for success and false for failure (retry)
     private func handleNetworkResponse(hit: SignalHit, connection: HttpConnection, completion: @escaping (Bool) -> Void) {
-        let urlString = "\(String(describing: hit.url.host))\(String(describing: hit.url.path))"
         if connection.responseCode == 200 {
             // hit sent successfully
             Log.debug(label: LOG_TAG, "Signal request successfully sent: \(hit.url.absoluteString) sent successfully")
             completion(true)
         } else if NetworkServiceConstants.RECOVERABLE_ERROR_CODES.contains(connection.responseCode ?? -1) {
             // retry this hit later
-            Log.debug(label: LOG_TAG, "Signal request failed with recoverable error \(connection.error?.localizedDescription ?? "") and status code \(connection.responseCode ?? -1). Will retry sending the request later: \(hit.url.absoluteString)")
+            Log.warning(label: LOG_TAG, "Signal request failed with recoverable error \(connection.error?.localizedDescription ?? "") and status code \(connection.responseCode ?? -1). Will retry sending the request later: \(hit.url.absoluteString)")
             completion(false)
         } else {
             // unrecoverable error. delete the hit from the database and continue
-            Log.warning(label: LOG_TAG, "Signal request failed with unrecoverable error \(connection.error?.localizedDescription ?? "") and status code \(connection.responseCode ?? -1). It will be dropped from the queue: \(urlString)")
+            Log.warning(label: LOG_TAG, "Signal request failed with unrecoverable error \(connection.error?.localizedDescription ?? "") and status code \(connection.responseCode ?? -1). It will be dropped from the queue: \(hit.url.absoluteString)")
             completion(true)
         }
     }


### PR DESCRIPTION
Reverts adobe/aepsdk-core-ios#470