### PR TITLE
[MOB-14426] - API to hide fullscreen message

### DIFF
--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
@@ -50,7 +50,7 @@ public class FullscreenMessage: NSObject, WKNavigationDelegate, FullscreenPresen
         self.isLocalImageUsed = isLocalImageUsed
         self.messageMonitor = messageMonitor
     }
-    
+
     /// Call this API to hide the fullscreen message.
     /// This API hides the fullscreen message with an animation, but it keeps alive its webView for future reappearances.
     /// Invoking show on a hidden fullscreen message, will display the fullscreen message in the existing state (i.e webView is not re-rendered)

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
@@ -50,7 +50,12 @@ public class FullscreenMessage: NSObject, WKNavigationDelegate, FullscreenPresen
         self.isLocalImageUsed = isLocalImageUsed
         self.messageMonitor = messageMonitor
     }
-
+    
+    /// Call this API to hide the fullscreen message.
+    /// This API hides the fullscreen message with an animation, but it keeps alive its webView for future reappearances.
+    /// Invoking show on a hidden fullscreen message, will display the fullscreen message in the existing state (i.e webView is not re-rendered)
+    ///
+    /// Important Note : When you are completed using an Fullscreen message. You must call dismiss() to remove it from memory
     public func hide() {
         DispatchQueue.main.async {
             if self.messageMonitor.dismiss() ==  false {


### PR DESCRIPTION
The motivation for this pull request is from Assurance, which wanted the fullScreen message to be taken off the screen but should still be in memory so it can be reshown from its previous state.

Example: 
The Status Screen for Assurance is now a FullScreenMessage. And this UI appears each time the user clicks on the Assurance floating button. In order to preserve the clientLogs that are populated in HTML. We were needed to implement the hide feature for the InAppMessage

<img width="300" alt="Screen Shot 2021-05-28 at 3 09 03 PM" src="https://user-images.githubusercontent.com/8909148/120046257-a5bd2b80-bfc6-11eb-8720-ae3317c2b595.png">


Note : The hide() API doesn't conform to any protocol. And can only be used by user who holds the FullScreenMessage object

