### PR TITLE
[MOB-14446] Only process hits when no other hits are being processed

### DIFF
--- a/AEPServices/Sources/utility/hitprocessor/PersistentHitQueue.swift
+++ b/AEPServices/Sources/utility/hitprocessor/PersistentHitQueue.swift
@@ -18,6 +18,7 @@ public class PersistentHitQueue: HitQueuing {
 
     private static let DEFAULT_RETRY_INTERVAL = TimeInterval(30)
     private var suspended = true
+    private var isTaskScheduled = false
     private let queue = DispatchQueue(label: "com.adobe.mobile.persistenthitqueue")
 
     /// Creates a new `HitQueue` with the underlying `DataQueue` which is used to persist hits
@@ -60,19 +61,26 @@ public class PersistentHitQueue: HitQueuing {
     /// A recursive function for processing hits, it will continue processing all the hits until none are left in the data queue
     private func processNextHit() {
         queue.async {
-            guard !self.suspended else { return }
-            guard let hit = self.dataQueue.peek() else { return } // nothing left in the queue, stop processing
+            guard !self.suspended, !self.isTaskScheduled else { return }
+
+            self.isTaskScheduled = true
+
+            guard let hit = self.dataQueue.peek() else {
+                self.isTaskScheduled = false
+                return
+            } // nothing left in the queue, stop processing
 
             let semaphore = DispatchSemaphore(value: 0)
             self.processor.processHit(entity: hit, completion: { [weak self] success in
                 if success {
                     // successful processing of hit, remove it from the queue, move to next hit
                     _ = self?.dataQueue.remove()
-
+                    self?.isTaskScheduled = false
                     self?.processNextHit()
                 } else {
                     // processing hit failed, leave it in the queue, retry after the retry interval
                     self?.queue.asyncAfter(deadline: .now() + (self?.processor.retryInterval(for: hit) ?? PersistentHitQueue.DEFAULT_RETRY_INTERVAL)) {
+                        self?.isTaskScheduled = false
                         self?.processNextHit()
                     }
                 }

--- a/AEPServices/Tests/utility/PersistentHitQueueTests.swift
+++ b/AEPServices/Tests/utility/PersistentHitQueueTests.swift
@@ -148,22 +148,79 @@ class PersistentHitQueueTests: XCTestCase {
 
     /// Tests that hits are retried properly and do not block the queue
     func testProcessesHitsManyWithIntermittentProcessor() {
-        hitProcessor = MockHitIntermittentProcessor()
+        let hitCount = 50
+        hitProcessor = MockHitIntermittentProcessor(hitCount: hitCount)
         hitQueue = PersistentHitQueue(dataQueue: MockDataQueue(), processor: hitProcessor)
 
         // test
-        for _ in 0 ..< 100 {
-            hitQueue.queue(entity: DataEntity(uniqueIdentifier: UUID().uuidString, timestamp: Date(), data: nil))
+        hitQueue.beginProcessing()
+        for i in 0 ..< hitCount {
+            hitQueue.queue(entity: DataEntity(uniqueIdentifier: "\(i)", timestamp: Date(), data: nil))
         }
 
-        hitQueue.beginProcessing()
-        sleep(1)
+        let intermittentProcessor = hitQueue.processor as? MockHitIntermittentProcessor
+        wait(for: [intermittentProcessor!.expectation], timeout: 100)
 
         // verify
         XCTAssertNil(hitQueue.dataQueue.peek()) // hits should no longer be in the queue as its been processed
-        let intermittentProcessor = hitQueue.processor as? MockHitIntermittentProcessor
-        XCTAssertEqual(100, intermittentProcessor?.processedHits.count) // all hits should be eventually processed
+        XCTAssertEqual(hitCount, intermittentProcessor?.processedHits.count) // All hits should be eventually processed
         XCTAssertFalse(intermittentProcessor?.failedHits.isEmpty ?? true) // some of the hits should have failed
+
+        // verify hits processed in-order
+        for i in 0 ..< (intermittentProcessor?.processedHits.count)! {
+            let hit = intermittentProcessor?.processedHits.shallowCopy[i]
+            XCTAssertEqual("\(i)", hit?.uniqueIdentifier)
+        }
+    }
+
+    /// Tests that hits are retried in an efficiently and orderly manner
+    func testHitRetryOrdering() {
+        let entity1 = DataEntity(uniqueIdentifier: "dataEntity1", timestamp: Date(), data: nil)
+        let entity2 = DataEntity(uniqueIdentifier: "dataEntity2", timestamp: Date(), data: nil)
+        let entity3 = DataEntity(uniqueIdentifier: "dataEntity3", timestamp: Date(), data: nil)
+
+        hitProcessor = ControllableHitProcessor()
+        hitQueue = PersistentHitQueue(dataQueue: MockDataQueue(), processor: hitProcessor)
+
+        guard let mockHitProcessor = hitProcessor as? ControllableHitProcessor else {
+            XCTFail()
+            return
+        }
+
+        mockHitProcessor.hitResult = false // retry hits
+        hitQueue.beginProcessing()
+        hitQueue.queue(entity: entity1)
+        hitQueue.queue(entity: entity2)
+        hitQueue.queue(entity: entity3)
+
+        // Sleep 0.1 seconds, which is less than the retry interval of 1 sec, then set hit result to success
+        Thread.sleep(forTimeInterval: 0.1)
+        mockHitProcessor.hitResult = true // set hit result to success (no retry)
+        // Sleep to allow retry interval to pass and data queue to get processed and emptied
+        Thread.sleep(forTimeInterval: 2)
+
+        let expectedProcessingOrder = [
+            entity1.uniqueIdentifier,
+            entity1.uniqueIdentifier, // entity 1 should be the only one retried
+            entity2.uniqueIdentifier,
+            entity3.uniqueIdentifier]
+
+        XCTAssertNil(hitQueue.dataQueue.peek()) // hits should no longer be in the queue as its been processed
+        XCTAssertEqual(expectedProcessingOrder, mockHitProcessor.processedHits.shallowCopy.map({$0.uniqueIdentifier}))
+    }
+}
+
+class ControllableHitProcessor: HitProcessing {
+    let processedHits = ThreadSafeArray<DataEntity>()
+    var hitResult = true
+
+    func retryInterval(for entity: DataEntity) -> TimeInterval {
+        return 1
+    }
+
+    func processHit(entity: DataEntity, completion: @escaping (Bool) -> Void) {
+        processedHits.append(entity)
+        completion(hitResult)
     }
 }
 
@@ -183,24 +240,36 @@ class MockHitProcessor: HitProcessing {
 class MockHitIntermittentProcessor: HitProcessing {
     let processedHits = ThreadSafeArray<DataEntity>()
     var failedHits = Set<String>()
+    let expectation = XCTestExpectation(description: "Hit fulfillment count")
+
+    let processingOrder = ThreadSafeArray<String>()
+
+    /// Creates a new `MockHitIntermittentProcessor`
+    /// - Parameter hitCount: Number of hits this processor is expected to process
+    init(hitCount: Int) {
+        expectation.expectedFulfillmentCount = hitCount
+        expectation.assertForOverFulfill = true
+    }
 
     func retryInterval(for entity: DataEntity) -> TimeInterval {
-        return TimeInterval(0)
+        return TimeInterval(2)
     }
 
     // 50% of hits need to be processed twice, other 50% process successfully the first time
     func processHit(entity: DataEntity, completion: (Bool) -> Void) {
+        processingOrder.append(entity.uniqueIdentifier)
+
         // check if we've already "failed" at processing this hit
         if failedHits.contains(entity.uniqueIdentifier) {
             processedHits.append(entity)
+            expectation.fulfill()
             completion(true)
             return
         }
 
-        let shouldRetry = entity.uniqueIdentifier.hashValue % 2 == 0 // retry 50% of hits
-
-        if !shouldRetry {
+        if !Bool.random() { // retry ~50% of hits
             processedHits.append(entity)
+            expectation.fulfill()
             completion(true)
         } else {
             failedHits.insert(entity.uniqueIdentifier)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add flag to PersistentHitQueue.processNextHit() to flag when a hit is currently being executed or scheduled. Fixes an issue where new hits can cause additional scheduled tasks if a scheduled task exists when the hit is queued.

## Related Issue

Internal

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
