### PR TITLE
[AMSDK-11542] Fix a data race in Event class

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -332,6 +332,7 @@
 		92EEA6062589343700DBA3EE /* MessageMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EEA6052589343700DBA3EE /* MessageMonitor.swift */; };
 		92F06BFC25B8F1FE004C1700 /* MessageMonitoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F06BFB25B8F1FE004C1700 /* MessageMonitoring.swift */; };
 		92F06D0425BA33F4004C1700 /* Showable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F06D0325BA33F3004C1700 /* Showable.swift */; };
+		ACD255AD26C21A9B00532B1E /* EventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD255AC26C21A9B00532B1E /* EventTests.swift */; };
 		B2F223F8573D6B132F285AD7 /* Pods_AEPLifecycleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6A7B39F8D2A807344E7098B /* Pods_AEPLifecycleTests.framework */; };
 		B6D6A019265EC9D8005042BE /* FloatingButtonPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D6A018265EC9D8005042BE /* FloatingButtonPosition.swift */; };
 		B6D6A02D26601279005042BE /* FloatingButtonPositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D6A02C26601279005042BE /* FloatingButtonPositionTests.swift */; };
@@ -929,6 +930,7 @@
 		92F06D0325BA33F3004C1700 /* Showable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Showable.swift; sourceTree = "<group>"; };
 		9444FBB20EFFE94F7726A49F /* Pods_AEPCoreTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AEPCoreTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A63AA3E0DA8692271AC7C724 /* Pods-AEPLifecycleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPLifecycleTests.release.xcconfig"; path = "Target Support Files/Pods-AEPLifecycleTests/Pods-AEPLifecycleTests.release.xcconfig"; sourceTree = "<group>"; };
+		ACD255AC26C21A9B00532B1E /* EventTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventTests.swift; sourceTree = "<group>"; };
 		B414FF5745B34BC95CF624DC /* Pods_AEPIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AEPIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6D6A018265EC9D8005042BE /* FloatingButtonPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingButtonPosition.swift; sourceTree = "<group>"; };
 		B6D6A02C26601279005042BE /* FloatingButtonPositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingButtonPositionTests.swift; sourceTree = "<group>"; };
@@ -1592,6 +1594,7 @@
 		3F3951E924CA096100F7325B /* EventHubTests */ = {
 			isa = PBXGroup;
 			children = (
+				ACD255AC26C21A9B00532B1E /* EventTests.swift */,
 				3F3951EB24CA096100F7325B /* EventHubTests.swift */,
 				3F3951EA24CA096100F7325B /* SharedStateTest.swift */,
 			);
@@ -2896,6 +2899,7 @@
 				78AA4ECB2513AF4200205AE9 /* ConfigurationAppIDTests.swift in Sources */,
 				3F16762824F031A00041B970 /* EventHubContractTests.swift in Sources */,
 				BBE1295124DBCE870045CD8D /* TokenFinderTests.swift in Sources */,
+				ACD255AD26C21A9B00532B1E /* EventTests.swift in Sources */,
 				3F5D45FB251904F00040E298 /* LaunchRuleTransformerTests.swift in Sources */,
 				3F39521624CA096200F7325B /* MockNetworkServiceOverrider.swift in Sources */,
 				3F16762A24F032C60041B970 /* ContractExtensionOne.swift in Sources */,

--- a/AEPCore/Sources/eventhub/Event.swift
+++ b/AEPCore/Sources/eventhub/Event.swift
@@ -29,13 +29,13 @@ public class Event: NSObject, Codable {
     @objc public let source: String
 
     /// Optional data associated with this event
-    @objc public internal(set) var data: [String: Any]?
+    @objc public private(set) var data: [String: Any]?
 
     /// Date this event was created
     @objc public private(set) var timestamp = Date()
 
     /// If `responseID` is not nil, then this event is a response event and `responseID` is the `event.id` of the `triggerEvent`
-    @objc public let responseID: UUID?
+    @objc public private(set) var responseID: UUID?
 
     /// Event description used for logging
     @objc override public var description: String {
@@ -89,6 +89,16 @@ public class Event: NSObject, Codable {
         return Event(name: name, type: type, source: source, data: data, requestEvent: self)
     }
 
+    /// Clones the current `Event` with updated data
+    /// - Parameters:
+    ///   - data: Any associated data with this `Event`
+    internal func copyWithNewData(data: [String: Any]?) -> Event {
+        let newEvent = Event(name: self.name, type: self.type, source: self.source, data: data)
+        newEvent.id = self.id
+        newEvent.timestamp = self.timestamp
+        newEvent.responseID = self.responseID
+        return newEvent
+    }
     // MARK: - Codable
 
     enum CodingKeys: String, CodingKey {

--- a/AEPCore/Tests/EventHubTests/EventTests.swift
+++ b/AEPCore/Tests/EventHubTests/EventTests.swift
@@ -1,0 +1,62 @@
+/*
+ Copyright 2020 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import XCTest
+
+@testable import AEPCore
+
+class EventTest: XCTestCase {
+    
+    func testCopyWithNewData() {
+        let data: [String: Any] = [ "k1": "v1", "k2": "v2"]
+        let event = Event(name: "name", type: "type", source: "source", data: data)
+        
+        let newData: [String: Any] = [ "nk1": "nv1", "nk2": "nv2"]
+        let newEvent = event.copyWithNewData(data: newData)
+        
+        XCTAssertEqual(event.id, newEvent.id)
+        XCTAssertEqual(event.name, newEvent.name)
+        XCTAssertEqual(event.timestamp, newEvent.timestamp)
+        XCTAssertEqual(event.source, newEvent.source)
+        XCTAssertEqual(event.type, newEvent.type)
+        
+        let eventData = event.data ?? [:]
+        XCTAssertTrue(NSDictionary(dictionary: eventData).isEqual(to: data))
+        
+        let newEventData = newEvent.data ?? [:]
+        XCTAssertTrue(NSDictionary(dictionary: newEventData).isEqual(to: newData))
+    }
+    
+    func testCopyWithNewDataResponseEvent() {
+        let requestEvent = Event(name: "name", type: "type", source: "source", data: nil)
+        
+        let data: [String: Any] = [ "k1": "v1", "k2": "v2"]
+        let responseEvent = requestEvent.createResponseEvent(name: "responseEvent", type: "type", source: "source", data: data)
+        
+        let newData: [String: Any] = [ "nk1": "nv1", "nk2": "nv2"]
+        let newEvent = responseEvent.copyWithNewData(data: newData)
+        
+        XCTAssertEqual(responseEvent.id, newEvent.id)
+        XCTAssertEqual(responseEvent.name, newEvent.name)
+        XCTAssertEqual(responseEvent.timestamp, newEvent.timestamp)
+        XCTAssertEqual(responseEvent.source, newEvent.source)
+        XCTAssertEqual(responseEvent.type, newEvent.type)
+        XCTAssertEqual(responseEvent.responseID, newEvent.responseID)
+        XCTAssertNotNil(responseEvent.responseID)
+        
+        let eventData = responseEvent.data ?? [:]
+        XCTAssertTrue(NSDictionary(dictionary: eventData).isEqual(to: data))
+        
+        let newEventData = newEvent.data ?? [:]
+        XCTAssertTrue(NSDictionary(dictionary: newEventData).isEqual(to: newData))
+    }
+}

--- a/AEPSignal/Tests/Event+SignalTests.swift
+++ b/AEPSignal/Tests/Event+SignalTests.swift
@@ -86,12 +86,14 @@ class EventPlusSignalTests: XCTestCase {
     /// validate no consequence type found
     func testNoConsequenceType() throws {
         // setup
-        let event = getRulesResponseEvent(type: SignalConstants.ConsequenceTypes.POSTBACK)
         let triggeredConsequence: [String : Any] = [
             SignalConstants.EventDataKeys.ID : UUID().uuidString,
             SignalConstants.EventDataKeys.DETAIL : [:]
         ]
-        event.data?[SignalConstants.EventDataKeys.TRIGGERED_CONSEQUENCE] = triggeredConsequence
+        let event = Event(name: "Test Rules Engine response",
+                          type: EventType.rulesEngine,
+                          source: EventSource.responseContent,
+                          data: triggeredConsequence)
         
         // verify
         XCTAssertFalse(event.isPostback)
@@ -102,11 +104,13 @@ class EventPlusSignalTests: XCTestCase {
     /// validate no details in triggered consequence
     func testNoDetails() throws {
         // setup
-        let event = getRulesResponseEvent(type: SignalConstants.ConsequenceTypes.POSTBACK)
         let triggeredConsequence: [String : Any] = [
             SignalConstants.EventDataKeys.DETAIL : [:]
         ]
-        event.data?[SignalConstants.EventDataKeys.TRIGGERED_CONSEQUENCE] = triggeredConsequence
+        let event = Event(name: "Test Rules Engine response",
+                          type: EventType.rulesEngine,
+                          source: EventSource.responseContent,
+                          data: triggeredConsequence)
         
         // verify
         XCTAssertNil(event.contentType)

--- a/AEPSignal/Tests/SignalTests.swift
+++ b/AEPSignal/Tests/SignalTests.swift
@@ -166,8 +166,9 @@ class SignalTests: XCTestCase {
         let configData = getConfigSharedStateEventData(privacy: .optedIn)
         mockRuntime.simulateSharedState(for: SignalConstants.Configuration.NAME,
                                         data: (configData, .set))
-        let rulesEvent = getRulesResponseEvent(type: SignalConstants.ConsequenceTypes.POSTBACK)
-        rulesEvent.data = updateDetailDict(dict: rulesEvent.data!, withValue: nil, forKey: SignalConstants.EventDataKeys.TEMPLATE_URL)
+        var rulesEvent = getRulesResponseEvent(type: SignalConstants.ConsequenceTypes.POSTBACK)
+        let updatedEventData = updateDetailDict(dict: rulesEvent.data!, withValue: nil, forKey: SignalConstants.EventDataKeys.TEMPLATE_URL)
+        rulesEvent = rulesEvent.copyWithNewData(data: updatedEventData)
         
         // test
         mockRuntime.simulateComingEvents(rulesEvent)
@@ -182,8 +183,10 @@ class SignalTests: XCTestCase {
         let configData = getConfigSharedStateEventData(privacy: .optedIn)
         mockRuntime.simulateSharedState(for: SignalConstants.Configuration.NAME,
                                         data: (configData, .set))
-        let rulesEvent = getRulesResponseEvent(type: SignalConstants.ConsequenceTypes.PII)
-        rulesEvent.data = updateDetailDict(dict: rulesEvent.data!, withValue: "http://nope.com", forKey: SignalConstants.EventDataKeys.TEMPLATE_URL)
+
+        var rulesEvent = getRulesResponseEvent(type: SignalConstants.ConsequenceTypes.PII)
+        let updatedEventData = updateDetailDict(dict: rulesEvent.data!, withValue: "http://nope.com", forKey: SignalConstants.EventDataKeys.TEMPLATE_URL)
+        rulesEvent = rulesEvent.copyWithNewData(data: updatedEventData)
         
         // test
         mockRuntime.simulateComingEvents(rulesEvent)
@@ -198,9 +201,10 @@ class SignalTests: XCTestCase {
         let configData = getConfigSharedStateEventData(privacy: .optedIn)
         mockRuntime.simulateSharedState(for: SignalConstants.Configuration.NAME,
                                         data: (configData, .set))
-        let rulesEvent = getRulesResponseEvent(type: SignalConstants.ConsequenceTypes.POSTBACK)
-        rulesEvent.data = updateDetailDict(dict: rulesEvent.data!, withValue: "http://nope.com/invalid#@%@%things()#~@!", forKey: SignalConstants.EventDataKeys.TEMPLATE_URL)
-        
+        var rulesEvent = getRulesResponseEvent(type: SignalConstants.ConsequenceTypes.POSTBACK)
+        let updatedEventData = updateDetailDict(dict: rulesEvent.data!, withValue: "http://nope.com/invalid#@%@%things()#~@!", forKey: SignalConstants.EventDataKeys.TEMPLATE_URL)
+        rulesEvent = rulesEvent.copyWithNewData(data: updatedEventData)
+
         // test
         mockRuntime.simulateComingEvents(rulesEvent)
         
@@ -247,8 +251,9 @@ class SignalTests: XCTestCase {
         let configData = getConfigSharedStateEventData(privacy: .optedIn)
         mockRuntime.simulateSharedState(for: SignalConstants.Configuration.NAME,
                                         data: (configData, .set))
-        let rulesEvent = getRulesResponseEvent(type: SignalConstants.ConsequenceTypes.OPEN_URL)
-        rulesEvent.data = updateDetailDict(dict: rulesEvent.data!, withValue: nil, forKey: SignalConstants.EventDataKeys.URL)
+        var rulesEvent = getRulesResponseEvent(type: SignalConstants.ConsequenceTypes.OPEN_URL)
+        let updatedEventData = updateDetailDict(dict: rulesEvent.data!, withValue: nil, forKey: SignalConstants.EventDataKeys.URL)
+        rulesEvent = rulesEvent.copyWithNewData(data: updatedEventData)
         
         // test
         mockRuntime.simulateComingEvents(rulesEvent)
@@ -263,9 +268,10 @@ class SignalTests: XCTestCase {
         let configData = getConfigSharedStateEventData(privacy: .optedIn)
         mockRuntime.simulateSharedState(for: SignalConstants.Configuration.NAME,
                                         data: (configData, .set))
-        let rulesEvent = getRulesResponseEvent(type: SignalConstants.ConsequenceTypes.OPEN_URL)
-        rulesEvent.data = updateDetailDict(dict: rulesEvent.data!, withValue: "http://nope.com/invalid#@%@%things()#~@!", forKey: SignalConstants.EventDataKeys.URL)
-        
+        var rulesEvent = getRulesResponseEvent(type: SignalConstants.ConsequenceTypes.OPEN_URL)
+        let updatedEventData = updateDetailDict(dict: rulesEvent.data!, withValue: "http://nope.com/invalid#@%@%things()#~@!", forKey: SignalConstants.EventDataKeys.URL)
+        rulesEvent = rulesEvent.copyWithNewData(data: updatedEventData)
+
         // test
         mockRuntime.simulateComingEvents(rulesEvent)
         


### PR DESCRIPTION
Fix a data race in Event class where AttachData or ModifyData consequences where updating event data. 
Made Event class immutable and add a new API to clone Event object with new event data. 

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
