### PR TITLE
Limit number of times an event can be processed from dispatch consequence

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -389,6 +389,7 @@
 		BF4A6F2726BB4A1B00612434 /* rules_testDispatchEventInvalidAction.json in Resources */ = {isa = PBXBuildFile; fileRef = BF4A6F2326BB4A1A00612434 /* rules_testDispatchEventInvalidAction.json */; };
 		BF4A6F2826BB4A1B00612434 /* rules_testDispatchEventNoSource.json in Resources */ = {isa = PBXBuildFile; fileRef = BF4A6F2426BB4A1B00612434 /* rules_testDispatchEventNoSource.json */; };
 		BF4A6F2926BB4A1B00612434 /* rules_testDispatchEventNoType.json in Resources */ = {isa = PBXBuildFile; fileRef = BF4A6F2526BB4A1B00612434 /* rules_testDispatchEventNoType.json */; };
+		BF4A6F8D26BBAE6500612434 /* rules_testDispatchEventChain.json in Resources */ = {isa = PBXBuildFile; fileRef = BF4A6F8C26BBAE6500612434 /* rules_testDispatchEventChain.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1006,6 +1007,7 @@
 		BF4A6F2326BB4A1A00612434 /* rules_testDispatchEventInvalidAction.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_testDispatchEventInvalidAction.json; sourceTree = "<group>"; };
 		BF4A6F2426BB4A1B00612434 /* rules_testDispatchEventNoSource.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_testDispatchEventNoSource.json; sourceTree = "<group>"; };
 		BF4A6F2526BB4A1B00612434 /* rules_testDispatchEventNoType.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_testDispatchEventNoType.json; sourceTree = "<group>"; };
+		BF4A6F8C26BBAE6500612434 /* rules_testDispatchEventChain.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_testDispatchEventChain.json; sourceTree = "<group>"; };
 		C63E76D9752A3702439C65D2 /* Pods-AEPIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPIntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-AEPIntegrationTests/Pods-AEPIntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C63ECCE4276B2C8008629BA4 /* Pods-AEPCore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPCore.debug.xcconfig"; path = "Target Support Files/Pods-AEPCore/Pods-AEPCore.debug.xcconfig"; sourceTree = "<group>"; };
 		D6A7B39F8D2A807344E7098B /* Pods_AEPLifecycleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AEPLifecycleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1676,6 +1678,7 @@
 				BBA512B124F5CF380030DAD1 /* rules_testAttachData.json */,
 				BF4A6EB726BB3B9D00612434 /* rules_testDispatchEventCopy.json */,
 				BF4A6F2326BB4A1A00612434 /* rules_testDispatchEventInvalidAction.json */,
+				BF4A6F8C26BBAE6500612434 /* rules_testDispatchEventChain.json */,
 				BF4A6EE626BB47FE00612434 /* rules_testDispatchEventNewData.json */,
 				BF4A6F0426BB48A200612434 /* rules_testDispatchEventNewNoData.json */,
 				BF4A6F2226BB4A1A00612434 /* rules_testDispatchEventNoAction.json */,
@@ -2441,6 +2444,7 @@
 				BBA5129B24F477550030DAD1 /* rules_testMatcherNe.json in Resources */,
 				BBA5129924F46C770030DAD1 /* rules_testGroupLogicalOperators.json in Resources */,
 				BBA5129F24F4A14C0030DAD1 /* rules_testMatcherGe.json in Resources */,
+				BF4A6F8D26BBAE6500612434 /* rules_testDispatchEventChain.json in Resources */,
 				BBA512B724F6C4D90030DAD1 /* rules_testAttachData_invalidJson.json in Resources */,
 				3F5D45FD25190E8D0040E298 /* rules_testTransform.json in Resources */,
 				BBA512B324F5CF380030DAD1 /* rules_testAttachData.json in Resources */,

--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -382,6 +382,13 @@
 		BBA512BB24F6C6CA0030DAD1 /* rules_testModifyData_invalidJson.json in Resources */ = {isa = PBXBuildFile; fileRef = BBA512BA24F6C6CA0030DAD1 /* rules_testModifyData_invalidJson.json */; };
 		BBE1294F24DBBBD60045CD8D /* Dictionary+FlattenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE1294E24DBBBD60045CD8D /* Dictionary+FlattenTests.swift */; };
 		BBE1295124DBCE870045CD8D /* TokenFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE1295024DBCE870045CD8D /* TokenFinderTests.swift */; };
+		BF4A6EB826BB3B9D00612434 /* rules_testDispatchEventCopy.json in Resources */ = {isa = PBXBuildFile; fileRef = BF4A6EB726BB3B9D00612434 /* rules_testDispatchEventCopy.json */; };
+		BF4A6EE726BB47FE00612434 /* rules_testDispatchEventNewData.json in Resources */ = {isa = PBXBuildFile; fileRef = BF4A6EE626BB47FE00612434 /* rules_testDispatchEventNewData.json */; };
+		BF4A6F0526BB48A200612434 /* rules_testDispatchEventNewNoData.json in Resources */ = {isa = PBXBuildFile; fileRef = BF4A6F0426BB48A200612434 /* rules_testDispatchEventNewNoData.json */; };
+		BF4A6F2626BB4A1B00612434 /* rules_testDispatchEventNoAction.json in Resources */ = {isa = PBXBuildFile; fileRef = BF4A6F2226BB4A1A00612434 /* rules_testDispatchEventNoAction.json */; };
+		BF4A6F2726BB4A1B00612434 /* rules_testDispatchEventInvalidAction.json in Resources */ = {isa = PBXBuildFile; fileRef = BF4A6F2326BB4A1A00612434 /* rules_testDispatchEventInvalidAction.json */; };
+		BF4A6F2826BB4A1B00612434 /* rules_testDispatchEventNoSource.json in Resources */ = {isa = PBXBuildFile; fileRef = BF4A6F2426BB4A1B00612434 /* rules_testDispatchEventNoSource.json */; };
+		BF4A6F2926BB4A1B00612434 /* rules_testDispatchEventNoType.json in Resources */ = {isa = PBXBuildFile; fileRef = BF4A6F2526BB4A1B00612434 /* rules_testDispatchEventNoType.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -992,6 +999,13 @@
 		BBA512BA24F6C6CA0030DAD1 /* rules_testModifyData_invalidJson.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_testModifyData_invalidJson.json; sourceTree = "<group>"; };
 		BBE1294E24DBBBD60045CD8D /* Dictionary+FlattenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+FlattenTests.swift"; sourceTree = "<group>"; };
 		BBE1295024DBCE870045CD8D /* TokenFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenFinderTests.swift; sourceTree = "<group>"; };
+		BF4A6EB726BB3B9D00612434 /* rules_testDispatchEventCopy.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_testDispatchEventCopy.json; sourceTree = "<group>"; };
+		BF4A6EE626BB47FE00612434 /* rules_testDispatchEventNewData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_testDispatchEventNewData.json; sourceTree = "<group>"; };
+		BF4A6F0426BB48A200612434 /* rules_testDispatchEventNewNoData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_testDispatchEventNewNoData.json; sourceTree = "<group>"; };
+		BF4A6F2226BB4A1A00612434 /* rules_testDispatchEventNoAction.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_testDispatchEventNoAction.json; sourceTree = "<group>"; };
+		BF4A6F2326BB4A1A00612434 /* rules_testDispatchEventInvalidAction.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_testDispatchEventInvalidAction.json; sourceTree = "<group>"; };
+		BF4A6F2426BB4A1B00612434 /* rules_testDispatchEventNoSource.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_testDispatchEventNoSource.json; sourceTree = "<group>"; };
+		BF4A6F2526BB4A1B00612434 /* rules_testDispatchEventNoType.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_testDispatchEventNoType.json; sourceTree = "<group>"; };
 		C63E76D9752A3702439C65D2 /* Pods-AEPIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPIntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-AEPIntegrationTests/Pods-AEPIntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C63ECCE4276B2C8008629BA4 /* Pods-AEPCore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPCore.debug.xcconfig"; path = "Target Support Files/Pods-AEPCore/Pods-AEPCore.debug.xcconfig"; sourceTree = "<group>"; };
 		D6A7B39F8D2A807344E7098B /* Pods_AEPLifecycleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AEPLifecycleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1655,30 +1669,37 @@
 		3F3951EC24CA096100F7325B /* TestResources */ = {
 			isa = PBXGroup;
 			children = (
-				3F08FF9A24DA0DA100D34DE3 /* rules_functional_1.zip */,
-				3F3951ED24CA096100F7325B /* TestRules.zip */,
-				3F3951EE24CA096100F7325B /* TestImage.png */,
-				3F3951EF24CA096100F7325B /* rules_1.json */,
 				3F3951F024CA096100F7325B /* ADBMobileConfig.json */,
-				3F3951F124CA096100F7325B /* TestConfig.json */,
-				3F3951F224CA096100F7325B /* testRulesDownloader.zip */,
-				BBA5129724F4588E0030DAD1 /* rules_testGroupLogicalOperators.json */,
-				BBA5129A24F477550030DAD1 /* rules_testMatcherNe.json */,
-				BBA5129C24F4899B0030DAD1 /* rules_testMatcherGt.json */,
-				BBA5129E24F4A14C0030DAD1 /* rules_testMatcherGe.json */,
-				BBA512A024F4A15C0030DAD1 /* rules_testMatcherLt.json */,
-				BBA512A224F4A16A0030DAD1 /* rules_testMatcherLe.json */,
-				BBA512A424F4A1790030DAD1 /* rules_testMatcherCo.json */,
-				BBA512A624F4A18B0030DAD1 /* rules_testMatcherNc.json */,
-				BBA512A824F4A7EE0030DAD1 /* rules_testMatcherNx.json */,
-				BBA512B124F5CF380030DAD1 /* rules_testAttachData.json */,
+				3F3951EF24CA096100F7325B /* rules_1.json */,
+				3F08FF9A24DA0DA100D34DE3 /* rules_functional_1.zip */,
 				BBA512B624F6C4D90030DAD1 /* rules_testAttachData_invalidJson.json */,
-				BBA512B224F5CF380030DAD1 /* rules_testModifyData.json */,
-				BBA512BA24F6C6CA0030DAD1 /* rules_testModifyData_invalidJson.json */,
-				BB3E86DC24F86B4100E39C53 /* rules_testUrlenc.json */,
-				BB3E86DF24F86E6200E39C53 /* rules_testUrlenc_invalidFnName.json */,
+				BBA512B124F5CF380030DAD1 /* rules_testAttachData.json */,
+				BF4A6EB726BB3B9D00612434 /* rules_testDispatchEventCopy.json */,
+				BF4A6F2326BB4A1A00612434 /* rules_testDispatchEventInvalidAction.json */,
+				BF4A6EE626BB47FE00612434 /* rules_testDispatchEventNewData.json */,
+				BF4A6F0426BB48A200612434 /* rules_testDispatchEventNewNoData.json */,
+				BF4A6F2226BB4A1A00612434 /* rules_testDispatchEventNoAction.json */,
+				BF4A6F2426BB4A1B00612434 /* rules_testDispatchEventNoSource.json */,
+				BF4A6F2526BB4A1B00612434 /* rules_testDispatchEventNoType.json */,
+				BBA5129724F4588E0030DAD1 /* rules_testGroupLogicalOperators.json */,
+				BBA512A424F4A1790030DAD1 /* rules_testMatcherCo.json */,
+				BBA5129E24F4A14C0030DAD1 /* rules_testMatcherGe.json */,
+				BBA5129C24F4899B0030DAD1 /* rules_testMatcherGt.json */,
+				BBA512A224F4A16A0030DAD1 /* rules_testMatcherLe.json */,
+				BBA512A024F4A15C0030DAD1 /* rules_testMatcherLt.json */,
+				BBA512A624F4A18B0030DAD1 /* rules_testMatcherNc.json */,
+				BBA5129A24F477550030DAD1 /* rules_testMatcherNe.json */,
+				BBA512A824F4A7EE0030DAD1 /* rules_testMatcherNx.json */,
 				BB3E86E124F975E000E39C53 /* rules_testMatcherWithDifferentTypesOfParameters.json */,
+				BBA512BA24F6C6CA0030DAD1 /* rules_testModifyData_invalidJson.json */,
+				BBA512B224F5CF380030DAD1 /* rules_testModifyData.json */,
 				3F5D45FC25190E8C0040E298 /* rules_testTransform.json */,
+				BB3E86DF24F86E6200E39C53 /* rules_testUrlenc_invalidFnName.json */,
+				BB3E86DC24F86B4100E39C53 /* rules_testUrlenc.json */,
+				3F3951F124CA096100F7325B /* TestConfig.json */,
+				3F3951EE24CA096100F7325B /* TestImage.png */,
+				3F3951ED24CA096100F7325B /* TestRules.zip */,
+				3F3951F224CA096100F7325B /* testRulesDownloader.zip */,
 			);
 			path = TestResources;
 			sourceTree = "<group>";
@@ -2395,6 +2416,8 @@
 				BB3E86DE24F86B6700E39C53 /* rules_testUrlenc.json in Resources */,
 				BBA512A724F4A18B0030DAD1 /* rules_testMatcherNc.json in Resources */,
 				BBA512B424F5CF380030DAD1 /* rules_testModifyData.json in Resources */,
+				BF4A6F2726BB4A1B00612434 /* rules_testDispatchEventInvalidAction.json in Resources */,
+				BF4A6EE726BB47FE00612434 /* rules_testDispatchEventNewData.json in Resources */,
 				3F08FF9B24DA0DA100D34DE3 /* rules_functional_1.zip in Resources */,
 				3F39520C24CA096100F7325B /* rules_1.json in Resources */,
 				BBA512A524F4A1790030DAD1 /* rules_testMatcherCo.json in Resources */,
@@ -2403,10 +2426,15 @@
 				BB3E86E224F975E000E39C53 /* rules_testMatcherWithDifferentTypesOfParameters.json in Resources */,
 				3F39520D24CA096100F7325B /* ADBMobileConfig.json in Resources */,
 				BBA5129D24F4899B0030DAD1 /* rules_testMatcherGt.json in Resources */,
+				BF4A6F0526BB48A200612434 /* rules_testDispatchEventNewNoData.json in Resources */,
+				BF4A6F2826BB4A1B00612434 /* rules_testDispatchEventNoSource.json in Resources */,
+				BF4A6EB826BB3B9D00612434 /* rules_testDispatchEventCopy.json in Resources */,
 				3F39520F24CA096100F7325B /* testRulesDownloader.zip in Resources */,
+				BF4A6F2626BB4A1B00612434 /* rules_testDispatchEventNoAction.json in Resources */,
 				3F39520A24CA096100F7325B /* TestRules.zip in Resources */,
 				3F39520E24CA096100F7325B /* TestConfig.json in Resources */,
 				3F39520B24CA096100F7325B /* TestImage.png in Resources */,
+				BF4A6F2926BB4A1B00612434 /* rules_testDispatchEventNoType.json in Resources */,
 				BBA512BB24F6C6CA0030DAD1 /* rules_testModifyData_invalidJson.json in Resources */,
 				BB3E86E024F86E6200E39C53 /* rules_testUrlenc_invalidFnName.json in Resources */,
 				BBA512A324F4A16A0030DAD1 /* rules_testMatcherLe.json in Resources */,

--- a/AEPCore/Sources/eventhub/EventSource.swift
+++ b/AEPCore/Sources/eventhub/EventSource.swift
@@ -32,4 +32,6 @@ public class EventSource: NSObject {
     public static let removeIdentity = "com.adobe.eventSource.removeIdentity"
     public static let wildcard = "com.adobe.eventSource._wildcard_"
     public static let resetComplete = "com.adobe.eventSource.resetComplete"
+    public static let applicationLaunch = "com.adobe.eventSource.applicationLaunch"
+    public static let applicationClose = "com.adobe.eventSource.applicationClose"
 }

--- a/AEPCore/Sources/rules/LaunchRulesEngine.swift
+++ b/AEPCore/Sources/rules/LaunchRulesEngine.swift
@@ -265,3 +265,17 @@ public class LaunchRulesEngine {
         return Event(name: LaunchRulesEngine.CONSEQUENCE_EVENT_NAME, type: EventType.rulesEngine, source: EventSource.responseContent, data: [LaunchRulesEngine.CONSEQUENCE_EVENT_DATA_KEY_CONSEQUENCE: dict])
     }
 }
+
+extension RuleConsequence {
+    public var eventSource: String? {
+        return details["source"] as? String
+    }
+
+    public var eventType: String? {
+        return details["type"] as? String
+    }
+
+    public var eventDataAction: String? {
+        return details["eventdataaction"] as? String
+    }
+}

--- a/AEPCore/Sources/rules/LaunchRulesEngine.swift
+++ b/AEPCore/Sources/rules/LaunchRulesEngine.swift
@@ -150,19 +150,17 @@ public class LaunchRulesEngine {
                         Log.error(label: LOG_TAG, "(\(self.name)) : Unable to process a DispatchConsequence Event, 'eventdataaction' is missing from 'details'")
                         continue
                     }
-                    
-                    var dispatchEventData:[String:Any]?
-                    if (action == LaunchRulesEngine.CONSEQUENCE_DETAIL_ACTION_COPY) {
+
+                    var dispatchEventData: [String: Any]?
+                    if action == LaunchRulesEngine.CONSEQUENCE_DETAIL_ACTION_COPY {
                         dispatchEventData = eventData // copy event data from triggering event
-                    }
-                    else if (action == LaunchRulesEngine.CONSEQUENCE_DETAIL_ACTION_NEW) {
-                        dispatchEventData = consequenceWithConcreteValue.eventData as? [String : Any]
-                    }
-                    else {
+                    } else if action == LaunchRulesEngine.CONSEQUENCE_DETAIL_ACTION_NEW {
+                        dispatchEventData = consequenceWithConcreteValue.eventData?.compactMapValues { $0 }
+                    } else {
                         Log.error(label: LOG_TAG, "(\(self.name)) : Unable to process a DispatchConsequence Event, unsupported 'eventdataaction', expected values copy/new")
                         continue
                     }
-                    
+
                     let dispatchEvent = Event(name: LaunchRulesEngine.CONSEQUENCE_DISPATCH_EVENT_NAME,
                                               type: type,
                                               source: source,

--- a/AEPCore/Sources/rules/LaunchRulesEngine.swift
+++ b/AEPCore/Sources/rules/LaunchRulesEngine.swift
@@ -156,7 +156,7 @@ public class LaunchRulesEngine {
                         dispatchEventData = eventData // copy event data from triggering event
                     }
                     else if (action == LaunchRulesEngine.CONSEQUENCE_DETAIL_ACTION_NEW) {
-                        dispatchEventData = (consequenceWithConcreteValue.eventData ?? [:]) as [String : Any]
+                        dispatchEventData = consequenceWithConcreteValue.eventData as? [String : Any]
                     }
                     else {
                         Log.error(label: LOG_TAG, "(\(self.name)) : Unable to process a DispatchConsequence Event, unsupported 'eventdataaction', expected values copy/new")

--- a/AEPCore/Sources/rules/RuleConsequence.swift
+++ b/AEPCore/Sources/rules/RuleConsequence.swift
@@ -21,15 +21,15 @@ public struct RuleConsequence {
     public var eventData: [String: Any?]? {
         return details["eventdata"] as? [String: Any?]
     }
-    
+
     public var eventSource: String? {
         return details["source"] as? String
     }
-    
+
     public var eventType: String? {
         return details["type"] as? String
     }
-    
+
     public var eventDataAction: String? {
         return details["eventdataaction"] as? String
     }

--- a/AEPCore/Sources/rules/RuleConsequence.swift
+++ b/AEPCore/Sources/rules/RuleConsequence.swift
@@ -22,18 +22,6 @@ public struct RuleConsequence {
         return details["eventdata"] as? [String: Any?]
     }
 
-    public var eventSource: String? {
-        return details["source"] as? String
-    }
-
-    public var eventType: String? {
-        return details["type"] as? String
-    }
-
-    public var eventDataAction: String? {
-        return details["eventdataaction"] as? String
-    }
-
     public init(id: String, type: String, details: [String: Any?]) {
         self.id = id
         self.type = type

--- a/AEPCore/Sources/rules/RuleConsequence.swift
+++ b/AEPCore/Sources/rules/RuleConsequence.swift
@@ -21,6 +21,18 @@ public struct RuleConsequence {
     public var eventData: [String: Any?]? {
         return details["eventdata"] as? [String: Any?]
     }
+    
+    public var eventSource: String? {
+        return details["source"] as? String
+    }
+    
+    public var eventType: String? {
+        return details["type"] as? String
+    }
+    
+    public var eventDataAction: String? {
+        return details["eventdataaction"] as? String
+    }
 
     public init(id: String, type: String, details: [String: Any?]) {
         self.id = id

--- a/AEPCore/Tests/FunctionalTests/RulesEngineFunctionalTests.swift
+++ b/AEPCore/Tests/FunctionalTests/RulesEngineFunctionalTests.swift
@@ -605,6 +605,250 @@ class RulesEngineFunctionalTests: XCTestCase {
 
         XCTAssertTrue(lifecycleContextData["launches"] == nil)
     }
+    
+    func testDispatchEvent_copy() {
+        /// Given: a launch rule to dispatch an event which copies the triggering event data
+
+        //    ---------- dispatch event rule ----------
+        //        "detail": {
+        //          "type" : "com.adobe.eventType.edge",
+        //          "source" : "com.adobe.eventSource.requestContent",
+        //          "eventdataaction" : "copy"
+        //        }
+        //    --------------------------------------
+
+        resetRulesEngine(withNewRules: "rules_testDispatchEventCopy")
+
+        let event = Event(name: "Application Launch",
+                          type: EventType.lifecycle,
+                          source: EventSource.applicationLaunch,
+                          data: ["xdm": "test data"])
+        
+        let processedEvent = rulesEngine.process(event: event)
+
+        /// Then: One consequence event will be dispatched
+
+        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
+        let dispatchedEvent = mockRuntime.dispatchedEvents[0]
+        
+        XCTAssertEqual(EventType.edge, dispatchedEvent.type)
+        XCTAssertEqual(EventSource.requestContent, dispatchedEvent.source)
+        XCTAssertEqual(event.data as? [String : String], dispatchedEvent.data as? [String : String])
+        
+        // verify original event is unchanged
+        XCTAssertEqual(event, processedEvent)
+    }
+    
+    func testDispatchEvent_copyNoEventData() {
+        /// Given: a launch rule to dispatch an event which copies the triggering event data, but none is given
+
+        //    ---------- dispatch event rule ----------
+        //        "detail": {
+        //          "type" : "com.adobe.eventType.edge",
+        //          "source" : "com.adobe.eventSource.requestContent",
+        //          "eventdataaction" : "copy"
+        //        }
+        //    --------------------------------------
+
+        resetRulesEngine(withNewRules: "rules_testDispatchEventCopy")
+
+        let event = Event(name: "Application Launch",
+                          type: EventType.lifecycle,
+                          source: EventSource.applicationLaunch,
+                          data: nil)
+        
+        let processedEvent = rulesEngine.process(event: event)
+
+        /// Then: One consequence event will be dispatched
+
+        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
+        let dispatchedEvent = mockRuntime.dispatchedEvents[0]
+        
+        XCTAssertEqual(EventType.edge, dispatchedEvent.type)
+        XCTAssertEqual(EventSource.requestContent, dispatchedEvent.source)
+        XCTAssertNil(dispatchedEvent.data)
+        
+        // verify original event is unchanged
+        XCTAssertEqual(event, processedEvent)
+    }
+    
+    func testDispatchEvent_newData() {
+        /// Given: a launch rule to dispatch an event which adds new event data
+
+        //    ---------- dispatch event rule ----------
+        //        "detail": {
+        //          "type" : "com.adobe.eventType.edge",
+        //          "source" : "com.adobe.eventSource.requestContent",
+        //          "eventdataaction" : "new",
+        //          "eventdata" : {
+        //            "key" : "value",
+        //            "key.subkey" : "subvalue",
+        //            "launches": "{%~state.com.adobe.module.lifecycle/lifecyclecontextdata.launches%}",
+        //          }
+        //        }
+        //    --------------------------------------
+
+        resetRulesEngine(withNewRules: "rules_testDispatchEventNewData")
+
+        let event = Event(name: "Application Launch",
+                          type: EventType.lifecycle,
+                          source: EventSource.applicationLaunch,
+                          data: ["xdm": "test data"])
+        mockRuntime.simulateSharedState(for: "com.adobe.module.lifecycle", data: (value: ["lifecyclecontextdata": ["launches": 2]], status: .set))
+        let processedEvent = rulesEngine.process(event: event)
+
+        /// Then: One consequence event will be dispatched
+
+        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
+        let dispatchedEvent = mockRuntime.dispatchedEvents[0]
+        
+        XCTAssertEqual(EventType.edge, dispatchedEvent.type)
+        XCTAssertEqual(EventSource.requestContent, dispatchedEvent.source)
+        XCTAssertEqual(3, dispatchedEvent.data?.count)
+        XCTAssertEqual("value", dispatchedEvent.data?["key"] as? String)
+        XCTAssertEqual("subvalue", dispatchedEvent.data?["key.subkey"] as? String)
+        XCTAssertEqual("2", dispatchedEvent.data?["launches"] as? String)
+        
+        // verify original event is unchanged
+        XCTAssertEqual(event, processedEvent)
+    }
+    
+    func testDispatchEvent_newNoData() {
+        /// Given: a launch rule to dispatch an event which adds new event event data, but none is configured
+
+        //    ---------- dispatch event rule ----------
+        //        "detail": {
+        //          "type" : "com.adobe.eventType.edge",
+        //          "source" : "com.adobe.eventSource.requestContent",
+        //          "eventdataaction" : "new",
+        //        }
+        //    --------------------------------------
+
+        resetRulesEngine(withNewRules: "rules_testDispatchEventNewNoData")
+
+        let event = Event(name: "Application Launch",
+                          type: EventType.lifecycle,
+                          source: EventSource.applicationLaunch,
+                          data: ["xdm": "test data"])
+        let processedEvent = rulesEngine.process(event: event)
+
+        /// Then: One consequence event will be dispatched
+
+        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
+        let dispatchedEvent = mockRuntime.dispatchedEvents[0]
+        
+        XCTAssertEqual(EventType.edge, dispatchedEvent.type)
+        XCTAssertEqual(EventSource.requestContent, dispatchedEvent.source)
+        XCTAssertNil(dispatchedEvent.data)
+
+        // verify original event is unchanged
+        XCTAssertEqual(event, processedEvent)
+    }
+
+    func testDispatchEvent_invalidAction() {
+        /// Given: a launch rule to dispatch an event with invalid action
+
+        //    ---------- dispatch event rule ----------
+        //        "detail": {
+        //          "type" : "com.adobe.eventType.edge",
+        //          "source" : "com.adobe.eventSource.requestContent",
+        //          "eventdataaction" : "invalid",
+        //        }
+        //    --------------------------------------
+
+        resetRulesEngine(withNewRules: "rules_testDispatchEventInvalidAction")
+
+        let event = Event(name: "Application Launch",
+                          type: EventType.lifecycle,
+                          source: EventSource.applicationLaunch,
+                          data: ["xdm": "test data"])
+        let processedEvent = rulesEngine.process(event: event)
+
+        /// Then: No consequence event will be dispatched
+
+        XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
+
+        // verify original event is unchanged
+        XCTAssertEqual(event, processedEvent)
+    }
+
+    func testDispatchEvent_noAction() {
+        /// Given: a launch rule to dispatch an event with no action specified in details
+
+        //    ---------- dispatch event rule ----------
+        //        "detail": {
+        //          "type" : "com.adobe.eventType.edge",
+        //          "source" : "com.adobe.eventSource.requestContent"
+        //        }
+        //    --------------------------------------
+
+        resetRulesEngine(withNewRules: "rules_testDispatchEventNoAction")
+
+        let event = Event(name: "Application Launch",
+                          type: EventType.lifecycle,
+                          source: EventSource.applicationLaunch,
+                          data: ["xdm": "test data"])
+        let processedEvent = rulesEngine.process(event: event)
+
+        /// Then: No consequence event will be dispatched
+
+        XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
+
+        // verify original event is unchanged
+        XCTAssertEqual(event, processedEvent)
+    }
+    
+    func testDispatchEvent_noType() {
+        /// Given: a launch rule to dispatch an event with no type specified in details
+
+        //    ---------- dispatch event rule ----------
+        //        "detail": {
+        //          "source" : "com.adobe.eventSource.requestContent",
+        //          "eventdataaction" : "copy"
+        //        }
+        //    --------------------------------------
+
+        resetRulesEngine(withNewRules: "rules_testDispatchEventNoType")
+
+        let event = Event(name: "Application Launch",
+                          type: EventType.lifecycle,
+                          source: EventSource.applicationLaunch,
+                          data: ["xdm": "test data"])
+        let processedEvent = rulesEngine.process(event: event)
+
+        /// Then: No consequence event will be dispatched
+
+        XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
+
+        // verify original event is unchanged
+        XCTAssertEqual(event, processedEvent)
+    }
+    
+    func testDispatchEvent_noSource() {
+        /// Given: a launch rule to dispatch an event with no source specified in details
+
+        //    ---------- dispatch event rule ----------
+        //        "detail": {
+        //          "type" : "com.adobe.eventType.edge",
+        //          "eventdataaction" : "copy"
+        //        }
+        //    --------------------------------------
+
+        resetRulesEngine(withNewRules: "rules_testDispatchEventNoSource")
+
+        let event = Event(name: "Application Launch",
+                          type: EventType.lifecycle,
+                          source: EventSource.applicationLaunch,
+                          data: ["xdm": "test data"])
+        let processedEvent = rulesEngine.process(event: event)
+
+        /// Then: No consequence event will be dispatched
+
+        XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
+
+        // verify original event is unchanged
+        XCTAssertEqual(event, processedEvent)
+    }
 
 
     // MARK: - Transforming tests

--- a/AEPCore/Tests/FunctionalTests/RulesEngineFunctionalTests.swift
+++ b/AEPCore/Tests/FunctionalTests/RulesEngineFunctionalTests.swift
@@ -605,7 +605,7 @@ class RulesEngineFunctionalTests: XCTestCase {
 
         XCTAssertTrue(lifecycleContextData["launches"] == nil)
     }
-    
+
     func testDispatchEvent_copy() {
         /// Given: a launch rule to dispatch an event which copies the triggering event data
 
@@ -623,22 +623,22 @@ class RulesEngineFunctionalTests: XCTestCase {
                           type: EventType.lifecycle,
                           source: EventSource.applicationLaunch,
                           data: ["xdm": "test data"])
-        
+
         let processedEvent = rulesEngine.process(event: event)
 
         /// Then: One consequence event will be dispatched
 
         XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
         let dispatchedEvent = mockRuntime.dispatchedEvents[0]
-        
+
         XCTAssertEqual(EventType.edge, dispatchedEvent.type)
         XCTAssertEqual(EventSource.requestContent, dispatchedEvent.source)
         XCTAssertEqual(event.data as? [String : String], dispatchedEvent.data as? [String : String])
-        
+
         // verify original event is unchanged
         XCTAssertEqual(event, processedEvent)
     }
-    
+
     func testDispatchEvent_copyNoEventData() {
         /// Given: a launch rule to dispatch an event which copies the triggering event data, but none is given
 
@@ -656,22 +656,22 @@ class RulesEngineFunctionalTests: XCTestCase {
                           type: EventType.lifecycle,
                           source: EventSource.applicationLaunch,
                           data: nil)
-        
+
         let processedEvent = rulesEngine.process(event: event)
 
         /// Then: One consequence event will be dispatched
 
         XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
         let dispatchedEvent = mockRuntime.dispatchedEvents[0]
-        
+
         XCTAssertEqual(EventType.edge, dispatchedEvent.type)
         XCTAssertEqual(EventSource.requestContent, dispatchedEvent.source)
         XCTAssertNil(dispatchedEvent.data)
-        
+
         // verify original event is unchanged
         XCTAssertEqual(event, processedEvent)
     }
-    
+
     func testDispatchEvent_newData() {
         /// Given: a launch rule to dispatch an event which adds new event data
 
@@ -701,18 +701,18 @@ class RulesEngineFunctionalTests: XCTestCase {
 
         XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
         let dispatchedEvent = mockRuntime.dispatchedEvents[0]
-        
+
         XCTAssertEqual(EventType.edge, dispatchedEvent.type)
         XCTAssertEqual(EventSource.requestContent, dispatchedEvent.source)
         XCTAssertEqual(3, dispatchedEvent.data?.count)
         XCTAssertEqual("value", dispatchedEvent.data?["key"] as? String)
         XCTAssertEqual("subvalue", dispatchedEvent.data?["key.subkey"] as? String)
         XCTAssertEqual("2", dispatchedEvent.data?["launches"] as? String)
-        
+
         // verify original event is unchanged
         XCTAssertEqual(event, processedEvent)
     }
-    
+
     func testDispatchEvent_newNoData() {
         /// Given: a launch rule to dispatch an event which adds new event event data, but none is configured
 
@@ -736,7 +736,7 @@ class RulesEngineFunctionalTests: XCTestCase {
 
         XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
         let dispatchedEvent = mockRuntime.dispatchedEvents[0]
-        
+
         XCTAssertEqual(EventType.edge, dispatchedEvent.type)
         XCTAssertEqual(EventSource.requestContent, dispatchedEvent.source)
         XCTAssertNil(dispatchedEvent.data)
@@ -797,7 +797,7 @@ class RulesEngineFunctionalTests: XCTestCase {
         // verify original event is unchanged
         XCTAssertEqual(event, processedEvent)
     }
-    
+
     func testDispatchEvent_noType() {
         /// Given: a launch rule to dispatch an event with no type specified in details
 
@@ -823,7 +823,7 @@ class RulesEngineFunctionalTests: XCTestCase {
         // verify original event is unchanged
         XCTAssertEqual(event, processedEvent)
     }
-    
+
     func testDispatchEvent_noSource() {
         /// Given: a launch rule to dispatch an event with no source specified in details
 

--- a/AEPCore/Tests/TestResources/rules_testDispatchEventChain.json
+++ b/AEPCore/Tests/TestResources/rules_testDispatchEventChain.json
@@ -1,0 +1,119 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "condition": {
+        "type": "group",
+        "definition": {
+          "logic": "and",
+          "conditions": [
+            {
+              "type": "group",
+              "definition": {
+                "logic": "or",
+                "conditions": [
+                  {
+                    "type": "group",
+                    "definition": {
+                      "logic": "and",
+                      "conditions": [
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~type",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventType.edge"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~source",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventSource.requestContent"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "consequences": [
+        {
+          "id": "48181acd22b3edaebc8a447868a7df7ce629920a",
+          "type": "dispatch",
+          "detail": {
+            "type" : "com.adobe.eventType.edge",
+            "source" : "com.adobe.eventSource.requestContent",
+            "eventdataaction" : "copy"
+          }
+        }
+      ]
+    },
+    {
+      "condition": {
+        "type": "group",
+        "definition": {
+          "logic": "and",
+          "conditions": [
+            {
+              "type": "group",
+              "definition": {
+                "logic": "or",
+                "conditions": [
+                  {
+                    "type": "group",
+                    "definition": {
+                      "logic": "and",
+                      "conditions": [
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~type",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventType.lifecycle"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~source",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventSource.applicationLaunch"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "consequences": [
+        {
+          "id": "48181acd22b3edaebc8a447868a7df7ce629920a",
+          "type": "dispatch",
+          "detail": {
+            "type" : "com.adobe.eventType.edge",
+            "source" : "com.adobe.eventSource.requestContent",
+            "eventdataaction" : "copy"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/AEPCore/Tests/TestResources/rules_testDispatchEventCopy.json
+++ b/AEPCore/Tests/TestResources/rules_testDispatchEventCopy.json
@@ -1,0 +1,62 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "condition": {
+        "type": "group",
+        "definition": {
+          "logic": "and",
+          "conditions": [
+            {
+              "type": "group",
+              "definition": {
+                "logic": "or",
+                "conditions": [
+                  {
+                    "type": "group",
+                    "definition": {
+                      "logic": "and",
+                      "conditions": [
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~type",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventType.lifecycle"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~source",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventSource.applicationLaunch"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "consequences": [
+        {
+          "id": "48181acd22b3edaebc8a447868a7df7ce629920a",
+          "type": "dispatch",
+          "detail": {
+            "type" : "com.adobe.eventType.edge",
+            "source" : "com.adobe.eventSource.requestContent",
+            "eventdataaction" : "copy"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/AEPCore/Tests/TestResources/rules_testDispatchEventInvalidAction.json
+++ b/AEPCore/Tests/TestResources/rules_testDispatchEventInvalidAction.json
@@ -1,0 +1,62 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "condition": {
+        "type": "group",
+        "definition": {
+          "logic": "and",
+          "conditions": [
+            {
+              "type": "group",
+              "definition": {
+                "logic": "or",
+                "conditions": [
+                  {
+                    "type": "group",
+                    "definition": {
+                      "logic": "and",
+                      "conditions": [
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~type",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventType.lifecycle"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~source",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventSource.applicationLaunch"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "consequences": [
+        {
+          "id": "48181acd22b3edaebc8a447868a7df7ce629920a",
+          "type": "dispatch",
+          "detail": {
+            "type" : "com.adobe.eventType.edge",
+            "source" : "com.adobe.eventSource.requestContent",
+            "eventdataaction" : "invalid"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/AEPCore/Tests/TestResources/rules_testDispatchEventNewData.json
+++ b/AEPCore/Tests/TestResources/rules_testDispatchEventNewData.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "condition": {
+        "type": "group",
+        "definition": {
+          "logic": "and",
+          "conditions": [
+            {
+              "type": "group",
+              "definition": {
+                "logic": "or",
+                "conditions": [
+                  {
+                    "type": "group",
+                    "definition": {
+                      "logic": "and",
+                      "conditions": [
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~type",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventType.lifecycle"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~source",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventSource.applicationLaunch"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "consequences": [
+        {
+          "id": "48181acd22b3edaebc8a447868a7df7ce629920a",
+          "type": "dispatch",
+          "detail": {
+            "type" : "com.adobe.eventType.edge",
+            "source" : "com.adobe.eventSource.requestContent",
+            "eventdataaction" : "new",
+            "eventdata" : {
+              "key" : "value",
+              "key.subkey" : "subvalue",
+              "launches": "{%~state.com.adobe.module.lifecycle/lifecyclecontextdata.launches%}"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/AEPCore/Tests/TestResources/rules_testDispatchEventNewNoData.json
+++ b/AEPCore/Tests/TestResources/rules_testDispatchEventNewNoData.json
@@ -1,0 +1,62 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "condition": {
+        "type": "group",
+        "definition": {
+          "logic": "and",
+          "conditions": [
+            {
+              "type": "group",
+              "definition": {
+                "logic": "or",
+                "conditions": [
+                  {
+                    "type": "group",
+                    "definition": {
+                      "logic": "and",
+                      "conditions": [
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~type",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventType.lifecycle"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~source",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventSource.applicationLaunch"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "consequences": [
+        {
+          "id": "48181acd22b3edaebc8a447868a7df7ce629920a",
+          "type": "dispatch",
+          "detail": {
+            "type" : "com.adobe.eventType.edge",
+            "source" : "com.adobe.eventSource.requestContent",
+            "eventdataaction" : "new"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/AEPCore/Tests/TestResources/rules_testDispatchEventNoAction.json
+++ b/AEPCore/Tests/TestResources/rules_testDispatchEventNoAction.json
@@ -1,0 +1,61 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "condition": {
+        "type": "group",
+        "definition": {
+          "logic": "and",
+          "conditions": [
+            {
+              "type": "group",
+              "definition": {
+                "logic": "or",
+                "conditions": [
+                  {
+                    "type": "group",
+                    "definition": {
+                      "logic": "and",
+                      "conditions": [
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~type",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventType.lifecycle"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~source",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventSource.applicationLaunch"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "consequences": [
+        {
+          "id": "48181acd22b3edaebc8a447868a7df7ce629920a",
+          "type": "dispatch",
+          "detail": {
+            "type" : "com.adobe.eventType.edge",
+            "source" : "com.adobe.eventSource.requestContent"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/AEPCore/Tests/TestResources/rules_testDispatchEventNoSource.json
+++ b/AEPCore/Tests/TestResources/rules_testDispatchEventNoSource.json
@@ -1,0 +1,61 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "condition": {
+        "type": "group",
+        "definition": {
+          "logic": "and",
+          "conditions": [
+            {
+              "type": "group",
+              "definition": {
+                "logic": "or",
+                "conditions": [
+                  {
+                    "type": "group",
+                    "definition": {
+                      "logic": "and",
+                      "conditions": [
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~type",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventType.lifecycle"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~source",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventSource.applicationLaunch"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "consequences": [
+        {
+          "id": "48181acd22b3edaebc8a447868a7df7ce629920a",
+          "type": "dispatch",
+          "detail": {
+            "type" : "com.adobe.eventType.edge",
+            "eventdataaction" : "copy"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/AEPCore/Tests/TestResources/rules_testDispatchEventNoType.json
+++ b/AEPCore/Tests/TestResources/rules_testDispatchEventNoType.json
@@ -1,0 +1,61 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "condition": {
+        "type": "group",
+        "definition": {
+          "logic": "and",
+          "conditions": [
+            {
+              "type": "group",
+              "definition": {
+                "logic": "or",
+                "conditions": [
+                  {
+                    "type": "group",
+                    "definition": {
+                      "logic": "and",
+                      "conditions": [
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~type",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventType.lifecycle"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~source",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventSource.applicationLaunch"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "consequences": [
+        {
+          "id": "48181acd22b3edaebc8a447868a7df7ce629920a",
+          "type": "dispatch",
+          "detail": {
+            "source" : "com.adobe.eventSource.requestContent",
+            "eventdataaction" : "copy"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Limit number of chained Dispatch Consequence events processed by the Core Rules Engine. 

internal ticket: mob-14753

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
