### PR TITLE
Make HitQueuing+PrivacyStatus public

### DIFF
--- a/AEPCore/Sources/configuration/HitQueuing+PrivacyStatus.swift
+++ b/AEPCore/Sources/configuration/HitQueuing+PrivacyStatus.swift
@@ -13,10 +13,10 @@
 import AEPServices
 import Foundation
 
-extension HitQueuing {
+public extension HitQueuing {
     /// Based on `status` determines if we should continue processing hits or if we should suspend processing and clear hits
     /// - Parameter status: the current privacy status
-    public func handlePrivacyChange(status: PrivacyStatus) {
+    func handlePrivacyChange(status: PrivacyStatus) {
         switch status {
         case .optedIn:
             beginProcessing()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Make HitQueuing+PrivacyStatus extension public to be used by other extensions outside of Core. To be used by Edge.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
