### PR TITLE
Fix authentication state when calling syncIdentifiers

### DIFF
--- a/AEPIdentity/Sources/Identity+PublicAPI.swift
+++ b/AEPIdentity/Sources/Identity+PublicAPI.swift
@@ -112,7 +112,7 @@ import Foundation
     static func syncIdentifiers(identifiers: [String: String]?, authenticationState: MobileVisitorAuthenticationState) {
         var eventData = [String: Any]()
         eventData[IdentityConstants.EventDataKeys.IDENTIFIERS] = identifiers
-        eventData[IdentityConstants.EventDataKeys.AUTHENTICATION_STATE] = authenticationState.rawValue
+        eventData[IdentityConstants.EventDataKeys.AUTHENTICATION_STATE] = authenticationState
         eventData[IdentityConstants.EventDataKeys.FORCE_SYNC] = false
         eventData[IdentityConstants.EventDataKeys.IS_SYNC_EVENT] = true
 

--- a/AEPIdentity/Tests/IdentityPublicAPITests.swift
+++ b/AEPIdentity/Tests/IdentityPublicAPITests.swift
@@ -34,7 +34,7 @@ class IdentityAPITests: XCTestCase {
 
     private func assertSyncEvent(event: Event, identifiers: [String: String]?, authState: MobileVisitorAuthenticationState) {
         XCTAssertEqual(identifiers, event.data?[IdentityConstants.EventDataKeys.IDENTIFIERS] as? [String: String])
-        XCTAssertEqual(authState.rawValue, event.data?[IdentityConstants.EventDataKeys.AUTHENTICATION_STATE] as? Int)
+        XCTAssertEqual(authState, event.data?[IdentityConstants.EventDataKeys.AUTHENTICATION_STATE] as? MobileVisitorAuthenticationState)
         XCTAssertFalse(event.data?[IdentityConstants.EventDataKeys.FORCE_SYNC] as? Bool ?? true)
         XCTAssertTrue(event.data?[IdentityConstants.EventDataKeys.IS_SYNC_EVENT] as? Bool ?? false)
     }

--- a/AEPIntegrationTests/IdentityIntegrationTests.swift
+++ b/AEPIntegrationTests/IdentityIntegrationTests.swift
@@ -56,7 +56,7 @@ class IdentityIntegrationTests: XCTestCase {
         let mockNetworkService = TestableNetworkService()
         ServiceProvider.shared.networkService = mockNetworkService
         mockNetworkService.mock { request in
-            if request.url.absoluteString.contains("d_cid_ic=id1%2501value1%25010") {
+            if request.url.absoluteString.contains("d_cid_ic=id1%2501value1%25011") {
                 XCTAssertTrue(request.url.absoluteString.contains("https://test.com/id"))
                 XCTAssertTrue(request.url.absoluteString.contains("d_orgid=orgid"))
                 requestExpectation.fulfill()
@@ -65,7 +65,7 @@ class IdentityIntegrationTests: XCTestCase {
         }
 
         MobileCore.updateConfigurationWith(configDict: ["experienceCloud.org": "orgid", "experienceCloud.server": "test.com", "global.privacy": "optedin"])
-        Identity.syncIdentifiers(identifiers: ["id1": "value1"])
+        Identity.syncIdentifiers(identifiers: ["id1": "value1"], authenticationState: .authenticated)
 
         wait(for: [requestExpectation], timeout: 1)
     }


### PR DESCRIPTION

## Description

Send authentication state as MobileVisitorAuthenticationState instead of Int in event data for syncIdentifiers API call. The Identity extension casts the authentication state as a MobileVisitorAuthenticationState when extracting from the event data. When using the raw value (Int) of the MobileVisitorAuthenticationState enum, the cast always fails and returns value .unknown. This fix will allow the user specified authentication state for the custom identifier in the syncIdentifiers call instead of all authentication states being unknown.

Internal ticket: AMSDK-11493

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
