### PR TITLE
Add barrier flag when getting XDM shared state

### DIFF
--- a/AEPCore/Mocks/TestableExtensionRuntime.swift
+++ b/AEPCore/Mocks/TestableExtensionRuntime.swift
@@ -74,6 +74,10 @@ public class TestableExtensionRuntime: ExtensionRuntime {
         }
         return mockedXdmSharedStates["\(extensionName)"]
     }
+    
+    public func getXDMSharedState(extensionName: String, event: Event?, barrier: Bool) -> SharedStateResult? {
+        return getXDMSharedState(extensionName: extensionName, event: event)
+    }
 
     public func startEvents() {}
 

--- a/AEPCore/Mocks/TestableExtensionRuntime.swift
+++ b/AEPCore/Mocks/TestableExtensionRuntime.swift
@@ -74,7 +74,7 @@ public class TestableExtensionRuntime: ExtensionRuntime {
         }
         return mockedXdmSharedStates["\(extensionName)"]
     }
-    
+
     public func getXDMSharedState(extensionName: String, event: Event?, barrier: Bool) -> SharedStateResult? {
         return getXDMSharedState(extensionName: extensionName, event: event)
     }

--- a/AEPCore/Mocks/TestableExtensionRuntime.swift
+++ b/AEPCore/Mocks/TestableExtensionRuntime.swift
@@ -67,16 +67,12 @@ public class TestableExtensionRuntime: ExtensionRuntime {
         }
     }
 
-    public func getXDMSharedState(extensionName: String, event: Event?) -> SharedStateResult? {
+    public func getXDMSharedState(extensionName: String, event: Event?, barrier: Bool = false) -> SharedStateResult? {
         // if there is an shared state setup for the specific (extension, event id) pair, return it. Otherwise, return the shared state that is setup for the extension.
         if let id = event?.id {
             return mockedXdmSharedStates["\(extensionName)-\(id)"] ?? mockedXdmSharedStates["\(extensionName)"]
         }
         return mockedXdmSharedStates["\(extensionName)"]
-    }
-
-    public func getXDMSharedState(extensionName: String, event: Event?, barrier: Bool) -> SharedStateResult? {
-        return getXDMSharedState(extensionName: extensionName, event: event)
     }
 
     public func startEvents() {}

--- a/AEPCore/Sources/eventhub/Extension.swift
+++ b/AEPCore/Sources/eventhub/Extension.swift
@@ -143,9 +143,10 @@ public extension Extension {
     /// - Parameters:
     ///   - extensionName: An extension name whose `SharedState` will be returned
     ///   - event: If not nil, will retrieve the `SharedState` that corresponds with the event's version, if nil will return the latest `SharedState`
+    ///   - barrier: If true, the `EventHub` will only return `.set` if `extensionName` has moved past `event`
     /// - Returns: A `SharedStateResult?` for the requested `extensionName` and `event`
-    func getXDMSharedState(extensionName: String, event: Event?) -> SharedStateResult? {
-        return runtime.getXDMSharedState(extensionName: extensionName, event: event)
+    func getXDMSharedState(extensionName: String, event: Event?, barrier: Bool = false) -> SharedStateResult? {
+        return runtime.getXDMSharedState(extensionName: extensionName, event: event, barrier: barrier)
     }
 
     /// Called before each `Event` is processed by any `ExtensionListener` owned by this `Extension`

--- a/AEPCore/Sources/eventhub/ExtensionContainer.swift
+++ b/AEPCore/Sources/eventhub/ExtensionContainer.swift
@@ -120,11 +120,7 @@ extension ExtensionContainer: ExtensionRuntime {
         return EventHub.shared.createPendingSharedState(extensionName: sharedStateName, event: event, sharedStateType: .xdm)
     }
 
-    func getXDMSharedState(extensionName: String, event: Event?) -> SharedStateResult? {
-        return EventHub.shared.getSharedState(extensionName: extensionName, event: event, sharedStateType: .xdm)
-    }
-
-    func getXDMSharedState(extensionName: String, event: Event?, barrier: Bool) -> SharedStateResult? {
+    func getXDMSharedState(extensionName: String, event: Event?, barrier: Bool = false) -> SharedStateResult? {
         return EventHub.shared.getSharedState(extensionName: extensionName, event: event, barrier: barrier, sharedStateType: .xdm)
     }
 

--- a/AEPCore/Sources/eventhub/ExtensionContainer.swift
+++ b/AEPCore/Sources/eventhub/ExtensionContainer.swift
@@ -124,6 +124,10 @@ extension ExtensionContainer: ExtensionRuntime {
         return EventHub.shared.getSharedState(extensionName: extensionName, event: event, sharedStateType: .xdm)
     }
 
+    func getXDMSharedState(extensionName: String, event: Event?, barrier: Bool) -> SharedStateResult? {
+        return EventHub.shared.getSharedState(extensionName: extensionName, event: event, barrier: barrier, sharedStateType: .xdm)
+    }
+
     func startEvents() {
         eventOrderer.start()
     }

--- a/AEPCore/Sources/eventhub/ExtensionRuntime.swift
+++ b/AEPCore/Sources/eventhub/ExtensionRuntime.swift
@@ -93,4 +93,12 @@ public protocol ExtensionRuntime {
     ///   - event: If not nil, will retrieve the `SharedState` that corresponds with the event's version, if nil will return the latest `SharedState`
     /// - Returns: A `SharedStateResult?` for the requested `extensionName` and `event`
     func getXDMSharedState(extensionName: String, event: Event?) -> SharedStateResult?
+    
+    /// Gets the XDM SharedState data for a specified extension. If this extension populates multiple mixins in their shared state, all the data will be returned at once and it can be accessed using path discovery.
+    /// - Parameters:
+    ///   - extensionName: An extension name whose `SharedState` will be returned
+    ///   - event: If not nil, will retrieve the `SharedState` that corresponds with the event's version, if nil will return the latest `SharedState`
+    ///   - barrier: If true, the `EventHub` will only return `.set` if `extensionName` has moved past `event`
+    /// - Returns: A `SharedStateResult?` for the requested `extensionName` and `event`
+    func getXDMSharedState(extensionName: String, event: Event?, barrier: Bool) -> SharedStateResult?
 }

--- a/AEPCore/Sources/eventhub/ExtensionRuntime.swift
+++ b/AEPCore/Sources/eventhub/ExtensionRuntime.swift
@@ -93,7 +93,7 @@ public protocol ExtensionRuntime {
     ///   - event: If not nil, will retrieve the `SharedState` that corresponds with the event's version, if nil will return the latest `SharedState`
     /// - Returns: A `SharedStateResult?` for the requested `extensionName` and `event`
     func getXDMSharedState(extensionName: String, event: Event?) -> SharedStateResult?
-    
+
     /// Gets the XDM SharedState data for a specified extension. If this extension populates multiple mixins in their shared state, all the data will be returned at once and it can be accessed using path discovery.
     /// - Parameters:
     ///   - extensionName: An extension name whose `SharedState` will be returned

--- a/AEPCore/Sources/eventhub/ExtensionRuntime.swift
+++ b/AEPCore/Sources/eventhub/ExtensionRuntime.swift
@@ -91,13 +91,6 @@ public protocol ExtensionRuntime {
     /// - Parameters:
     ///   - extensionName: An extension name whose `SharedState` will be returned
     ///   - event: If not nil, will retrieve the `SharedState` that corresponds with the event's version, if nil will return the latest `SharedState`
-    /// - Returns: A `SharedStateResult?` for the requested `extensionName` and `event`
-    func getXDMSharedState(extensionName: String, event: Event?) -> SharedStateResult?
-
-    /// Gets the XDM SharedState data for a specified extension. If this extension populates multiple mixins in their shared state, all the data will be returned at once and it can be accessed using path discovery.
-    /// - Parameters:
-    ///   - extensionName: An extension name whose `SharedState` will be returned
-    ///   - event: If not nil, will retrieve the `SharedState` that corresponds with the event's version, if nil will return the latest `SharedState`
     ///   - barrier: If true, the `EventHub` will only return `.set` if `extensionName` has moved past `event`
     /// - Returns: A `SharedStateResult?` for the requested `extensionName` and `event`
     func getXDMSharedState(extensionName: String, event: Event?, barrier: Bool) -> SharedStateResult?

--- a/AEPIdentity/Tests/TestHelpers/TestableExtensionRuntime.swift
+++ b/AEPIdentity/Tests/TestHelpers/TestableExtensionRuntime.swift
@@ -66,7 +66,7 @@ class TestableExtensionRuntime: ExtensionRuntime {
         }
     }
 
-    public func getXDMSharedState(extensionName: String, event: Event?) -> SharedStateResult? {
+    public func getXDMSharedState(extensionName: String, event: Event?, barrier: Bool = false) -> SharedStateResult? {
         return otherXDMSharedStates["\(extensionName)-\(String(describing: event?.id))"] ?? nil
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds the ability to specify barrier flag when reading XDM shared state.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
