### PR TITLE
Only share event hub state after started

### DIFF
--- a/AEPCore/Tests/MobileCoreTests.swift
+++ b/AEPCore/Tests/MobileCoreTests.swift
@@ -223,16 +223,20 @@ class MobileCoreTests: XCTestCase {
 
         // test
         MobileCore.registerExtensions([MockExtension.self, MockExtensionTwo.self], {
-            sleep(UInt32(2))
-            let registered = MobileCore.getRegisteredExtensions()
-            let registeredDict = self.jsonStrToDict(jsonStr: registered)?["extensions"] as? Dictionary<String, Any>
-            let equal = NSDictionary(dictionary: registeredDict!).isEqual(to: expectedDict!)
-            XCTAssertTrue(equal)
-            expectation.fulfill()
+            EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(type: EventType.hub, source: EventSource.sharedState) { event in
+                if event.data?[EventHubConstants.EventDataKeys.Configuration.EVENT_STATE_OWNER] as? String == EventHubConstants.NAME {
+                    let registered = MobileCore.getRegisteredExtensions()
+                    let registeredDict = self.jsonStrToDict(jsonStr: registered)?["extensions"] as? Dictionary<String, Any>
+                    let equal = NSDictionary(dictionary: registeredDict!).isEqual(to: expectedDict!)
+                    XCTAssertTrue(equal)
+                    expectation.fulfill()
+                    
+                }
+            }
         })
 
         // verify
-        wait(for: [expectation], timeout: 0.25)
+        wait(for: [expectation], timeout: 1)
     }
 
     private func jsonStrToDict(jsonStr: String) -> [String: Any]? {

--- a/AEPCore/Tests/MobileCoreTests.swift
+++ b/AEPCore/Tests/MobileCoreTests.swift
@@ -223,6 +223,7 @@ class MobileCoreTests: XCTestCase {
 
         // test
         MobileCore.registerExtensions([MockExtension.self, MockExtensionTwo.self], {
+            sleep(UInt32(0.5))
             let registered = MobileCore.getRegisteredExtensions()
             let registeredDict = self.jsonStrToDict(jsonStr: registered)?["extensions"] as? Dictionary<String, Any>
             let equal = NSDictionary(dictionary: registeredDict!).isEqual(to: expectedDict!)

--- a/AEPCore/Tests/MobileCoreTests.swift
+++ b/AEPCore/Tests/MobileCoreTests.swift
@@ -230,7 +230,7 @@ class MobileCoreTests: XCTestCase {
                     let equal = NSDictionary(dictionary: registeredDict!).isEqual(to: expectedDict!)
                     XCTAssertTrue(equal)
                     expectation.fulfill()
-                    
+
                 }
             }
         })

--- a/AEPCore/Tests/MobileCoreTests.swift
+++ b/AEPCore/Tests/MobileCoreTests.swift
@@ -223,7 +223,7 @@ class MobileCoreTests: XCTestCase {
 
         // test
         MobileCore.registerExtensions([MockExtension.self, MockExtensionTwo.self], {
-            sleep(UInt32(0.5))
+            sleep(UInt32(2))
             let registered = MobileCore.getRegisteredExtensions()
             let registeredDict = self.jsonStrToDict(jsonStr: registered)?["extensions"] as? Dictionary<String, Any>
             let equal = NSDictionary(dictionary: registeredDict!).isEqual(to: expectedDict!)

--- a/AEPServices/Sources/utility/AtomicCounter.swift
+++ b/AEPServices/Sources/utility/AtomicCounter.swift
@@ -19,4 +19,5 @@ public final class AtomicCounter {
     public func incrementAndGet() -> Int {
         return Int(OSAtomicIncrement32(&count))
     }
+
 }

--- a/AEPServices/Sources/utility/AtomicCounter.swift
+++ b/AEPServices/Sources/utility/AtomicCounter.swift
@@ -19,5 +19,4 @@ public final class AtomicCounter {
     public func incrementAndGet() -> Int {
         return Int(OSAtomicIncrement32(&count))
     }
-
 }


### PR DESCRIPTION
If an extension is registered by itself via registerExtension before registerExtensions it causes an extra EventHub shared state to be dispatched. This PR adds an optimization to only share the EventHub shared state after it has been started.

I ran the sample app that was described in #596 and confirmed that now only 1 EventHub shared state is published.