### PR TITLE
UI services updates

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -76,6 +76,8 @@
 		24CF602B2538AC79006473BA /* MobileCore+Tracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CF602A2538AC79006473BA /* MobileCore+Tracking.swift */; };
 		24CF603B2538C7E4006473BA /* MobileCore+TrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CF603A2538C7E4006473BA /* MobileCore+TrackingTests.swift */; };
 		24D2A3D524DB5B370079DCCF /* HitQueuing+PrivacyStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D2A3D424DB5B370079DCCF /* HitQueuing+PrivacyStatus.swift */; };
+		24D9D52E26AB788D002A441A /* FullscreenMessage+WKNavigationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D9D52D26AB788C002A441A /* FullscreenMessage+WKNavigationDelegate.swift */; };
+		24D9D54C26AB797D002A441A /* FullscreenMessage+WKScriptMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D9D54B26AB797D002A441A /* FullscreenMessage+WKScriptMessageHandler.swift */; };
 		344CB8028DA7A7F0F44E65F4 /* Pods_AEPIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B414FF5745B34BC95CF624DC /* Pods_AEPIntegrationTests.framework */; };
 		3F03979024BE5DD30019F095 /* AEPServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F03978724BE5DD30019F095 /* AEPServices.framework */; };
 		3F0397C324BE5FF30019F095 /* Caching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F0397A024BE5FF30019F095 /* Caching.swift */; };
@@ -659,6 +661,8 @@
 		24CF602A2538AC79006473BA /* MobileCore+Tracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MobileCore+Tracking.swift"; sourceTree = "<group>"; };
 		24CF603A2538C7E4006473BA /* MobileCore+TrackingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MobileCore+TrackingTests.swift"; sourceTree = "<group>"; };
 		24D2A3D424DB5B370079DCCF /* HitQueuing+PrivacyStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HitQueuing+PrivacyStatus.swift"; sourceTree = "<group>"; };
+		24D9D52D26AB788C002A441A /* FullscreenMessage+WKNavigationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FullscreenMessage+WKNavigationDelegate.swift"; sourceTree = "<group>"; };
+		24D9D54B26AB797D002A441A /* FullscreenMessage+WKScriptMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FullscreenMessage+WKScriptMessageHandler.swift"; sourceTree = "<group>"; };
 		2CDAE3FD5AB17A2ABC44C648 /* Pods-AEPSignalTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPSignalTests.debug.xcconfig"; path = "Target Support Files/Pods-AEPSignalTests/Pods-AEPSignalTests.debug.xcconfig"; sourceTree = "<group>"; };
 		379EA00DE567DCA654F85A63 /* Pods-AEPCore.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPCore.release.xcconfig"; path = "Target Support Files/Pods-AEPCore/Pods-AEPCore.release.xcconfig"; sourceTree = "<group>"; };
 		3F03978724BE5DD30019F095 /* AEPServices.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AEPServices.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1870,6 +1874,8 @@
 			children = (
 				92EEA5F5258933A600DBA3EE /* FullscreenMessageDelegate.swift */,
 				92EEA56F25885C1C00DBA3EE /* FullscreenMessage.swift */,
+				24D9D52D26AB788C002A441A /* FullscreenMessage+WKNavigationDelegate.swift */,
+				24D9D54B26AB797D002A441A /* FullscreenMessage+WKScriptMessageHandler.swift */,
 				78B36AB325CA1FCE00D6D25F /* FullscreenPresentable.swift */,
 			);
 			path = fullscreen;
@@ -2959,6 +2965,7 @@
 				923547EB25BF9C6600BEA9A3 /* AEPUIService.swift in Sources */,
 				3F0397CE24BE5FF30019F095 /* LoggingService.swift in Sources */,
 				786C000525B8EE2100F26D34 /* DefaultHeadersFormatter.swift in Sources */,
+				24D9D52E26AB788D002A441A /* FullscreenMessage+WKNavigationDelegate.swift in Sources */,
 				3F0397C924BE5FF30019F095 /* Logging.swift in Sources */,
 				78B36A9625CA1C2D00D6D25F /* Dismissible.swift in Sources */,
 				3F0397D224BE5FF30019F095 /* NetworkRequest.swift in Sources */,
@@ -2973,6 +2980,7 @@
 				3F0397C424BE5FF30019F095 /* Cache.swift in Sources */,
 				3F0397D724BE5FF30019F095 /* DataQueueService.swift in Sources */,
 				3F0397F324BE60910019F095 /* PersistentHitQueue.swift in Sources */,
+				24D9D54C26AB797D002A441A /* FullscreenMessage+WKScriptMessageHandler.swift in Sources */,
 				3F0397CD24BE5FF30019F095 /* NetworkServiceConstants.swift in Sources */,
 				3F0397C724BE5FF30019F095 /* CacheExpiry.swift in Sources */,
 				3F0397C624BE5FF30019F095 /* DiskCacheService.swift in Sources */,

--- a/AEPServices/Sources/ui/AEPUIService.swift
+++ b/AEPServices/Sources/ui/AEPUIService.swift
@@ -18,7 +18,11 @@ class AEPUIService: UIService {
     private var messageMonitor = MessageMonitor()
 
     func createFullscreenMessage(payload: String, listener: FullscreenMessageDelegate?, isLocalImageUsed: Bool = false) -> FullscreenPresentable {
-        return FullscreenMessage(payload: payload, listener: listener, isLocalImageUsed: isLocalImageUsed, messageMonitor: messageMonitor)
+        return createFullscreenMessage(payload: payload, listener: listener, isLocalImageUsed: isLocalImageUsed, parent: nil)
+    }
+    
+    func createFullscreenMessage(payload: String, listener: FullscreenMessageDelegate?, isLocalImageUsed: Bool = false, parent: Any? = nil) -> FullscreenPresentable {
+        return FullscreenMessage(payload: payload, listener: listener, isLocalImageUsed: isLocalImageUsed, messageMonitor: messageMonitor, parent: parent)
     }
 
     func createFloatingButton(listener: FloatingButtonDelegate) -> FloatingButtonPresentable {

--- a/AEPServices/Sources/ui/AEPUIService.swift
+++ b/AEPServices/Sources/ui/AEPUIService.swift
@@ -20,7 +20,7 @@ class AEPUIService: UIService {
     func createFullscreenMessage(payload: String, listener: FullscreenMessageDelegate?, isLocalImageUsed: Bool = false) -> FullscreenPresentable {
         return createFullscreenMessage(payload: payload, listener: listener, isLocalImageUsed: isLocalImageUsed, parent: nil)
     }
-    
+
     func createFullscreenMessage(payload: String, listener: FullscreenMessageDelegate?, isLocalImageUsed: Bool = false, parent: Any? = nil) -> FullscreenPresentable {
         return FullscreenMessage(payload: payload, listener: listener, isLocalImageUsed: isLocalImageUsed, messageMonitor: messageMonitor, parent: parent)
     }

--- a/AEPServices/Sources/ui/MessagingDelegate.swift
+++ b/AEPServices/Sources/ui/MessagingDelegate.swift
@@ -34,7 +34,7 @@ public protocol MessagingDelegate {
     /// - Returns: true if the message should be shown else false
     @objc
     func shouldShowMessage(message: Showable) -> Bool
-    
+
     /// Called when `message` loads a URL
     /// - Parameters:
     ///     - url: the `URL` being loaded by the `message`

--- a/AEPServices/Sources/ui/MessagingDelegate.swift
+++ b/AEPServices/Sources/ui/MessagingDelegate.swift
@@ -13,21 +13,32 @@
 import Foundation
 
 /// UI Message delegate which is used to listen for current message lifecycle events
-@objc(AEPMessagingDelegate) public protocol MessagingDelegate {
+@objc(AEPMessagingDelegate)
+public protocol MessagingDelegate {
 
     /// Invoked when the any message is displayed
     /// - Parameters:
     ///     - message: UIMessaging message that is being displayed
+    @objc
     func onShow(message: Showable)
 
     /// Invoked when the any message is dismissed
     /// - Parameters:
     ///     - message: UIMessaging message that is being dismissed
+    @objc
     func onDismiss(message: Showable)
 
     /// Used to find whether messages should be shown or not
     /// - Parameters:
     ///     - message: UIMessaging message that is about to get displayed
     /// - Returns: true if the message should be shown else false
+    @objc
     func shouldShowMessage(message: Showable) -> Bool
+    
+    /// Called when `message` loads a URL
+    /// - Parameters:
+    ///     - url: the `URL` being loaded by the `message`
+    ///     - message: the Message loading a `URL`
+    @objc
+    optional func urlLoaded(_ url: URL, byMessage message: Showable)
 }

--- a/AEPServices/Sources/ui/UIService.swift
+++ b/AEPServices/Sources/ui/UIService.swift
@@ -18,7 +18,7 @@ import UIKit
 ///
 @objc
 public protocol UIService {
-    
+
     /// Creates a `FullscreenPresentable`
     /// - Parameters:
     ///     - payload: The payload used in the FullscreenPresentable as a string
@@ -27,7 +27,7 @@ public protocol UIService {
     /// - Returns: A `FullscreenPresentable` implementation
     @objc
     func createFullscreenMessage(payload: String, listener: FullscreenMessageDelegate?, isLocalImageUsed: Bool) -> FullscreenPresentable
-    
+
     /// Creates a `FullscreenPresentable`
     /// - Parameters:
     ///     - payload: The payload used in the FullscreenPresentable as a string
@@ -37,7 +37,7 @@ public protocol UIService {
     /// - Returns: A `FullscreenPresentable` implementation
     @objc
     optional func createFullscreenMessage(payload: String, listener: FullscreenMessageDelegate?, isLocalImageUsed: Bool, parent: Any?) -> FullscreenPresentable
-    
+
     /// Creates a `FloatingButtonPresentable`
     /// - Parameters:
     ///     - listener: The `FloatingButtonPresentable`'s `FloatingButtonDelegate`

--- a/AEPServices/Sources/ui/UIService.swift
+++ b/AEPServices/Sources/ui/UIService.swift
@@ -16,21 +16,32 @@ import UIKit
 ///
 /// UIService for creating UI elements
 ///
+@objc
 public protocol UIService {
-
-    ///
+    
     /// Creates a `FullscreenPresentable`
     /// - Parameters:
     ///     - payload: The payload used in the FullscreenPresentable as a string
     ///     - listener: The `FullscreenPresentable`'s `FullscreenMessageDelegate`
     ///     - isLocalImageUsed: An optional flag indicating if a local image is used instead of the default image provided
     /// - Returns: A `FullscreenPresentable` implementation
+    @objc
     func createFullscreenMessage(payload: String, listener: FullscreenMessageDelegate?, isLocalImageUsed: Bool) -> FullscreenPresentable
-
-    ///
-    /// Creates a `FloatinButtonPresentable`
+    
+    /// Creates a `FullscreenPresentable`
+    /// - Parameters:
+    ///     - payload: The payload used in the FullscreenPresentable as a string
+    ///     - listener: The `FullscreenPresentable`'s `FullscreenMessageDelegate`
+    ///     - isLocalImageUsed: An optional flag indicating if a local image is used instead of the default image provided
+    ///     - parent: The object that will own the newly created message
+    /// - Returns: A `FullscreenPresentable` implementation
+    @objc
+    optional func createFullscreenMessage(payload: String, listener: FullscreenMessageDelegate?, isLocalImageUsed: Bool, parent: Any?) -> FullscreenPresentable
+    
+    /// Creates a `FloatingButtonPresentable`
     /// - Parameters:
     ///     - listener: The `FloatingButtonPresentable`'s `FloatingButtonDelegate`
     /// - Returns: A `FloatingButtonPresentable` implementation
+    @objc
     func createFloatingButton(listener: FloatingButtonDelegate) -> FloatingButtonPresentable
 }

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage+WKNavigationDelegate.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage+WKNavigationDelegate.swift
@@ -3,7 +3,7 @@
  This file is licensed to you under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License. You may obtain a copy
  of the License at http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software distributed under
  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  OF ANY KIND, either express or implied. See the License for the specific language

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage+WKNavigationDelegate.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage+WKNavigationDelegate.swift
@@ -23,22 +23,22 @@ extension FullscreenMessage: WKNavigationDelegate {
             decisionHandler(.allow)
             return
         }
-        
+
         var navigation: WKNavigationActionPolicy = .allow
-        
+
         if self.listener != nil {
             let navigateNormally = self.listener?.overrideUrlLoad(message: self, url: urlToLoad.absoluteString) ?? true
-            
+
             navigation = navigateNormally ? .allow : .cancel
-            
+
             if navigation == .cancel {
                 self.messagingDelegate?.urlLoaded?(urlToLoad, byMessage: self)
             }
         }
-        
+
         decisionHandler(navigation)
     }
-    
+
     /// Delegate method invoked when the webView navigation is complete.
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         if navigation == self.loadingNavigation {

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage+WKNavigationDelegate.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage+WKNavigationDelegate.swift
@@ -1,0 +1,48 @@
+/*
+ Copyright 2021 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+import WebKit
+
+extension FullscreenMessage: WKNavigationDelegate {
+    // MARK: WKNavigationDelegate delegate
+    // default behavior is to call the decisionHandler with .allow
+    // either the messagingDelegate or listener may suppress this navigation
+    public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        // notify the messagingDelegate of the url being loaded
+        guard let urlToLoad = navigationAction.request.url else {
+            decisionHandler(.allow)
+            return
+        }
+        
+        var navigation: WKNavigationActionPolicy = .allow
+        
+        if self.listener != nil {
+            let navigateNormally = self.listener?.overrideUrlLoad(message: self, url: urlToLoad.absoluteString) ?? true
+            
+            navigation = navigateNormally ? .allow : .cancel
+            
+            if navigation == .cancel {
+                self.messagingDelegate?.urlLoaded?(urlToLoad, byMessage: self)
+            }
+        }
+        
+        decisionHandler(navigation)
+    }
+    
+    /// Delegate method invoked when the webView navigation is complete.
+    public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        if navigation == self.loadingNavigation {
+            self.listener?.webViewDidFinishInitialLoading?(webView: webView)
+        }
+    }
+}

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage+WKScriptMessageHandler.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage+WKScriptMessageHandler.swift
@@ -3,7 +3,7 @@
  This file is licensed to you under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License. You may obtain a copy
  of the License at http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software distributed under
  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  OF ANY KIND, either express or implied. See the License for the specific language

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage+WKScriptMessageHandler.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage+WKScriptMessageHandler.swift
@@ -1,0 +1,24 @@
+/*
+ Copyright 2021 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+import WebKit
+
+// MARK: - WKScriptMessageHandler
+extension FullscreenMessage: WKScriptMessageHandler {
+    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        if message.name == jsDismissAction {
+            print("message dismissed from \(message.body)")
+            dismissWithAnimation(animate: true)
+        }
+    }
+}

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage+WKScriptMessageHandler.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage+WKScriptMessageHandler.swift
@@ -16,9 +16,9 @@ import WebKit
 // MARK: - WKScriptMessageHandler
 extension FullscreenMessage: WKScriptMessageHandler {
     public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        if message.name == jsDismissAction {
-            print("message dismissed from \(message.body)")
-            dismissWithAnimation(animate: true)
+        if let handler = scriptHandlers[message.name] {
+            Log.debug(label: LOG_PREFIX, "Calling javascript handler for \(message.name) with content \(message.body).")
+            handler(message.body)
         }
     }
 }

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
@@ -181,7 +181,7 @@ public class FullscreenMessage: NSObject, FullscreenPresentable {
     /// - Parameters:
     ///   - name: the name of the message being passed from javascript
     ///   - handler: a method to be called when the javascript message is passed    
-    public func handleMessage(_ name: String, withHandler handler: @escaping (Any?) -> Void) {
+    public func handleJavascriptMessage(_ name: String, withHandler handler: @escaping (Any?) -> Void) {
         scriptHandlers[name] = handler
     }
 


### PR DESCRIPTION
- changes to `FullscreenMessage`
  - added a property to give access to parent object
  - added support for registering native handlers for javascript code in the message html
- changes to `MessagingDelegate`
  - added an optional method: `optional func urlLoaded(_ url: URL, byMessage message: Showable)`
- some minor refactoring