### PR TITLE
Only share event hub state after started

### DIFF
--- a/AEPCore/Tests/MobileCoreTests.swift
+++ b/AEPCore/Tests/MobileCoreTests.swift
@@ -223,16 +223,20 @@ class MobileCoreTests: XCTestCase {
 
         // test
         MobileCore.registerExtensions([MockExtension.self, MockExtensionTwo.self], {
-            sleep(UInt32(2))
-            let registered = MobileCore.getRegisteredExtensions()
-            let registeredDict = self.jsonStrToDict(jsonStr: registered)?["extensions"] as? Dictionary<String, Any>
-            let equal = NSDictionary(dictionary: registeredDict!).isEqual(to: expectedDict!)
-            XCTAssertTrue(equal)
-            expectation.fulfill()
+            EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(type: EventType.hub, source: EventSource.sharedState) { event in
+                if event.data?[EventHubConstants.EventDataKeys.Configuration.EVENT_STATE_OWNER] as? String == EventHubConstants.NAME {
+                    let registered = MobileCore.getRegisteredExtensions()
+                    let registeredDict = self.jsonStrToDict(jsonStr: registered)?["extensions"] as? Dictionary<String, Any>
+                    let equal = NSDictionary(dictionary: registeredDict!).isEqual(to: expectedDict!)
+                    XCTAssertTrue(equal)
+                    expectation.fulfill()
+                    
+                }
+            }
         })
 
         // verify
-        wait(for: [expectation], timeout: 0.25)
+        wait(for: [expectation], timeout: 1)
     }
 
     private func jsonStrToDict(jsonStr: String) -> [String: Any]? {

--- a/AEPCore/Tests/MobileCoreTests.swift
+++ b/AEPCore/Tests/MobileCoreTests.swift
@@ -223,6 +223,7 @@ class MobileCoreTests: XCTestCase {
 
         // test
         MobileCore.registerExtensions([MockExtension.self, MockExtensionTwo.self], {
+            sleep(UInt32(0.5))
             let registered = MobileCore.getRegisteredExtensions()
             let registeredDict = self.jsonStrToDict(jsonStr: registered)?["extensions"] as? Dictionary<String, Any>
             let equal = NSDictionary(dictionary: registeredDict!).isEqual(to: expectedDict!)

--- a/AEPCore/Tests/MobileCoreTests.swift
+++ b/AEPCore/Tests/MobileCoreTests.swift
@@ -230,7 +230,7 @@ class MobileCoreTests: XCTestCase {
                     let equal = NSDictionary(dictionary: registeredDict!).isEqual(to: expectedDict!)
                     XCTAssertTrue(equal)
                     expectation.fulfill()
-                    
+
                 }
             }
         })

--- a/AEPCore/Tests/MobileCoreTests.swift
+++ b/AEPCore/Tests/MobileCoreTests.swift
@@ -223,7 +223,7 @@ class MobileCoreTests: XCTestCase {
 
         // test
         MobileCore.registerExtensions([MockExtension.self, MockExtensionTwo.self], {
-            sleep(UInt32(0.5))
+            sleep(UInt32(2))
             let registered = MobileCore.getRegisteredExtensions()
             let registeredDict = self.jsonStrToDict(jsonStr: registered)?["extensions"] as? Dictionary<String, Any>
             let equal = NSDictionary(dictionary: registeredDict!).isEqual(to: expectedDict!)

--- a/AEPServices/Sources/utility/AtomicCounter.swift
+++ b/AEPServices/Sources/utility/AtomicCounter.swift
@@ -19,4 +19,5 @@ public final class AtomicCounter {
     public func incrementAndGet() -> Int {
         return Int(OSAtomicIncrement32(&count))
     }
+
 }

--- a/AEPServices/Sources/utility/AtomicCounter.swift
+++ b/AEPServices/Sources/utility/AtomicCounter.swift
@@ -19,5 +19,4 @@ public final class AtomicCounter {
     public func incrementAndGet() -> Int {
         return Int(OSAtomicIncrement32(&count))
     }
-
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If an extension is registered by itself via `registerExtension` before `registerExtensions` it causes an extra EventHub shared state to be dispatched. This PR adds an optimization to only share the EventHub shared state after it has been started.

I ran the sample app that was described in https://github.com/adobe/aepsdk-core-ios/issues/596 and confirmed that now only 1 EventHub shared state is published.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
