### PR TITLE
Clear SQL table instead of dropping it

### DIFF
--- a/AEPServices/Sources/dataqueue/SQLiteDataQueue.swift
+++ b/AEPServices/Sources/dataqueue/SQLiteDataQueue.swift
@@ -127,7 +127,7 @@ class SQLiteDataQueue: DataQueue {
         if isClosed { return false}
         return serialQueue.sync {
             let dropTableStatement = """
-            DROP TABLE IF EXISTS \(SQLiteDataQueue.TABLE_NAME);
+            DELETE FROM \(SQLiteDataQueue.TABLE_NAME);
             """
             guard let connection = connect() else {
                 return false
@@ -136,7 +136,7 @@ class SQLiteDataQueue: DataQueue {
                 disconnect(database: connection)
             }
             guard SQLiteWrapper.execute(database: connection, sql: dropTableStatement) else {
-                Log.warning(label: LOG_PREFIX, "Failed to drop table '\(SQLiteDataQueue.TABLE_NAME)' in database: \(self.databaseName).")
+                Log.warning(label: LOG_PREFIX, "Failed to clear table '\(SQLiteDataQueue.TABLE_NAME)' in database: \(self.databaseName).")
                 return false
             }
 

--- a/AEPServices/Sources/dataqueue/SQLiteWrapper.swift
+++ b/AEPServices/Sources/dataqueue/SQLiteWrapper.swift
@@ -126,4 +126,15 @@ internal struct SQLiteWrapper {
         }
         return false
     }
+
+    /// Check table has 0 rows
+    /// - Parameters:
+    ///   - database: the database connection
+    ///   - tableName: the database name
+    /// - Returns: True, if the database is empty, otherwise false
+    static func tableIsEmpty(database: OpaquePointer, tableName: String) -> Bool {
+        let sql = "SELECT COUNT(*) FROM \(tableName)"
+        let res = query(database: database, sql: sql)?.first?["COUNT(*)"]
+        return res == "0"
+    }
 }

--- a/AEPServices/Tests/services/DataQueueTests.swift
+++ b/AEPServices/Tests/services/DataQueueTests.swift
@@ -458,12 +458,14 @@ class DataQueueTests: XCTestCase {
         XCTAssertTrue(result)
         let connection = SQLiteWrapper.connect(databaseFilePath: .cachesDirectory, databaseName: fileName)!
         let tableExist = SQLiteWrapper.tableExists(database: connection, tableName: SQLiteDataQueue.TABLE_NAME)
+        let tableEmpty = SQLiteWrapper.tableIsEmpty(database: connection, tableName: SQLiteDataQueue.TABLE_NAME)
 
         defer {
             _ = SQLiteWrapper.disconnect(database: connection)
         }
 
-        XCTAssertFalse(tableExist)
+        XCTAssertTrue(tableExist)
+        XCTAssertTrue(tableEmpty)
     }
 
     /// count()


### PR DESCRIPTION
This helps to prevent deleting the table when we are clearing the hit queue. This allows us to eventually re-queue hits if needed.