### PR TITLE
Simplify Zip Slip validation

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 		3FF829692509937100483C74 /* SignalIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF829682509937100483C74 /* SignalIntegrationTests.swift */; };
 		3FF8296C2509942300483C74 /* rules_signal.zip in Resources */ = {isa = PBXBuildFile; fileRef = 3FF8296A2509942200483C74 /* rules_signal.zip */; };
 		3FF8296D2509942300483C74 /* rules_signal.json in Resources */ = {isa = PBXBuildFile; fileRef = 3FF8296B2509942300483C74 /* rules_signal.json */; };
+		7814B23325CB455200841429 /* URL+Validator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7814B23225CB455200841429 /* URL+Validator.swift */; };
 		786C000525B8EE2100F26D34 /* DefaultHeadersFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786C000425B8EE2100F26D34 /* DefaultHeadersFormatter.swift */; };
 		786C001525B8EE6200F26D34 /* HttpConnectionConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786C001425B8EE6200F26D34 /* HttpConnectionConstants.swift */; };
 		786C004825B8F43E00F26D34 /* DefaultHeadersFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786C004725B8F43E00F26D34 /* DefaultHeadersFormatterTests.swift */; };
@@ -869,6 +870,7 @@
 		3FF8296B2509942300483C74 /* rules_signal.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_signal.json; sourceTree = "<group>"; };
 		42E2B003910D73C12B88CC06 /* Pods_AEPIdentityTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AEPIdentityTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4E248A93FA9CBDD50605A356 /* Pods-AEPIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-AEPIntegrationTests/Pods-AEPIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
+		7814B23225CB455200841429 /* URL+Validator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Validator.swift"; sourceTree = "<group>"; };
 		786C000425B8EE2100F26D34 /* DefaultHeadersFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultHeadersFormatter.swift; sourceTree = "<group>"; };
 		786C001425B8EE6200F26D34 /* HttpConnectionConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpConnectionConstants.swift; sourceTree = "<group>"; };
 		786C004725B8F43E00F26D34 /* DefaultHeadersFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultHeadersFormatterTests.swift; sourceTree = "<group>"; };
@@ -1457,6 +1459,7 @@
 				2467E43924CA4DE20022F6BE /* Unzipping.swift */,
 				3F0397E924BE60910019F095 /* ZipArchive.swift */,
 				3F0397EA24BE60910019F095 /* ZipEntry.swift */,
+				7814B23225CB455200841429 /* URL+Validator.swift */,
 			);
 			path = unzip;
 			sourceTree = "<group>";
@@ -2948,6 +2951,7 @@
 				3F0397DA24BE5FF30019F095 /* NamedCollectionProcessing.swift in Sources */,
 				92EEA5F6258933A600DBA3EE /* FullscreenMessageDelegate.swift in Sources */,
 				3F0397FE24BE60910019F095 /* URLEncoder.swift in Sources */,
+				7814B23325CB455200841429 /* URL+Validator.swift in Sources */,
 				3F0397FF24BE60910019F095 /* AnyCodable.swift in Sources */,
 				3F0397D124BE5FF30019F095 /* HttpConnection.swift in Sources */,
 				3F0397D824BE5FF30019F095 /* DataQueuing.swift in Sources */,

--- a/AEPServices/Sources/utility/unzip/FileUnzipper.swift
+++ b/AEPServices/Sources/utility/unzip/FileUnzipper.swift
@@ -45,7 +45,7 @@ public class FileUnzipper: Unzipping {
             entryNames.append(path)
             let destinationEntryURL = destinationURL.appendingPathComponent(path)
             // Validate path for entry
-            if !isValidPath(destinationEntryURL, destination: destinationURL) {
+            if !destinationEntryURL.isValidUrl() {
                 Log.error(label: LOG_PREFIX, "The zip file contained an invalid path. Verify that your zip file is formatted correctly and has not been tampered with.")
                 return []
             }
@@ -57,24 +57,5 @@ public class FileUnzipper: Unzipping {
         }
 
         return entryNames
-    }
-    ///
-    /// Validates the entryUrl path
-    /// - Parameters:
-    ///     - entryUrl: The url for the entry being extracted from the archive
-    ///     - destination: The destination url for the entry being extracted
-    /// - Returns: True if valid, false if invalid
-    private func isValidPath(_ entryUrl: URL, destination: URL) -> Bool {
-        let destinationComponents = canonicalize(destination).pathComponents
-        let entryComponents = canonicalize(entryUrl).pathComponents
-        return destinationComponents.count < entryComponents.count && !zip(destinationComponents, entryComponents).contains(where: !=)
-    }
-
-    ///
-    /// Canonicalizes the Url by standardizing as a file url and resolving symlinks in the path
-    /// - Parameter url: The url to canonicalize
-    /// - Returns: The canonicalized url
-    private func canonicalize(_ url: URL) -> URL {
-        url.standardizedFileURL.resolvingSymlinksInPath()
     }
 }

--- a/AEPServices/Sources/utility/unzip/FileUnzipper.swift
+++ b/AEPServices/Sources/utility/unzip/FileUnzipper.swift
@@ -45,7 +45,7 @@ public class FileUnzipper: Unzipping {
             entryNames.append(path)
             let destinationEntryURL = destinationURL.appendingPathComponent(path)
             // Validate path for entry
-            if !destinationEntryURL.isValidUrl() {
+            if !destinationEntryURL.isSafeUrl() {
                 Log.error(label: LOG_PREFIX, "The zip file contained an invalid path. Verify that your zip file is formatted correctly and has not been tampered with.")
                 return []
             }

--- a/AEPServices/Sources/utility/unzip/URL+Validator.swift
+++ b/AEPServices/Sources/utility/unzip/URL+Validator.swift
@@ -18,7 +18,7 @@ extension URL {
         if self.absoluteString.contains("../") {
             return false
         }
-        
+
         return true
     }
 }

--- a/AEPServices/Sources/utility/unzip/URL+Validator.swift
+++ b/AEPServices/Sources/utility/unzip/URL+Validator.swift
@@ -14,7 +14,7 @@ extension URL {
     ///
     /// Validates a URL against a Zip Slip attack. Simply checks if there is any sort of traversal attempted in the url
     /// - Returns: True if valid, false if invalid
-    func isValidUrl() -> Bool {
+    func isSafeUrl() -> Bool {
         if self.absoluteString.contains("../") {
             return false
         }

--- a/AEPServices/Sources/utility/unzip/URL+Validator.swift
+++ b/AEPServices/Sources/utility/unzip/URL+Validator.swift
@@ -1,0 +1,24 @@
+/*
+ Copyright 2021 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+
+extension URL {
+    ///
+    /// Validates a URL against a Zip Slip attack. Simply checks if there is any sort of traversal attempted in the url
+    /// - Returns: True if valid, false if invalid
+    func isValidUrl() -> Bool {
+        if self.absoluteString.contains("../") {
+            return false
+        }
+        
+        return true
+    }
+}

--- a/AEPServices/Tests/services/UnzipperTest.swift
+++ b/AEPServices/Tests/services/UnzipperTest.swift
@@ -237,9 +237,9 @@ class FileUnzipperTest: XCTestCase {
         let invalidUrl1 = URL(string: "/var/mobile/Containers/Data/Application/A87F42D1-3EFE-4F4D-A22D-233F184684BB/Library/Caches/com.adobe.edge/../../../")
         let invalidUrl2 = URL(string: "/var/../mobile/Containers/Data/Application/A87F42D1-3EFE-4F4D-A22D-233F184684BB/Library/Caches/com.adobe.edge/")
         let validUrl1 = URL(string: "/var/mobile/Containers/Data/Application/A87F42D1-3EFE-4F4D-A22D-233F184684BB/Library/Caches/com.adobe.edge/")
-        XCTAssertFalse(invalidUrl1!.isValidUrl())
-        XCTAssertFalse(invalidUrl2!.isValidUrl())
-        XCTAssertTrue(validUrl1!.isValidUrl())
+        XCTAssertFalse(invalidUrl1!.isSafeUrl())
+        XCTAssertFalse(invalidUrl2!.isSafeUrl())
+        XCTAssertTrue(validUrl1!.isSafeUrl())
     }
 
     // MARK: - Helpers

--- a/AEPServices/Tests/services/UnzipperTest.swift
+++ b/AEPServices/Tests/services/UnzipperTest.swift
@@ -231,7 +231,7 @@ class FileUnzipperTest: XCTestCase {
         let unzippedItems = unzipper.unzipItem(at: sourceURL, to: destinationURL)
         XCTAssertTrue(unzippedItems.isEmpty)
     }
-    
+
 
     func testIsValidUrlWithInvalidUrl() {
         let invalidUrl1 = URL(string: "/var/mobile/Containers/Data/Application/A87F42D1-3EFE-4F4D-A22D-233F184684BB/Library/Caches/com.adobe.edge/../../../")

--- a/AEPServices/Tests/services/UnzipperTest.swift
+++ b/AEPServices/Tests/services/UnzipperTest.swift
@@ -220,7 +220,7 @@ class FileUnzipperTest: XCTestCase {
     ///
     /// Test Zip Slip attempt does not succeed
     ///
-    func testZipSlipCatch() {
+    func testZipSlipCatchWithExploitedZip() {
         removeResourceWith(name: testZipSlipFileName)
         guard let sourceURL = getResourceURLWith(name: testZipSlipFileName) else {
             XCTFail()
@@ -230,6 +230,16 @@ class FileUnzipperTest: XCTestCase {
         let destinationURL = sourceURL.deletingLastPathComponent().appendingPathComponent(testZipSlipFileName)
         let unzippedItems = unzipper.unzipItem(at: sourceURL, to: destinationURL)
         XCTAssertTrue(unzippedItems.isEmpty)
+    }
+    
+
+    func testIsValidUrlWithInvalidUrl() {
+        let invalidUrl1 = URL(string: "/var/mobile/Containers/Data/Application/A87F42D1-3EFE-4F4D-A22D-233F184684BB/Library/Caches/com.adobe.edge/../../../")
+        let invalidUrl2 = URL(string: "/var/../mobile/Containers/Data/Application/A87F42D1-3EFE-4F4D-A22D-233F184684BB/Library/Caches/com.adobe.edge/")
+        let validUrl1 = URL(string: "/var/mobile/Containers/Data/Application/A87F42D1-3EFE-4F4D-A22D-233F184684BB/Library/Caches/com.adobe.edge/")
+        XCTAssertFalse(invalidUrl1!.isValidUrl())
+        XCTAssertFalse(invalidUrl2!.isValidUrl())
+        XCTAssertTrue(validUrl1!.isValidUrl())
     }
 
     // MARK: - Helpers
@@ -249,3 +259,5 @@ class FileUnzipperTest: XCTestCase {
         }
     }
 }
+
+


### PR DESCRIPTION
Manual canonicalization on a physical device produced unexpected results. Simply checking if the url attempts traversal via "../" is the current solution. 