### PR TITLE
Revert "Handle AdId to zero or empty on first launch (#530)"

### DIFF
--- a/AEPIdentity/Sources/IdentityState.swift
+++ b/AEPIdentity/Sources/IdentityState.swift
@@ -269,11 +269,7 @@ class IdentityState {
     /// - Returns: A tuple indicating if the ad id has changed, and if the consent flag should be added
     private func shouldUpdateAdId(newAdID: String?) -> (adIdChanged: Bool, addConsentFlag: Bool) {
         guard let newAdID = newAdID else { return (false, false) }
-        guard let existingAdId = identityProperties.advertisingIdentifier else {
-            // existing is nil but new is not, update with new and update consent
-            // covers first call case where existing ad ID is not set and new ad ID is empty/all zeros
-            return (true, true)
-        }
+        let existingAdId = identityProperties.advertisingIdentifier ?? ""
 
         // did the advertising identifier change?
         if (!newAdID.isEmpty && newAdID != existingAdId)

--- a/AEPIdentity/Tests/IdentityStateTests.swift
+++ b/AEPIdentity/Tests/IdentityStateTests.swift
@@ -328,60 +328,6 @@ class IdentityStateTests: XCTestCase {
         XCTAssertTrue(hit.url.absoluteString.contains("device_consent=1")) // device flag should be added
     }
 
-    /// Tests that the ad id is correctly updated when a new (all zero) value is passed (ad id changed from nil to all zero value), hit is successfully queued and device_consent is set to 0.
-    func testSyncIdentifiersAdIDIsUpdatedFromNilToZero() {
-        // setup
-        let configSharedState = [IdentityConstants.Configuration.EXPERIENCE_CLOUD_ORGID: "test-org",
-                                 IdentityConstants.Configuration.EXPERIENCE_CLOUD_SERVER: "test-server",
-                                 IdentityConstants.Configuration.GLOBAL_CONFIG_PRIVACY: PrivacyStatus.optedIn.rawValue] as [String: Any]
-        var props = IdentityProperties()
-        props.advertisingIdentifier = nil
-        state = IdentityState(identityProperties: props, hitQueue: MockHitQueue(processor: MockHitProcessor()), pushIdManager: mockPushIdManager)
-        state.lastValidConfig = configSharedState
-
-        // test
-        let data = [IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER: IdentityConstants.Default.ZERO_ADVERTISING_ID]
-        let event = Event(name: "Fake Sync Event", type: EventType.genericIdentity, source: EventSource.requestReset, data: data)
-        let eventData = state.syncIdentifiers(event: event)
-
-        // verify
-        XCTAssertEqual(1, eventData!.count)
-        XCTAssertNotNil(eventData![IdentityConstants.EventDataKeys.VISITOR_ID_ECID])
-        XCTAssertNil(eventData![IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER])
-        XCTAssertNil(eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST])
-        XCTAssertFalse(mockHitQueue.queuedHits.isEmpty) // hit should be queued in the hit queue
-        let hit = try! JSONDecoder().decode(IdentityHit.self, from: mockHitQueue.queuedHits.first!.data!)
-        XCTAssertTrue(hit.url.absoluteString.contains("device_consent=0")) // device flag should be added
-        XCTAssertTrue(hit.url.absoluteString.contains("d_consent_ic=DSID_20915")) // id namespace should be added
-    }
-
-    /// Tests that the ad id is correctly updated when a new (empty) value is passed (ad id changed from nil to empty), hit is successfully queued and device_consent is set to 0.
-    func testSyncIdentifiersAdIDIsUpdatedFromNilToEmpty() {
-        // setup
-        let configSharedState = [IdentityConstants.Configuration.EXPERIENCE_CLOUD_ORGID: "test-org",
-                                 IdentityConstants.Configuration.EXPERIENCE_CLOUD_SERVER: "test-server",
-                                 IdentityConstants.Configuration.GLOBAL_CONFIG_PRIVACY: PrivacyStatus.optedIn.rawValue] as [String: Any]
-        var props = IdentityProperties()
-        props.advertisingIdentifier = nil
-        state = IdentityState(identityProperties: props, hitQueue: MockHitQueue(processor: MockHitProcessor()), pushIdManager: mockPushIdManager)
-        state.lastValidConfig = configSharedState
-
-        // test
-        let data = [IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER: ""]
-        let event = Event(name: "Fake Sync Event", type: EventType.genericIdentity, source: EventSource.requestReset, data: data)
-        let eventData = state.syncIdentifiers(event: event)
-
-        // verify
-        XCTAssertEqual(1, eventData!.count)
-        XCTAssertNotNil(eventData![IdentityConstants.EventDataKeys.VISITOR_ID_ECID])
-        XCTAssertNil(eventData![IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER])
-        XCTAssertNil(eventData![IdentityConstants.EventDataKeys.VISITOR_IDS_LIST])
-        XCTAssertFalse(mockHitQueue.queuedHits.isEmpty) // hit should be queued in the hit queue
-        let hit = try! JSONDecoder().decode(IdentityHit.self, from: mockHitQueue.queuedHits.first!.data!)
-        XCTAssertTrue(hit.url.absoluteString.contains("device_consent=0")) // device flag should be added
-        XCTAssertTrue(hit.url.absoluteString.contains("d_consent_ic=DSID_20915")) // id namespace should be added
-    }
-
     /// Tests that the ad is is correctly updated when a new value is passed
     func testSyncIdentifiersAdIDIsUpdatedFromZeroString() {
         // setup


### PR DESCRIPTION
This reverts commit 670e707ae71deec39c913454de411ebd7c533fcc.

Per the specification for when the `device_consent` flag is added, when the persisted advertising identifier is nil or empty and the new advertising identifier is also an empty string, then Identity does not sync with the ID Service, even on the first time the API is called.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
