### PR TITLE
[MOB-14414] - API to set the starting position of floating button

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -333,6 +333,7 @@
 		92F06BFC25B8F1FE004C1700 /* MessageMonitoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F06BFB25B8F1FE004C1700 /* MessageMonitoring.swift */; };
 		92F06D0425BA33F4004C1700 /* Showable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F06D0325BA33F3004C1700 /* Showable.swift */; };
 		B2F223F8573D6B132F285AD7 /* Pods_AEPLifecycleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6A7B39F8D2A807344E7098B /* Pods_AEPLifecycleTests.framework */; };
+		B6D6A019265EC9D8005042BE /* FloatingButtonPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D6A018265EC9D8005042BE /* FloatingButtonPosition.swift */; };
 		B87CF27D61573F409CEDF5E9 /* Pods_AEPSignalTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 451696B755E6DEB6897A8892 /* Pods_AEPSignalTests.framework */; };
 		BB00E26824D8C94600C578C1 /* TokenFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00E26624D8C94600C578C1 /* TokenFinder.swift */; };
 		BB00E26924D8C94600C578C1 /* Dictionary+Flatten.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00E26724D8C94600C578C1 /* Dictionary+Flatten.swift */; };
@@ -927,6 +928,7 @@
 		9444FBB20EFFE94F7726A49F /* Pods_AEPCoreTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AEPCoreTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A63AA3E0DA8692271AC7C724 /* Pods-AEPLifecycleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPLifecycleTests.release.xcconfig"; path = "Target Support Files/Pods-AEPLifecycleTests/Pods-AEPLifecycleTests.release.xcconfig"; sourceTree = "<group>"; };
 		B414FF5745B34BC95CF624DC /* Pods_AEPIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AEPIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B6D6A018265EC9D8005042BE /* FloatingButtonPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingButtonPosition.swift; sourceTree = "<group>"; };
 		BB00E26624D8C94600C578C1 /* TokenFinder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenFinder.swift; sourceTree = "<group>"; };
 		BB00E26724D8C94600C578C1 /* Dictionary+Flatten.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Flatten.swift"; sourceTree = "<group>"; };
 		BB00E26A24D8C9A600C578C1 /* Date+Format.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+Format.swift"; sourceTree = "<group>"; };
@@ -1852,6 +1854,7 @@
 				923547FB25BFF18200BEA9A3 /* FloatingButton.swift */,
 				9235481925BFF19800BEA9A3 /* FloatingButtonDelegate.swift */,
 				78B36AED25CA210E00D6D25F /* FloatingButtonPresentable.swift */,
+				B6D6A018265EC9D8005042BE /* FloatingButtonPosition.swift */,
 			);
 			path = floating;
 			sourceTree = "<group>";
@@ -2988,6 +2991,7 @@
 				92EEA5F6258933A600DBA3EE /* FullscreenMessageDelegate.swift in Sources */,
 				3F0397FE24BE60910019F095 /* URLEncoder.swift in Sources */,
 				7814B23325CB455200841429 /* URL+Validator.swift in Sources */,
+				B6D6A019265EC9D8005042BE /* FloatingButtonPosition.swift in Sources */,
 				3F0397FF24BE60910019F095 /* AnyCodable.swift in Sources */,
 				3F0397D124BE5FF30019F095 /* HttpConnection.swift in Sources */,
 				3F0397D824BE5FF30019F095 /* DataQueuing.swift in Sources */,

--- a/AEPServices/Sources/UIUtils.swift
+++ b/AEPServices/Sources/UIUtils.swift
@@ -23,7 +23,7 @@ struct UIUtils {
         guard let screenBounds: CGSize = keyWindow?.frame.size else { return nil }
         newFrame.size = screenBounds
 
-        // y is dependant on visibility and height
+        // y is dependent on visibility and height
         newFrame.origin.y = 0
         return newFrame
     }

--- a/AEPServices/Sources/ui/floating/FloatingButton.swift
+++ b/AEPServices/Sources/ui/floating/FloatingButton.swift
@@ -19,13 +19,15 @@ public class FloatingButton: NSObject, FloatingButtonPresentable {
 
     private let LOG_PREFIX = "FloatingButton"
 
-    private let PREVIEW_BUTTON_WIDTH = 60
-    private let PREVIEW_BUTTON_HEIGHT = 60
+    internal static let BUTTON_TOP_MARGIN = 40
+    internal static let PREVIEW_BUTTON_WIDTH = 60
+    internal static let PREVIEW_BUTTON_HEIGHT = 60
 
     private var singleTap: UITapGestureRecognizer?
     private var panner: UIPanGestureRecognizer?
     private var timer: Timer?
     private var buttonImageView: UIImageView?
+    private var buttonPosition: FloatingButtonPosition = .center
 
     private var listener: FloatingButtonDelegate?
 
@@ -68,6 +70,10 @@ public class FloatingButton: NSObject, FloatingButtonPresentable {
         DispatchQueue.main.async {
             self.buttonImageView?.image = image
         }
+    }
+
+    public func setInitialPosition(position: FloatingButtonPosition) {
+        buttonPosition = position
     }
 
     private func initFloatingButton() -> Bool {
@@ -113,14 +119,12 @@ public class FloatingButton: NSObject, FloatingButtonPresentable {
         if let buttonImageView = self.buttonImageView {
             keyWindow?.addSubview(buttonImageView)
             keyWindow?.bringSubviewToFront(buttonImageView)
-            guard let screenBounds = keyWindow?.frame.size else {
-                Log.debug(label: LOG_PREFIX, "Floating button couldn't be displayed, screenbound is nil.")
-                return false
-            }
-            UIView.animate(withDuration: 0.3, animations: {
-                var finalFrame = buttonImageView.frame
-                finalFrame.origin.x = (screenBounds.width - CGFloat(self.PREVIEW_BUTTON_WIDTH)) / 2
-                buttonImageView.frame = finalFrame
+
+            // set the initial position for animation
+            buttonImageView.frame.origin.x = buttonImageView.frame.origin.x + CGFloat(FloatingButton.PREVIEW_BUTTON_WIDTH)
+            // animate the x-axis of the button to its original position
+            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseIn, animations: {
+                buttonImageView.frame.origin.x = buttonImageView.frame.origin.x - CGFloat(FloatingButton.PREVIEW_BUTTON_WIDTH)
             }, completion: nil)
 
             // Notifiying global listeners
@@ -180,7 +184,7 @@ public class FloatingButton: NSObject, FloatingButtonPresentable {
         let size: CGSize? = newFrame.size
 
         if let screenBounds: CGSize = size {
-            newFrame = CGRect(x: (Int(screenBounds.width) - PREVIEW_BUTTON_WIDTH) - 30 / 2, y: (Int(screenBounds.height) - PREVIEW_BUTTON_HEIGHT) / 2, width: PREVIEW_BUTTON_WIDTH, height: PREVIEW_BUTTON_HEIGHT)
+            newFrame = buttonPosition.frame(screenBounds: screenBounds)
         }
 
         return newFrame

--- a/AEPServices/Sources/ui/floating/FloatingButton.swift
+++ b/AEPServices/Sources/ui/floating/FloatingButton.swift
@@ -72,7 +72,7 @@ public class FloatingButton: NSObject, FloatingButtonPresentable {
         }
     }
 
-    public func setInitialPosition(position: FloatingButtonPosition) {
+    public func setInitial(position: FloatingButtonPosition) {
         buttonPosition = position
     }
 
@@ -121,13 +121,13 @@ public class FloatingButton: NSObject, FloatingButtonPresentable {
             keyWindow?.bringSubviewToFront(buttonImageView)
 
             // set the initial position for animation
-            buttonImageView.frame.origin.x = buttonImageView.frame.origin.x + CGFloat(FloatingButton.PREVIEW_BUTTON_WIDTH)
+            buttonImageView.frame.origin.x += CGFloat(FloatingButton.PREVIEW_BUTTON_WIDTH)
             // animate the x-axis of the button to its original position
             UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseIn, animations: {
-                buttonImageView.frame.origin.x = buttonImageView.frame.origin.x - CGFloat(FloatingButton.PREVIEW_BUTTON_WIDTH)
+                buttonImageView.frame.origin.x -= CGFloat(FloatingButton.PREVIEW_BUTTON_WIDTH)
             }, completion: nil)
 
-            // Notifiying global listeners
+            // Notifying global listeners
             self.listener?.onShow()
         }
         return true

--- a/AEPServices/Sources/ui/floating/FloatingButtonPosition.swift
+++ b/AEPServices/Sources/ui/floating/FloatingButtonPosition.swift
@@ -1,0 +1,9 @@
+//
+//  FloatingButtonPosition.swift
+//  AEPServices
+//
+//  Created by pprakash on 5/26/21.
+//  Copyright © 2021 Adobe. All rights reserved.
+//
+
+import Foundation

--- a/AEPServices/Sources/ui/floating/FloatingButtonPosition.swift
+++ b/AEPServices/Sources/ui/floating/FloatingButtonPosition.swift
@@ -1,9 +1,44 @@
-//
-//  FloatingButtonPosition.swift
-//  AEPServices
-//
-//  Created by pprakash on 5/26/21.
-//  Copyright © 2021 Adobe. All rights reserved.
-//
+/*
+ Copyright 2021 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
 
 import Foundation
+import UIKit
+
+@objc(AEPFloatingButtonPosition) public enum FloatingButtonPosition: Int {
+
+    case center
+    case topRight
+    case topLeft
+
+    internal func frame(screenBounds: CGSize) -> CGRect {
+        switch self {
+        case .center:
+            return CGRect(x: (Int(screenBounds.width) - FloatingButton.PREVIEW_BUTTON_WIDTH) / 2,
+                          y: (Int(screenBounds.height) - FloatingButton.PREVIEW_BUTTON_HEIGHT) / 2,
+                          width: FloatingButton.PREVIEW_BUTTON_WIDTH,
+                          height: FloatingButton.PREVIEW_BUTTON_HEIGHT)
+
+        case .topRight:
+            return CGRect(x: (Int(screenBounds.width) - FloatingButton.PREVIEW_BUTTON_WIDTH),
+                          y: FloatingButton.BUTTON_TOP_MARGIN,
+                          width: FloatingButton.PREVIEW_BUTTON_WIDTH,
+                          height: FloatingButton.PREVIEW_BUTTON_HEIGHT)
+
+        case .topLeft:
+            return CGRect(x: 0,
+                          y: FloatingButton.BUTTON_TOP_MARGIN,
+                          width: FloatingButton.PREVIEW_BUTTON_WIDTH,
+                          height: FloatingButton.PREVIEW_BUTTON_HEIGHT)
+        }
+
+    }
+}

--- a/AEPServices/Sources/ui/floating/FloatingButtonPresentable.swift
+++ b/AEPServices/Sources/ui/floating/FloatingButtonPresentable.swift
@@ -29,5 +29,5 @@ public protocol FloatingButtonPresentable: Showable, Dismissible {
     /// Call this method before calling `floatingButton.show()` to set the position of the floating button when it appears.
     /// - Parameters:
     ///     - position : The `FloatingButtonPosition` defining the initial position of the floating button.
-    func setInitialPosition(position: FloatingButtonPosition)
+    func setInitial(position: FloatingButtonPosition)
 }

--- a/AEPServices/Sources/ui/floating/FloatingButtonPresentable.swift
+++ b/AEPServices/Sources/ui/floating/FloatingButtonPresentable.swift
@@ -23,4 +23,11 @@ public protocol FloatingButtonPresentable: Showable, Dismissible {
     /// - Parameters:
     ///     - imageData : The `Data` representation of a UIImage
     func setButtonImage(imageData: Data)
+
+    /// Set the initial position of floating button.
+    /// By default the initial position is set to `FloatingButtonPosition.center`.
+    /// Call this method before calling `floatingButton.show()` to set the position of the floating button when it appears.
+    /// - Parameters:
+    ///     - position : The `FloatingButtonPosition` defining the initial position of the floating button.
+    func setInitialPosition(position: FloatingButtonPosition)
 }

--- a/AEPServices/Tests/services/FloatingButtonPositionTests.swift
+++ b/AEPServices/Tests/services/FloatingButtonPositionTests.swift
@@ -37,24 +37,24 @@ class FloatingButtonPositionTests : XCTestCase {
     
     func test_PositionTopRight_Frame() {
         // test
-        let centerFrame = FloatingButtonPosition.topRight.frame(screenBounds: screenBounds)
+        let topRightFrame = FloatingButtonPosition.topRight.frame(screenBounds: screenBounds)
         
         // verify the the button positions to the topRight of the screen
-        XCTAssertEqual(40, centerFrame.origin.x)
-        XCTAssertEqual(40, centerFrame.origin.y)
-        XCTAssertEqual(60, centerFrame.size.width)
-        XCTAssertEqual(60, centerFrame.size.height)
+        XCTAssertEqual(40, topRightFrame.origin.x)
+        XCTAssertEqual(40, topRightFrame.origin.y)
+        XCTAssertEqual(60, topRightFrame.size.width)
+        XCTAssertEqual(60, topRightFrame.size.height)
     }
         
     func test_PositionTopLeft_Frame() {
         // test
-        let centerFrame = FloatingButtonPosition.topLeft.frame(screenBounds: screenBounds)
+        let topLeftFrame = FloatingButtonPosition.topLeft.frame(screenBounds: screenBounds)
         
         // verify the the button positions to the topLeft of the screen
-        XCTAssertEqual(0, centerFrame.origin.x)
-        XCTAssertEqual(40, centerFrame.origin.y)
-        XCTAssertEqual(60, centerFrame.size.width)
-        XCTAssertEqual(60, centerFrame.size.height)
+        XCTAssertEqual(0, topLeftFrame.origin.x)
+        XCTAssertEqual(40, topLeftFrame.origin.y)
+        XCTAssertEqual(60, topLeftFrame.size.width)
+        XCTAssertEqual(60, topLeftFrame.size.height)
     }
 
 }

--- a/AEPServices/Tests/services/FloatingButtonPositionTests.swift
+++ b/AEPServices/Tests/services/FloatingButtonPositionTests.swift
@@ -1,0 +1,60 @@
+/*
+ Copyright 2021 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+@testable import AEPServices
+import XCTest
+
+class FloatingButtonPositionTests : XCTestCase {
+    
+    // A sample screen bounds to which the button has to be centered
+    var screenBounds = CGSize(width: 100, height: 100)
+    
+    // Few other constants to know for the test
+    // FloatingButtonWidth = 60
+    // FloatingButtonHeight = 60
+    // TopMargin = 40
+    
+    func test_PositionCenter_Frame() {
+        // test
+        let centerFrame = FloatingButtonPosition.center.frame(screenBounds: screenBounds)
+        
+        // verify the the button positions to the center of the screen
+        XCTAssertEqual(20, centerFrame.origin.x)
+        XCTAssertEqual(20, centerFrame.origin.y)
+        XCTAssertEqual(60, centerFrame.size.width)
+        XCTAssertEqual(60, centerFrame.size.height)
+    }
+    
+    func test_PositionTopRight_Frame() {
+        // test
+        let centerFrame = FloatingButtonPosition.topRight.frame(screenBounds: screenBounds)
+        
+        // verify the the button positions to the topRight of the screen
+        XCTAssertEqual(40, centerFrame.origin.x)
+        XCTAssertEqual(40, centerFrame.origin.y)
+        XCTAssertEqual(60, centerFrame.size.width)
+        XCTAssertEqual(60, centerFrame.size.height)
+    }
+        
+    func test_PositionTopLeft_Frame() {
+        // test
+        let centerFrame = FloatingButtonPosition.topLeft.frame(screenBounds: screenBounds)
+        
+        // verify the the button positions to the topLeft of the screen
+        XCTAssertEqual(0, centerFrame.origin.x)
+        XCTAssertEqual(40, centerFrame.origin.y)
+        XCTAssertEqual(60, centerFrame.size.width)
+        XCTAssertEqual(60, centerFrame.size.height)
+    }
+
+}

--- a/AEPServices/Tests/services/FloatingButtonTests.swift
+++ b/AEPServices/Tests/services/FloatingButtonTests.swift
@@ -52,7 +52,7 @@ class FloatingButtonTests : XCTestCase {
         floatingButton = FloatingButton(listener: mockListener)
         XCTAssertNoThrow(floatingButton?.setButtonImage(imageData: Data()))
     }
-    
+
     func test_setInitialPosition() {
         floatingButton = FloatingButton(listener: mockListener)
         XCTAssertNoThrow(floatingButton?.setInitialPosition(position: .center))

--- a/AEPServices/Tests/services/FloatingButtonTests.swift
+++ b/AEPServices/Tests/services/FloatingButtonTests.swift
@@ -52,6 +52,12 @@ class FloatingButtonTests : XCTestCase {
         floatingButton = FloatingButton(listener: mockListener)
         XCTAssertNoThrow(floatingButton?.setButtonImage(imageData: Data()))
     }
+    
+    func test_setInitialPosition() {
+        floatingButton = FloatingButton(listener: mockListener)
+        XCTAssertNoThrow(floatingButton?.setInitialPosition(position: .center))
+        XCTAssertNoThrow(floatingButton?.show())
+    }
 
     class MockListener: FloatingButtonDelegate {
         func onShow() {}

--- a/AEPServices/Tests/services/FloatingButtonTests.swift
+++ b/AEPServices/Tests/services/FloatingButtonTests.swift
@@ -55,7 +55,7 @@ class FloatingButtonTests : XCTestCase {
 
     func test_setInitialPosition() {
         floatingButton = FloatingButton(listener: mockListener)
-        XCTAssertNoThrow(floatingButton?.setInitialPosition(position: .center))
+        XCTAssertNoThrow(floatingButton?.setInitial(position: .center))
         XCTAssertNoThrow(floatingButton?.show())
     }
 


### PR DESCRIPTION
API to set the initial position of the floating button

**Usage**
```
        let floatingButton = ServiceProvider.shared.uiService.createFloatingButton(listener: self)
        floatingButton.setInitialPosition(position: FloatingButtonPosition.topRight)
        floatingButton.show()
```

**How it appears**

<img width="300" alt="Screen Shot 2021-05-26 at 11 51 35 AM" src="https://user-images.githubusercontent.com/8909148/119715333-bcbe1b00-be18-11eb-81f5-ea78e3b33840.png">

**Supported Initial position values**
- center (default)
- topRight
- topLeft
