### PR TITLE
Handle AdId to zero or empty on first launch

### DIFF
--- a/AEPIdentity/Sources/IdentityState.swift
+++ b/AEPIdentity/Sources/IdentityState.swift
@@ -269,7 +269,11 @@ class IdentityState {
     /// - Returns: A tuple indicating if the ad id has changed, and if the consent flag should be added
     private func shouldUpdateAdId(newAdID: String?) -> (adIdChanged: Bool, addConsentFlag: Bool) {
         guard let newAdID = newAdID else { return (false, false) }
-        let existingAdId = identityProperties.advertisingIdentifier ?? ""
+        guard let existingAdId = identityProperties.advertisingIdentifier else {
+            // existing is nil but new is not, update with new and update consent
+            // covers first call case where existing ad ID is not set and new ad ID is empty/all zeros
+            return (true, true)
+        }
 
         // did the advertising identifier change?
         if (!newAdID.isEmpty && newAdID != existingAdId)

--- a/AEPIdentity/Tests/IdentityStateTests.swift
+++ b/AEPIdentity/Tests/IdentityStateTests.swift
@@ -327,6 +327,60 @@ class IdentityStateTests: XCTestCase {
         let hit = try! JSONDecoder().decode(IdentityHit.self, from: mockHitQueue.queuedHits.first!.data!)
         XCTAssertTrue(hit.url.absoluteString.contains("device_consent=1")) // device flag should be added
     }
+    
+    /// Tests that the ad id is correctly updated when a new (all zero) value is passed (ad id changed from nil to all zero value), hit is successfully queued and device_consent is set to 0.
+    func testSyncIdentifiersAdIDIsUpdatedFromNilToZero() {
+        // setup
+        let configSharedState = [IdentityConstants.Configuration.EXPERIENCE_CLOUD_ORGID: "test-org",
+                                 IdentityConstants.Configuration.EXPERIENCE_CLOUD_SERVER: "test-server",
+                                 IdentityConstants.Configuration.GLOBAL_CONFIG_PRIVACY: PrivacyStatus.optedIn.rawValue] as [String: Any]
+        var props = IdentityProperties()
+        props.advertisingIdentifier = nil
+        state = IdentityState(identityProperties: props, hitQueue: MockHitQueue(processor: MockHitProcessor()), pushIdManager: mockPushIdManager)
+        state.lastValidConfig = configSharedState
+
+        // test
+        let data = [IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER: IdentityConstants.Default.ZERO_ADVERTISING_ID]
+        let event = Event(name: "Fake Sync Event", type: EventType.genericIdentity, source: EventSource.requestReset, data: data)
+        let eventData = state.syncIdentifiers(event: event)
+
+        // verify
+        XCTAssertEqual(2, eventData!.count)
+        XCTAssertNotNil(eventData![IdentityConstants.EventDataKeys.VISITOR_ID_ECID])
+        XCTAssertEqual("", eventData![IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] as? String)
+        XCTAssertNil(eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST])
+        XCTAssertFalse(mockHitQueue.queuedHits.isEmpty) // hit should be queued in the hit queue
+        let hit = try! JSONDecoder().decode(IdentityHit.self, from: mockHitQueue.queuedHits.first!.data!)
+        XCTAssertTrue(hit.url.absoluteString.contains("device_consent=0")) // device flag should be added
+        XCTAssertTrue(hit.url.absoluteString.contains("d_consent_ic=DSID_20915")) // id namespace should be added
+    }
+    
+    /// Tests that the ad id is correctly updated when a new (empty) value is passed (ad id changed from nil to empty), hit is successfully queued and device_consent is set to 0.
+    func testSyncIdentifiersAdIDIsUpdatedFromNilToEmpty() {
+        // setup
+        let configSharedState = [IdentityConstants.Configuration.EXPERIENCE_CLOUD_ORGID: "test-org",
+                                 IdentityConstants.Configuration.EXPERIENCE_CLOUD_SERVER: "test-server",
+                                 IdentityConstants.Configuration.GLOBAL_CONFIG_PRIVACY: PrivacyStatus.optedIn.rawValue] as [String: Any]
+        var props = IdentityProperties()
+        props.advertisingIdentifier = nil
+        state = IdentityState(identityProperties: props, hitQueue: MockHitQueue(processor: MockHitProcessor()), pushIdManager: mockPushIdManager)
+        state.lastValidConfig = configSharedState
+
+        // test
+        let data = [IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER: ""]
+        let event = Event(name: "Fake Sync Event", type: EventType.genericIdentity, source: EventSource.requestReset, data: data)
+        let eventData = state.syncIdentifiers(event: event)
+
+        // verify
+        XCTAssertEqual(2, eventData!.count)
+        XCTAssertNotNil(eventData![IdentityConstants.EventDataKeys.VISITOR_ID_ECID])
+        XCTAssertEqual("", eventData![IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] as? String)
+        XCTAssertNil(eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST])
+        XCTAssertFalse(mockHitQueue.queuedHits.isEmpty) // hit should be queued in the hit queue
+        let hit = try! JSONDecoder().decode(IdentityHit.self, from: mockHitQueue.queuedHits.first!.data!)
+        XCTAssertTrue(hit.url.absoluteString.contains("device_consent=0")) // device flag should be added
+        XCTAssertTrue(hit.url.absoluteString.contains("d_consent_ic=DSID_20915")) // id namespace should be added
+    }
 
     /// Tests that the ad is is correctly updated when a new value is passed
     func testSyncIdentifiersAdIDIsUpdatedFromZeroString() {

--- a/AEPIdentity/Tests/IdentityStateTests.swift
+++ b/AEPIdentity/Tests/IdentityStateTests.swift
@@ -327,7 +327,7 @@ class IdentityStateTests: XCTestCase {
         let hit = try! JSONDecoder().decode(IdentityHit.self, from: mockHitQueue.queuedHits.first!.data!)
         XCTAssertTrue(hit.url.absoluteString.contains("device_consent=1")) // device flag should be added
     }
-    
+
     /// Tests that the ad id is correctly updated when a new (all zero) value is passed (ad id changed from nil to all zero value), hit is successfully queued and device_consent is set to 0.
     func testSyncIdentifiersAdIDIsUpdatedFromNilToZero() {
         // setup
@@ -354,7 +354,7 @@ class IdentityStateTests: XCTestCase {
         XCTAssertTrue(hit.url.absoluteString.contains("device_consent=0")) // device flag should be added
         XCTAssertTrue(hit.url.absoluteString.contains("d_consent_ic=DSID_20915")) // id namespace should be added
     }
-    
+
     /// Tests that the ad id is correctly updated when a new (empty) value is passed (ad id changed from nil to empty), hit is successfully queued and device_consent is set to 0.
     func testSyncIdentifiersAdIDIsUpdatedFromNilToEmpty() {
         // setup


### PR DESCRIPTION
When the app is first launched(current adId is nil) and then ad Id is set to an empty or all zero string we need to send out consent=0 on the hit.