### PR TITLE
[AMSDK-10268]Handle Analytics response identity events (#584)

### DIFF
--- a/AEPIdentity/Sources/Event+Identity.swift
+++ b/AEPIdentity/Sources/Event+Identity.swift
@@ -67,4 +67,9 @@ extension Event {
     var optOutHitSent: Bool {
         return data?[IdentityConstants.Audience.OPTED_OUT_HIT_SENT] as? Bool ?? false
     }
+
+    /// Reads the Analytics id if present in event data
+    var aid: String? {
+        return data?[IdentityConstants.Analytics.ANALYTICS_ID] as? String
+    }
 }

--- a/AEPIdentity/Sources/Identity.swift
+++ b/AEPIdentity/Sources/Identity.swift
@@ -45,6 +45,7 @@ import Foundation
         registerListener(type: EventType.genericIdentity, source: EventSource.requestContent, listener: handleIdentityRequest)
         registerListener(type: EventType.configuration, source: EventSource.requestIdentity, listener: receiveConfigurationIdentity(event:))
         registerListener(type: EventType.configuration, source: EventSource.responseContent, listener: handleConfigurationResponse)
+        registerListener(type: EventType.analytics, source: EventSource.responseIdentity, listener: handleAnalyticsResponseIdentity)
         registerListener(type: EventType.audienceManager, source: EventSource.responseContent, listener: handleAudienceResponse(event:))
     }
 
@@ -146,6 +147,11 @@ import Foundation
                                                       source: EventSource.responseIdentity,
                                                       data: eventData as [String: Any])
         dispatch(event: responseEvent)
+    }
+    /// Handles the analytics response event and dispatch an "AVID Sync" event
+    /// - Parameter event: the analytics response event
+    private func handleAnalyticsResponseIdentity(event: Event) {
+        state?.handleAnalyticsResponse(event: event, eventDispatcher: dispatch(event:))
     }
 
     /// Handles Audience Response Content events containing a flag which signals if the opt-out hit was sent by the Audience Extension.

--- a/AEPIdentity/Sources/IdentityConstants.swift
+++ b/AEPIdentity/Sources/IdentityConstants.swift
@@ -47,6 +47,7 @@ enum IdentityConstants {
         static let IDENTITY_RESPONSE_CONTENT_ONE_TIME = "IDENTITY_RESPONSE_CONTENT_ONE_TIME"
         static let IDENTITY_URL_VARIABLES = "IDENTITY_URL_VARIABLES"
         static let UPDATED_IDENTITY_RESPONSE = "UPDATED_IDENTITY_RESPONSE"
+        static let AVID_SYNC_EVENT = "AVID Sync"
     }
 
     enum EventDataKeys {
@@ -65,6 +66,7 @@ enum IdentityConstants {
         static let VISITOR_ID_LOCATION_HINT = "locationhint"
         static let VISITOR_IDS_LAST_SYNC = "lastsync"
         static let MCPNS_DPID = "20920"
+        static let ANALYTICS_ID = "AVID"
     }
 
     enum DataStoreKeys {

--- a/AEPIdentity/Sources/IdentityProperties.swift
+++ b/AEPIdentity/Sources/IdentityProperties.swift
@@ -46,6 +46,9 @@ struct IdentityProperties: Codable {
     /// The current privacy status provided by the Configuration extension, defaults to `unknown`
     var privacyStatus = PrivacyStatus.unknown
 
+    /// The aid synced status for handle analytics response event, set defaults to `false`
+    var isAidSynced: Bool? = false
+
     /// Converts `IdentityProperties` into an event data representation
     /// - Returns: A dictionary representing this `IdentityProperties`
     func toEventData() -> [String: Any] {

--- a/AEPIdentity/Tests/IdentityTests.swift
+++ b/AEPIdentity/Tests/IdentityTests.swift
@@ -326,4 +326,67 @@ class IdentityTests: XCTestCase {
         let mockNetworkService = ServiceProvider.shared.networkService as! MockNetworkServiceOverrider
         XCTAssertFalse(mockNetworkService.connectAsyncCalled) // network request for opt-out hit shouldn't have been sent
     }
+
+    /// Tests that when receives a valid analytics event and response identity event source that we dispatch an Avid Sync event
+    func testAnalyticsResponseIdentityHappy() {
+        // setup
+        let eventData = [IdentityConstants.Analytics.ANALYTICS_ID: "aid" ] as [String: Any]
+        let event = Event(name: "Test Analytics Response Identity", type: EventType.analytics, source: EventSource.responseIdentity, data: eventData)
+
+        // test
+        mockRuntime.simulateComingEvent(event: event)
+
+        // verify
+        let actualEvent = mockRuntime.dispatchedEvents.first(where: { $0.source == EventSource.requestIdentity })
+        XCTAssertNotNil(actualEvent)
+        XCTAssertNotNil(actualEvent?.id)
+        XCTAssertEqual(IdentityConstants.EventNames.AVID_SYNC_EVENT, actualEvent?.name)
+        XCTAssertEqual(EventType.identity, actualEvent?.type)
+        let identifierValue = [IdentityConstants.EventDataKeys.ANALYTICS_ID: "aid" ] as [String: String]
+        XCTAssertEqual(identifierValue, actualEvent?.data?[IdentityConstants.EventDataKeys.IDENTIFIERS]as? [String: String] )
+        XCTAssertEqual(false, actualEvent?.data?[IdentityConstants.EventDataKeys.FORCE_SYNC]as? Bool)
+        XCTAssertEqual(true, actualEvent?.data?[IdentityConstants.EventDataKeys.IS_SYNC_EVENT]as? Bool)
+        XCTAssertEqual(0, actualEvent?.data?[IdentityConstants.EventDataKeys.AUTHENTICATION_STATE]as? Int)
+    }
+
+    /// Tests Handle Analytics Response Identity with empty aid that we don't dispatch an event
+    func testAnalyticsResponseIdentityWithEmptyAid() {
+        // setup
+        let eventData = [IdentityConstants.Analytics.ANALYTICS_ID: "" ] as [String: Any]
+        let event = Event(name: "Test Analytics Response Identity", type: EventType.analytics, source: EventSource.responseIdentity, data: eventData)
+
+        // test
+        mockRuntime.simulateComingEvent(event: event)
+
+        // verify
+        let actualEvent = mockRuntime.dispatchedEvents.first(where: { $0.source == EventSource.requestIdentity })
+        XCTAssertNil(actualEvent)
+    }
+
+    /// Tests Handle Analytics Response Identity with no aid key that we don't dispatch an event
+    func testAnalyticsResponseIdentityWithNoAid() {
+        // setup
+        let eventData = ["key": "aid" ] as [String: Any]
+        let event = Event(name: "Test Analytics Response Identity", type: EventType.analytics, source: EventSource.responseIdentity, data: eventData)
+
+        // test
+        mockRuntime.simulateComingEvent(event: event)
+
+        // verify
+        let actualEvent = mockRuntime.dispatchedEvents.first(where: { $0.source == EventSource.requestIdentity })
+        XCTAssertNil(actualEvent)
+    }
+
+    /// Tests Handle Analytics Response Identity with no event data that we don't dispatch an event
+    func testAnalyticsResponseIdentityWithNoEventData() {
+        // setup
+        let event = Event(name: "Test Analytics Response Identity", type: EventType.analytics, source: EventSource.responseIdentity, data: nil)
+
+        // test
+        mockRuntime.simulateComingEvent(event: event)
+
+        // verify
+        let actualEvent = mockRuntime.dispatchedEvents.first(where: { $0.source == EventSource.requestIdentity })
+        XCTAssertNil(actualEvent)
+    }
 }


### PR DESCRIPTION
* fix link in doc

* Update Event.md (#579)

* Identity-Handle Analytics response identity events

Listen for Analytics response identity event
Dispatch Avid sync event
Add unit tests

* refactor the code

refactor the code move logic out of identity.swift

* Change isAdSynced in properties optional.

Change isAdSynced in properties optional

* Revert "Merge branch 'main' of github.com:adobe/aepsdk-core-ios into Identity_handleAnalyticsIdentity"

This reverts commit 7656fa79e1d1c5e50db3b53f66b3d26a6fb0d6ec, reversing
changes made to 951ac9075d2d5cf74b63d7b04d909367fb75b83f.

* Updates for review comments

Updates for review comments

Co-authored-by: Steve Benedick <sbenedic@adobe.com>
Co-authored-by: Nick Porter <43650450+nporter-adbe@users.noreply.github.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
