### PR TITLE
Fix log warnings

### DIFF
--- a/AEPServices/Sources/utility/PrettyDictionary.swift
+++ b/AEPServices/Sources/utility/PrettyDictionary.swift
@@ -17,7 +17,7 @@ public enum PrettyDictionary {
     ///
     /// - Parameter dictionary: `Dictionary` to be prettified
     /// - Returns: `JSON` string
-    public static func prettify(_ dictionary: [String: Any]?) -> String {
+    public static func prettify(_ dictionary: [String: Any?]?) -> String {
         guard let dictionary = dictionary else {
             return ""
         }

--- a/AEPServices/Tests/utility/PrettyDictionaryTests.swift
+++ b/AEPServices/Tests/utility/PrettyDictionaryTests.swift
@@ -41,6 +41,33 @@ class PrettyDictionaryTests: XCTestCase {
         XCTAssert(output.contains("AEPServices.LogLevel"))
     }
 
+    func testPrintEventData_as_AnyObjectWithNil() throws {
+        var eventData = [String: Any?]()
+        eventData = [
+            "a": "13435454",
+            "b":[
+                "b1": 1235566,
+                "b2": LogLevel.debug
+            ],
+            "c": nil
+        ]
+        let output = "\(PrettyDictionary.prettify(eventData))"
+        let expected = """
+        {
+            a = 13435454;
+            b = {
+                b1 = 1235566;
+                b2 = "AEPServices.LogLevel";
+            };
+        }
+        """
+        print(output)
+        print(expected)
+        XCTAssert(output.contains("13435454;"))
+        XCTAssert(output.contains("AEPServices.LogLevel"))
+        XCTAssert(output.contains("null"))
+    }
+
     func testPrintEventData_with_prettifiedJsonString() throws {
         var eventData = [String: Any]()
         eventData = [


### PR DESCRIPTION
Fixes two warnings coming from casting a [String: Any?] to [String: Any]