### PR TITLE
Require extensions to be NSObjects

### DIFF
--- a/AEPCore/Sources/eventhub/EventHubPlaceholderExtension.swift
+++ b/AEPCore/Sources/eventhub/EventHubPlaceholderExtension.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 /// An `Extension` for `EventHub`. This serves no purpose other than to allow `EventHub` to share state.
-class EventHubPlaceholderExtension: Extension {
+class EventHubPlaceholderExtension: NSObject, Extension {
     let name = EventHubConstants.NAME
     let friendlyName = EventHubConstants.FRIENDLY_NAME
     static let extensionVersion = EventHubConstants.VERSION_NUMBER

--- a/AEPCore/Sources/eventhub/Extension.swift
+++ b/AEPCore/Sources/eventhub/Extension.swift
@@ -15,7 +15,7 @@ import Foundation
 // MARK: - Extension protocol
 /// An object which can be registered with the `EventHub`
 @objc(AEPExtension)
-public protocol Extension {
+public protocol Extension where Self: NSObject {
     /// Name of the extension
     var name: String { get }
 


### PR DESCRIPTION
Since our APIs require them to be NSObject's, I think we should enforce it on our protocol.