### PR TITLE
Remove message monitor from service provider, add onShowFailed to delegates

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -292,8 +292,8 @@
 		3FF829692509937100483C74 /* SignalIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF829682509937100483C74 /* SignalIntegrationTests.swift */; };
 		3FF8296C2509942300483C74 /* rules_signal.zip in Resources */ = {isa = PBXBuildFile; fileRef = 3FF8296A2509942200483C74 /* rules_signal.zip */; };
 		3FF8296D2509942300483C74 /* rules_signal.json in Resources */ = {isa = PBXBuildFile; fileRef = 3FF8296B2509942300483C74 /* rules_signal.json */; };
-		7814B25125CB52AC00841429 /* AlertMessageShowable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7814B25025CB52AC00841429 /* AlertMessageShowable.swift */; };
 		7814B23325CB455200841429 /* URL+Validator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7814B23225CB455200841429 /* URL+Validator.swift */; };
+		7814B25125CB52AC00841429 /* AlertMessageShowable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7814B25025CB52AC00841429 /* AlertMessageShowable.swift */; };
 		786C000525B8EE2100F26D34 /* DefaultHeadersFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786C000425B8EE2100F26D34 /* DefaultHeadersFormatter.swift */; };
 		786C001525B8EE6200F26D34 /* HttpConnectionConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786C001425B8EE6200F26D34 /* HttpConnectionConstants.swift */; };
 		786C004825B8F43E00F26D34 /* DefaultHeadersFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786C004725B8F43E00F26D34 /* DefaultHeadersFormatterTests.swift */; };
@@ -326,8 +326,8 @@
 		92867D6525C0B56400E32CDC /* FloatingButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92867D6425C0B56400E32CDC /* FloatingButtonTests.swift */; };
 		92EEA57025885C1C00DBA3EE /* FullscreenMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EEA56F25885C1C00DBA3EE /* FullscreenMessage.swift */; };
 		92EEA5F6258933A600DBA3EE /* FullscreenMessageDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EEA5F5258933A600DBA3EE /* FullscreenMessageDelegate.swift */; };
-		92EEA6062589343700DBA3EE /* MessageMonitorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EEA6052589343700DBA3EE /* MessageMonitorService.swift */; };
-		92F06BFC25B8F1FE004C1700 /* MessageMonitorServicing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F06BFB25B8F1FE004C1700 /* MessageMonitorServicing.swift */; };
+		92EEA6062589343700DBA3EE /* MessageMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EEA6052589343700DBA3EE /* MessageMonitor.swift */; };
+		92F06BFC25B8F1FE004C1700 /* MessageMonitoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F06BFB25B8F1FE004C1700 /* MessageMonitoring.swift */; };
 		92F06D0425BA33F4004C1700 /* Showable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F06D0325BA33F3004C1700 /* Showable.swift */; };
 		A72E12E73A89C07875FF52B0 /* Pods_AEPIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 89F79E25B71BEC12CCD2D22E /* Pods_AEPIntegrationTests.framework */; };
 		BB00E26824D8C94600C578C1 /* TokenFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00E26624D8C94600C578C1 /* TokenFinder.swift */; };
@@ -875,8 +875,8 @@
 		3FF8296B2509942300483C74 /* rules_signal.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_signal.json; sourceTree = "<group>"; };
 		42E2B003910D73C12B88CC06 /* Pods_AEPIdentityTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AEPIdentityTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4E248A93FA9CBDD50605A356 /* Pods-AEPIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-AEPIntegrationTests/Pods-AEPIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
-		7814B25025CB52AC00841429 /* AlertMessageShowable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertMessageShowable.swift; sourceTree = "<group>"; };
 		7814B23225CB455200841429 /* URL+Validator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Validator.swift"; sourceTree = "<group>"; };
+		7814B25025CB52AC00841429 /* AlertMessageShowable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertMessageShowable.swift; sourceTree = "<group>"; };
 		786C000425B8EE2100F26D34 /* DefaultHeadersFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultHeadersFormatter.swift; sourceTree = "<group>"; };
 		786C001425B8EE6200F26D34 /* HttpConnectionConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpConnectionConstants.swift; sourceTree = "<group>"; };
 		786C004725B8F43E00F26D34 /* DefaultHeadersFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultHeadersFormatterTests.swift; sourceTree = "<group>"; };
@@ -910,8 +910,8 @@
 		92867D6425C0B56400E32CDC /* FloatingButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingButtonTests.swift; sourceTree = "<group>"; };
 		92EEA56F25885C1C00DBA3EE /* FullscreenMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenMessage.swift; sourceTree = "<group>"; };
 		92EEA5F5258933A600DBA3EE /* FullscreenMessageDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenMessageDelegate.swift; sourceTree = "<group>"; };
-		92EEA6052589343700DBA3EE /* MessageMonitorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageMonitorService.swift; sourceTree = "<group>"; };
-		92F06BFB25B8F1FE004C1700 /* MessageMonitorServicing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageMonitorServicing.swift; sourceTree = "<group>"; };
+		92EEA6052589343700DBA3EE /* MessageMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageMonitor.swift; sourceTree = "<group>"; };
+		92F06BFB25B8F1FE004C1700 /* MessageMonitoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageMonitoring.swift; sourceTree = "<group>"; };
 		92F06D0325BA33F3004C1700 /* Showable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Showable.swift; sourceTree = "<group>"; };
 		96BE464331BD2F2538F7BDCF /* Pods-AEPIdentityTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPIdentityTests.debug.xcconfig"; path = "Target Support Files/Pods-AEPIdentityTests/Pods-AEPIdentityTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9AD1C8FAF7E8C192A4441902 /* Pods-AEPLifecycleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPLifecycleTests.release.xcconfig"; path = "Target Support Files/Pods-AEPLifecycleTests/Pods-AEPLifecycleTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1813,10 +1813,10 @@
 				923547FA25BFF16900BEA9A3 /* floating */,
 				9239726625ACF1340056A3E5 /* alert */,
 				92EEA64D258956FE00DBA3EE /* fullscreen */,
-				92EEA6052589343700DBA3EE /* MessageMonitorService.swift */,
+				92EEA6052589343700DBA3EE /* MessageMonitor.swift */,
+				92F06BFB25B8F1FE004C1700 /* MessageMonitoring.swift */,
 				92F06D0325BA33F3004C1700 /* Showable.swift */,
 				78B36A9525CA1C2D00D6D25F /* Dismissible.swift */,
-				92F06BFB25B8F1FE004C1700 /* MessageMonitorServicing.swift */,
 				9239713F25A6380A0056A3E5 /* MessagingDelegate.swift */,
 				923972B225AD844E0056A3E5 /* UIApplication+Window.swift */,
 				923547EA25BF9C6600BEA9A3 /* AEPUIService.swift */,
@@ -2965,7 +2965,7 @@
 				3F0397DB24BE5FF30019F095 /* NamedCollectionDataStore.swift in Sources */,
 				3F0397C524BE5FF30019F095 /* CacheEntry.swift in Sources */,
 				3F0397F524BE60910019F095 /* AtomicCounter.swift in Sources */,
-				92F06BFC25B8F1FE004C1700 /* MessageMonitorServicing.swift in Sources */,
+				92F06BFC25B8F1FE004C1700 /* MessageMonitoring.swift in Sources */,
 				78B36AB425CA1FCE00D6D25F /* FullscreenPresentable.swift in Sources */,
 				3F0397DA24BE5FF30019F095 /* NamedCollectionProcessing.swift in Sources */,
 				92EEA5F6258933A600DBA3EE /* FullscreenMessageDelegate.swift in Sources */,
@@ -2976,7 +2976,7 @@
 				3F0397D824BE5FF30019F095 /* DataQueuing.swift in Sources */,
 				3F0397E024BE5FF30019F095 /* URLService.swift in Sources */,
 				3F0397CA24BE5FF30019F095 /* Log.swift in Sources */,
-				92EEA6062589343700DBA3EE /* MessageMonitorService.swift in Sources */,
+				92EEA6062589343700DBA3EE /* MessageMonitor.swift in Sources */,
 				3F0397DC24BE5FF30019F095 /* UserDefaultsNamedCollection.swift in Sources */,
 				92F06D0425BA33F4004C1700 /* Showable.swift in Sources */,
 				3F0397D524BE5FF30019F095 /* DataQueue.swift in Sources */,

--- a/AEPServices/Mocks/MockUIService.swift
+++ b/AEPServices/Mocks/MockUIService.swift
@@ -18,11 +18,13 @@ public class MockUIService: UIService {
     
     public init() {}
     
+    var mockMessageMonitor: MessageMonitoring?
+    
     var createFullscreenMessageCalled = false
     var fullscreenMessage: FullscreenPresentable?
     public func createFullscreenMessage(payload: String, listener: FullscreenMessageDelegate?, isLocalImageUsed: Bool) -> FullscreenPresentable {
         createFullscreenMessageCalled = true
-        return fullscreenMessage ?? FullscreenMessage(payload: payload, listener: listener, isLocalImageUsed: isLocalImageUsed)
+        return fullscreenMessage ?? FullscreenMessage(payload: payload, listener: listener, isLocalImageUsed: isLocalImageUsed, messageMonitor: mockMessageMonitor ?? MessageMonitor())
     }
     
     var createFloatingButtonCalled = false
@@ -36,7 +38,7 @@ public class MockUIService: UIService {
     var alertMessage: AlertMessageShowable?
     public func createAlertMessage(title: String, message: String, positiveButtonLabel: String?, negativeButtonLabel: String?, listener: AlertMessageDelegate?) -> AlertMessageShowable {
         createAlertMessageCalled = true
-        return alertMessage ?? AlertMessage(title: title, message: message, positiveButtonLabel: positiveButtonLabel, negativeButtonLabel: negativeButtonLabel, listener: listener)
+        return alertMessage ?? AlertMessage(title: title, message: message, positiveButtonLabel: positiveButtonLabel, negativeButtonLabel: negativeButtonLabel, listener: listener, messageMonitor: mockMessageMonitor ?? MessageMonitor())
     }
     
     

--- a/AEPServices/Sources/ServiceProvider.swift
+++ b/AEPServices/Sources/ServiceProvider.swift
@@ -33,7 +33,6 @@ public class ServiceProvider {
     private var overrideURLService: URLOpening?
     private var defaultURLService = URLService()
     private var defaultLoggingService = LoggingService()
-    private var defaultMessageMonitorService = MessageMonitorService()
     private var overrideUIService: UIService?
     private var defaultUIService = AEPUIService()
 
@@ -118,14 +117,6 @@ public class ServiceProvider {
         }
     }
 
-    var messageMonitorService: MessageMonitorServicing {
-        get {
-            return queue.sync {
-                return defaultMessageMonitorService
-            }
-        }
-    }
-
     public var uiService: UIService {
         get {
             return queue.sync {
@@ -147,7 +138,6 @@ public class ServiceProvider {
         defaultCacheService = DiskCacheService()
         defaultURLService = URLService()
         defaultLoggingService = LoggingService()
-        defaultMessageMonitorService = MessageMonitorService()
         defaultUIService = AEPUIService()
 
         overrideSystemInfoService = nil

--- a/AEPServices/Sources/ui/AEPUIService.swift
+++ b/AEPServices/Sources/ui/AEPUIService.swift
@@ -14,8 +14,11 @@ import Foundation
 import UIKit
 
 class AEPUIService: UIService {
+    
+    private var messageMonitor = MessageMonitor()
+    
     func createFullscreenMessage(payload: String, listener: FullscreenMessageDelegate?, isLocalImageUsed: Bool = false) -> FullscreenPresentable {
-        return FullscreenMessage(payload: payload, listener: listener, isLocalImageUsed: isLocalImageUsed)
+        return FullscreenMessage(payload: payload, listener: listener, isLocalImageUsed: isLocalImageUsed, messageMonitor: messageMonitor)
     }
 
     func createFloatingButton(listener: FloatingButtonDelegate) -> FloatingButtonPresentable {
@@ -23,6 +26,6 @@ class AEPUIService: UIService {
     }
 
     func createAlertMessage(title: String, message: String, positiveButtonLabel: String?, negativeButtonLabel: String?, listener: AlertMessageDelegate?) -> AlertMessageShowable {
-        return AlertMessage(title: title, message: message, positiveButtonLabel: positiveButtonLabel, negativeButtonLabel: negativeButtonLabel, listener: listener)
+        return AlertMessage(title: title, message: message, positiveButtonLabel: positiveButtonLabel, negativeButtonLabel: negativeButtonLabel, listener: listener, messageMonitor: messageMonitor)
     }
 }

--- a/AEPServices/Sources/ui/AEPUIService.swift
+++ b/AEPServices/Sources/ui/AEPUIService.swift
@@ -14,9 +14,9 @@ import Foundation
 import UIKit
 
 class AEPUIService: UIService {
-    
+
     private var messageMonitor = MessageMonitor()
-    
+
     func createFullscreenMessage(payload: String, listener: FullscreenMessageDelegate?, isLocalImageUsed: Bool = false) -> FullscreenPresentable {
         return FullscreenMessage(payload: payload, listener: listener, isLocalImageUsed: isLocalImageUsed, messageMonitor: messageMonitor)
     }

--- a/AEPServices/Sources/ui/MessageMonitor.swift
+++ b/AEPServices/Sources/ui/MessageMonitor.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-class MessageMonitorService: MessageMonitorServicing {
+class MessageMonitor: MessageMonitoring {
     private let LOG_PREFIX = "MessageMonitor"
     private var isMsgDisplayed = false
     private let messageQueue = DispatchQueue(label: "com.adobe.uiservice.messagemonitor")

--- a/AEPServices/Sources/ui/MessageMonitoring.swift
+++ b/AEPServices/Sources/ui/MessageMonitoring.swift
@@ -14,7 +14,7 @@ import Foundation
 
 /// This protocol is used to monitor if an UI message is displayed at some point in time, currently this applies for full screen and alert messages.
 /// The status is exposed through isMessageDisplayed.
-protocol MessageMonitorServicing {
+protocol MessageMonitoring {
     /// - Returns: True if the message is being displayed else false
     func isMessageDisplayed() -> Bool
 

--- a/AEPServices/Sources/ui/alert/AlertMessage.swift
+++ b/AEPServices/Sources/ui/alert/AlertMessage.swift
@@ -24,25 +24,24 @@ public class AlertMessage: NSObject, AlertMessageShowable {
     private let positiveButtonLabel: String?
     private let negativeButtonLabel: String?
     private var listener: AlertMessageDelegate?
-
-    private var messageService: MessageMonitorServicing {
-        return ServiceProvider.shared.messageMonitorService
-    }
+    private var messageMonitor: MessageMonitoring
 
     private var messagingDelegate: MessagingDelegate? {
         return ServiceProvider.shared.messagingDelegate
     }
 
-    init(title: String, message: String, positiveButtonLabel: String?, negativeButtonLabel: String?, listener: AlertMessageDelegate?) {
+    init(title: String, message: String, positiveButtonLabel: String?, negativeButtonLabel: String?, listener: AlertMessageDelegate?, messageMonitor: MessageMonitoring) {
         self.title = title
         self.message = message
         self.positiveButtonLabel = positiveButtonLabel
         self.negativeButtonLabel = negativeButtonLabel
         self.listener = listener
+        self.messageMonitor = messageMonitor
     }
 
     public func show() {
-        if messageService.show(message: self) == false {
+        if messageMonitor.show(message: self) == false {
+            listener?.onShowFailed()
             return
         }
 
@@ -73,11 +72,13 @@ public class AlertMessage: NSObject, AlertMessageShowable {
                     }
                 } else {
                     Log.warning(label: "\(self.LOG_PREFIX):\(#function)", "Unable to show Alert. ViewController is not loaded.")
-                    self.messageService.dismissMessage()
+                    self.listener?.onShowFailed()
+                    self.messageMonitor.dismissMessage()
                 }
             } else {
                 Log.warning(label: "\(self.LOG_PREFIX):\(#function)", "Unable to show Alert. KeyWindow is null.")
-                self.messageService.dismissMessage()
+                self.listener?.onShowFailed()
+                self.messageMonitor.dismissMessage()
             }
         }
     }
@@ -127,7 +128,7 @@ public class AlertMessage: NSObject, AlertMessageShowable {
     }
 
     private func dismiss() {
-        if messageService.dismiss() == false {
+        if messageMonitor.dismiss() == false {
             return
         }
         self.listener?.onDismiss(message: self)

--- a/AEPServices/Sources/ui/alert/AlertMessage.swift
+++ b/AEPServices/Sources/ui/alert/AlertMessage.swift
@@ -41,7 +41,7 @@ public class AlertMessage: NSObject, AlertMessageShowable {
 
     public func show() {
         if messageMonitor.show(message: self) == false {
-            listener?.onShowFailed()
+            listener?.onShowFailure()
             return
         }
 
@@ -72,12 +72,12 @@ public class AlertMessage: NSObject, AlertMessageShowable {
                     }
                 } else {
                     Log.warning(label: "\(self.LOG_PREFIX):\(#function)", "Unable to show Alert. ViewController is not loaded.")
-                    self.listener?.onShowFailed()
+                    self.listener?.onShowFailure()
                     self.messageMonitor.dismissMessage()
                 }
             } else {
                 Log.warning(label: "\(self.LOG_PREFIX):\(#function)", "Unable to show Alert. KeyWindow is null.")
-                self.listener?.onShowFailed()
+                self.listener?.onShowFailure()
                 self.messageMonitor.dismissMessage()
             }
         }

--- a/AEPServices/Sources/ui/alert/AlertMessageDelegate.swift
+++ b/AEPServices/Sources/ui/alert/AlertMessageDelegate.swift
@@ -41,5 +41,5 @@ import Foundation
     ///
     /// Invoked when the alert failed to be displayed
     ///
-    func onShowFailed()
+    func onShowFailure()
 }

--- a/AEPServices/Sources/ui/alert/AlertMessageDelegate.swift
+++ b/AEPServices/Sources/ui/alert/AlertMessageDelegate.swift
@@ -37,7 +37,7 @@ import Foundation
     ///     - message: Alert message which is currently dismissed
     @objc(onDismissWithAlertMessage:)
     func onDismiss(message: AlertMessage)
-    
+
     ///
     /// Invoked when the alert failed to be displayed
     ///

--- a/AEPServices/Sources/ui/alert/AlertMessageDelegate.swift
+++ b/AEPServices/Sources/ui/alert/AlertMessageDelegate.swift
@@ -37,4 +37,9 @@ import Foundation
     ///     - message: Alert message which is currently dismissed
     @objc(onDismissWithAlertMessage:)
     func onDismiss(message: AlertMessage)
+    
+    ///
+    /// Invoked when the alert failed to be displayed
+    ///
+    func onShowFailed()
 }

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
@@ -53,14 +53,14 @@ public class FullscreenMessage: NSObject, WKNavigationDelegate, FullscreenPresen
 
     public func show() {
         if messageMonitor.show(message: self) ==  false {
-            self.listener?.onShowFailed()
+            self.listener?.onShowFailure()
             return
         }
 
         DispatchQueue.main.async {
             guard var newFrame: CGRect = UIUtils.getFrame() else {
                 Log.debug(label: self.LOG_PREFIX, "Failed to show the fullscreen message, newly created frame is nil.")
-                self.listener?.onShowFailed()
+                self.listener?.onShowFailure()
                 return
             }
             newFrame.origin.y = newFrame.size.height

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessageDelegate.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessageDelegate.swift
@@ -33,7 +33,7 @@ import Foundation
     /// - Returns: True if the core wants to handle the URL (and not the fullscreen message view implementation)
     @objc(overrideUrlLoadFullscreenMessage:url:)
     func overrideUrlLoad(message: FullscreenMessage, url: String?) -> Bool
-    
+
     ///
     /// Invoked when the FullscreenMessage failed to be displayed
     ///

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessageDelegate.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessageDelegate.swift
@@ -33,4 +33,9 @@ import Foundation
     /// - Returns: True if the core wants to handle the URL (and not the fullscreen message view implementation)
     @objc(overrideUrlLoadFullscreenMessage:url:)
     func overrideUrlLoad(message: FullscreenMessage, url: String?) -> Bool
+    
+    ///
+    /// Invoked when the FullscreenMessage failed to be displayed
+    ///
+    func onShowFailed()
 }

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessageDelegate.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessageDelegate.swift
@@ -37,5 +37,5 @@ import Foundation
     ///
     /// Invoked when the FullscreenMessage failed to be displayed
     ///
-    func onShowFailed()
+    func onShowFailure()
 }

--- a/AEPServices/Tests/services/AlertMessageTests.swift
+++ b/AEPServices/Tests/services/AlertMessageTests.swift
@@ -69,7 +69,7 @@ class AlertMessageTests : XCTestCase {
         func onNegativeResponse(message: AlertMessage) {}
         func onShow(message: AlertMessage) {}
         func onDismiss(message: AlertMessage) {}
-        func onShowFailed() {
+        func onShowFailure() {
             AlertMessageTests.onShowFailedCall = true
             AlertMessageTests.expectation?.fulfill()
         }

--- a/AEPServices/Tests/services/AlertMessageTests.swift
+++ b/AEPServices/Tests/services/AlertMessageTests.swift
@@ -28,11 +28,11 @@ class AlertMessageTests : XCTestCase {
 
     var mockListener: AlertMessageDelegate?
     var messageDelegate : MessagingDelegate?
-    
+
     var messageMonitor = MessageMonitor()
 
     static var onShowFailedCall = false
-    
+
     override func setUp() {
         mockListener = MockListener()
         alertMessage = AlertMessage(title: AlertMessageTests.mockTitle, message: AlertMessageTests.mockMessage, positiveButtonLabel: AlertMessageTests.mockPositiveLabel, negativeButtonLabel: AlertMessageTests.mockNegativeLabel, listener: mockListener, messageMonitor: messageMonitor)
@@ -55,7 +55,7 @@ class AlertMessageTests : XCTestCase {
         messageMonitor.dismissMessage()
         XCTAssertNoThrow(alertMessage?.show())
     }
-    
+
     func testShowFailed() {
         AlertMessageTests.expectation = XCTestExpectation(description: "Testing show failed")
         alertMessage = AlertMessage(title: "", message: "", positiveButtonLabel: "", negativeButtonLabel: "", listener: mockListener, messageMonitor: messageMonitor)

--- a/AEPServices/Tests/services/FullscreenMessageTests.swift
+++ b/AEPServices/Tests/services/FullscreenMessageTests.swift
@@ -20,46 +20,58 @@ class FullscreenMessageTests : XCTestCase {
     let mockHtml = "somehtml"
     static var onShowFullscreenMessagingCall = false
     static var onDismissullscreenMessagingCall = false
+    static var onShowFailedCall = false
     var fullscreenMessage : FullscreenMessage?
     static var expectation: XCTestExpectation?
     var mockUIService: UIService?
 
     var rootViewController: UIViewController!
+    
+    var messageMonitor = MessageMonitor()
 
     override func setUp() {
         FullscreenMessageTests.onShowFullscreenMessagingCall = false
         FullscreenMessageTests.onDismissullscreenMessagingCall = false
-        fullscreenMessage = FullscreenMessage(payload: mockHtml, listener: MockFullscreenListener(), isLocalImageUsed: false)
+        fullscreenMessage = FullscreenMessage(payload: mockHtml, listener: MockFullscreenListener(), isLocalImageUsed: false, messageMonitor: messageMonitor)
         mockUIService = MockUIService()
         ServiceProvider.shared.uiService = mockUIService!
     }
 
     func test_init_whenListenerIsNil() {
-        fullscreenMessage = FullscreenMessage(payload: mockHtml, listener: nil, isLocalImageUsed: false)
+        fullscreenMessage = FullscreenMessage(payload: mockHtml, listener: nil, isLocalImageUsed: false, messageMonitor: messageMonitor)
         XCTAssertNotNil(fullscreenMessage)
     }
 
     func test_init_whenIsLocalImageTrue() {
-        fullscreenMessage = FullscreenMessage(payload: mockHtml, listener: MockFullscreenListener(), isLocalImageUsed: true)
+        fullscreenMessage = FullscreenMessage(payload: mockHtml, listener: MockFullscreenListener(), isLocalImageUsed: true, messageMonitor: messageMonitor)
         XCTAssertNotNil(fullscreenMessage)
     }
 
     func test_init_whenIsLocalImageFalse() {
-        fullscreenMessage = FullscreenMessage(payload: mockHtml, listener: MockFullscreenListener(), isLocalImageUsed: false)
+        fullscreenMessage = FullscreenMessage(payload: mockHtml, listener: MockFullscreenListener(), isLocalImageUsed: false, messageMonitor: messageMonitor)
         XCTAssertNotNil(fullscreenMessage)
     }
 
     func test_dismiss() {
         FullscreenMessageTests.expectation = XCTestExpectation(description: "Testing Dismiss")
-        ServiceProvider.shared.messageMonitorService.displayMessage()
+        messageMonitor.displayMessage()
         fullscreenMessage?.dismiss()
         wait(for: [FullscreenMessageTests.expectation!], timeout: 10.0)
         XCTAssertTrue(FullscreenMessageTests.onDismissullscreenMessagingCall)
     }
 
     func test_show() {
-        ServiceProvider.shared.messageMonitorService.dismissMessage()
+        messageMonitor.dismissMessage()
         XCTAssertNoThrow(fullscreenMessage?.show())
+    }
+    
+    func test_showFailed() {
+        FullscreenMessageTests.expectation = XCTestExpectation(description: "Testing show failed")
+        fullscreenMessage = FullscreenMessage(payload: mockHtml, listener: MockFullscreenListener(), isLocalImageUsed: false, messageMonitor: messageMonitor)
+        fullscreenMessage?.show()
+        wait(for: [FullscreenMessageTests.expectation!], timeout: 1.0)
+        XCTAssertTrue(FullscreenMessageTests.onShowFailedCall)
+        
     }
 
     class MockFullscreenListener: FullscreenMessageDelegate {
@@ -75,6 +87,11 @@ class FullscreenMessageTests : XCTestCase {
 
         func overrideUrlLoad(message: FullscreenMessage, url: String?) -> Bool {
             return true
+        }
+        
+        func onShowFailed() {
+            FullscreenMessageTests.onShowFailedCall = true
+            FullscreenMessageTests.expectation?.fulfill()
         }
     }
 }

--- a/AEPServices/Tests/services/FullscreenMessageTests.swift
+++ b/AEPServices/Tests/services/FullscreenMessageTests.swift
@@ -89,7 +89,7 @@ class FullscreenMessageTests : XCTestCase {
             return true
         }
 
-        func onShowFailed() {
+        func onShowFailure() {
             FullscreenMessageTests.onShowFailedCall = true
             FullscreenMessageTests.expectation?.fulfill()
         }

--- a/AEPServices/Tests/services/FullscreenMessageTests.swift
+++ b/AEPServices/Tests/services/FullscreenMessageTests.swift
@@ -26,7 +26,7 @@ class FullscreenMessageTests : XCTestCase {
     var mockUIService: UIService?
 
     var rootViewController: UIViewController!
-    
+
     var messageMonitor = MessageMonitor()
 
     override func setUp() {
@@ -64,14 +64,14 @@ class FullscreenMessageTests : XCTestCase {
         messageMonitor.dismissMessage()
         XCTAssertNoThrow(fullscreenMessage?.show())
     }
-    
+
     func test_showFailed() {
         FullscreenMessageTests.expectation = XCTestExpectation(description: "Testing show failed")
         fullscreenMessage = FullscreenMessage(payload: mockHtml, listener: MockFullscreenListener(), isLocalImageUsed: false, messageMonitor: messageMonitor)
         fullscreenMessage?.show()
         wait(for: [FullscreenMessageTests.expectation!], timeout: 1.0)
         XCTAssertTrue(FullscreenMessageTests.onShowFailedCall)
-        
+
     }
 
     class MockFullscreenListener: FullscreenMessageDelegate {
@@ -88,7 +88,7 @@ class FullscreenMessageTests : XCTestCase {
         func overrideUrlLoad(message: FullscreenMessage, url: String?) -> Bool {
             return true
         }
-        
+
         func onShowFailed() {
             FullscreenMessageTests.onShowFailedCall = true
             FullscreenMessageTests.expectation?.fulfill()

--- a/AEPServices/Tests/services/MessageMonitorServiceTest.swift
+++ b/AEPServices/Tests/services/MessageMonitorServiceTest.swift
@@ -21,57 +21,58 @@ class MessageMonitorServiceTest : XCTestCase {
     static var onShowCall = false
     static var onDismissCall = false
     static var shouldShowMessageCall = false
-    var mockMessageMonitorService: MessageMonitorService?
+    var mockMessageMonitor: MessageMonitoring?
     var messageDelegate : MessagingDelegate?
-    var message: FullscreenPresentable = FullscreenMessage(payload: "", listener: nil, isLocalImageUsed: false)
+    var message: FullscreenPresentable?
 
     override func setUp() {
         MessageMonitorServiceTest.onShowCall = false
         MessageMonitorServiceTest.onDismissCall = false
         MessageMonitorServiceTest.mockShouldShow = true
-        mockMessageMonitorService = MessageMonitorService()
+        mockMessageMonitor = MessageMonitor()
+        message = FullscreenMessage(payload: "", listener: nil, isLocalImageUsed: false, messageMonitor: mockMessageMonitor!)
         messageDelegate = MockGlobalUIMessagingListener()
         ServiceProvider.shared.messagingDelegate = messageDelegate
     }
 
     func test_isMessageDisplayed_DefaultIsFalse() {
-        let isDisplayed = mockMessageMonitorService?.isMessageDisplayed()
+        let isDisplayed = mockMessageMonitor?.isMessageDisplayed()
         XCTAssertTrue((isDisplayed == false))
     }
 
     func test_isMessageDislayed_isTrue_whenDislayMessageCalled() {
-        mockMessageMonitorService?.displayMessage()
-        let display : Bool = mockMessageMonitorService?.isMessageDisplayed() == true
+        mockMessageMonitor?.displayMessage()
+        let display : Bool = mockMessageMonitor?.isMessageDisplayed() == true
         XCTAssertTrue(display)
     }
 
     func test_isMessageDislayed_isFalse_whenDismissMessageIsCalled() {
-        mockMessageMonitorService?.dismissMessage()
-        let display : Bool = mockMessageMonitorService?.isMessageDisplayed() == false
+        mockMessageMonitor?.dismissMessage()
+        let display : Bool = mockMessageMonitor?.isMessageDisplayed() == false
         XCTAssertTrue(display)
     }
 
     func test_show_whenMessageAlreadyDisplayed() {
-        mockMessageMonitorService?.displayMessage()
-        XCTAssertTrue(mockMessageMonitorService?.show(message: message) == false)
+        mockMessageMonitor?.displayMessage()
+        XCTAssertTrue(mockMessageMonitor?.show(message: message!) == false)
     }
 
     func test_show_withShouldShowMessageTrue() {
-        XCTAssertTrue(mockMessageMonitorService?.show(message: message) == true)
-        let display : Bool = mockMessageMonitorService?.isMessageDisplayed() == true
+        XCTAssertTrue(mockMessageMonitor?.show(message: message!) == true)
+        let display : Bool = mockMessageMonitor?.isMessageDisplayed() == true
         XCTAssertTrue(display)
     }
 
     func test_show_withShouldShowMessageFalse() {
         MessageMonitorServiceTest.mockShouldShow = false
-        XCTAssertTrue(mockMessageMonitorService?.show(message: message) == false)
-        let display : Bool = mockMessageMonitorService?.isMessageDisplayed() == false
+        XCTAssertTrue(mockMessageMonitor?.show(message: message!) == false)
+        let display : Bool = mockMessageMonitor?.isMessageDisplayed() == false
         XCTAssertTrue(display)
     }
 
     func test_dismiss_whenNoMessageToDismiss() {
-        mockMessageMonitorService?.dismissMessage()
-        XCTAssertTrue(mockMessageMonitorService?.dismiss() == false)
+        mockMessageMonitor?.dismissMessage()
+        XCTAssertTrue(mockMessageMonitor?.dismiss() == false)
     }
 
     class MockGlobalUIMessagingListener : MessagingDelegate {


### PR DESCRIPTION
Now that we are using a UIService to provide the UI elements, we no longer need the MessagingMonitor to be a service. 