### PR TITLE
[AMSDK-11201] - Differentiate XDM vs standard shared state via eventName

### DIFF
--- a/AEPCore/Sources/eventhub/EventHubConstants.swift
+++ b/AEPCore/Sources/eventhub/EventHubConstants.swift
@@ -13,7 +13,8 @@ import Foundation
 
 /// Constant values used throughout `EventHub`
 enum EventHubConstants {
-    static let STATE_CHANGE = "STATE_CHANGE_EVENT"
+    static let STATE_CHANGE = "Shared state change"
+    static let XDM_STATE_CHANGE = "Shared state change (XDM)"
     static let NAME = "com.adobe.module.eventhub"
     static let FRIENDLY_NAME = "EventHub"
     static let VERSION_NUMBER = "3.1.0"

--- a/AEPCore/Tests/EventHubTests/EventHubTests.swift
+++ b/AEPCore/Tests/EventHubTests/EventHubTests.swift
@@ -1027,8 +1027,8 @@ class EventHubTests: XCTestCase {
 
         let event = Event(name: "test", type: EventType.acquisition, source: EventSource.requestContent, data: nil)
         eventHub.getExtensionContainer(MockExtension.self)?.registerListener(type: EventType.hub, source: EventSource.sharedState) { event in
-            XCTAssertEqual(event.name, EventHubConstants.STATE_CHANGE)
             if event.data?[EventHubConstants.EventDataKeys.Configuration.EVENT_STATE_OWNER] as! String == EventHubTests.MOCK_EXTENSION_NAME {
+                XCTAssertEqual(event.name, EventHubConstants.STATE_CHANGE)
                 expectation.fulfill()
             }
         }
@@ -1052,8 +1052,8 @@ class EventHubTests: XCTestCase {
 
         let event = Event(name: "test", type: EventType.acquisition, source: EventSource.requestContent, data: nil)
         eventHub.getExtensionContainer(MockExtension.self)?.registerListener(type: EventType.hub, source: EventSource.sharedState) { event in
-            XCTAssertEqual(event.name, EventHubConstants.STATE_CHANGE)
             if event.data?[EventHubConstants.EventDataKeys.Configuration.EVENT_STATE_OWNER] as! String == EventHubTests.MOCK_EXTENSION_NAME {
+                XCTAssertEqual(event.name, EventHubConstants.XDM_STATE_CHANGE)
                 expectation.fulfill()
             }
         }

--- a/AEPCore/Tests/FunctionalTests/EventHubContractTests.swift
+++ b/AEPCore/Tests/FunctionalTests/EventHubContractTests.swift
@@ -124,7 +124,7 @@ class EventHubContractTest: XCTestCase {
         let sharedStateEventExpectation = XCTestExpectation(description: "Event Hub shared stated event is received")
         ContractExtensionOne.eventReceivedClosure = { event in
             switch event.name{
-            case "STATE_CHANGE_EVENT":
+            case "Shared state change":
                 sharedStateEventExpectation.fulfill()
             default:
                 XCTAssertFalse(true)
@@ -156,7 +156,7 @@ class EventHubContractTest: XCTestCase {
                 firstEventExpectation.fulfill()
             case "second":
                 secondEventExpectation.fulfill()
-            case "STATE_CHANGE_EVENT":
+            case "Shared state change":
                 sharedStateEventExpectation.fulfill()
             default:
                 XCTAssertFalse(true)


### PR DESCRIPTION
Different eventName to differentiate between XDM vs standard shared state change event

Standard state change event name = "Shared state change"
XDM state change event name = "Shared state change (XDM)"

Unit tests are updated