### PR TITLE
Load ECID earlier

### DIFF
--- a/AEPIdentity/Sources/IdentityState.swift
+++ b/AEPIdentity/Sources/IdentityState.swift
@@ -32,6 +32,7 @@ class IdentityState {
     /// - Parameter pushIdManager: a push id manager
     init(identityProperties: IdentityProperties, hitQueue: HitQueuing, pushIdManager: PushIDManageable) {
         self.identityProperties = identityProperties
+        self.identityProperties.loadFromPersistence()
         self.hitQueue = hitQueue
         self.pushIdManager = pushIdManager
     }


### PR DESCRIPTION
Not currently a bug, but to be safe we load the ECID immediately on initialization of the Identity extension.
Ref: https://jira.corp.adobe.com/browse/AMSDK-10233