### PR TITLE
Rename XDMLifecycleLanguage and EventType 

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -350,6 +350,7 @@
 		92EEA6062589343700DBA3EE /* MessageMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EEA6052589343700DBA3EE /* MessageMonitor.swift */; };
 		92F06BFC25B8F1FE004C1700 /* MessageMonitoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F06BFB25B8F1FE004C1700 /* MessageMonitoring.swift */; };
 		92F06D0425BA33F4004C1700 /* Showable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F06D0325BA33F3004C1700 /* Showable.swift */; };
+		AC1089C926DD87C0004ABAC4 /* XDMLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1089C826DD87C0004ABAC4 /* XDMLanguage.swift */; };
 		AC4D8D4626D9AC0200A86435 /* EventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4D8D4526D9AC0200A86435 /* EventTests.swift */; };
 		ACD255AF26CE353000532B1E /* LifecycleV2StateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD255AE26CE353000532B1E /* LifecycleV2StateManager.swift */; };
 		ACD255B126CE51EA00532B1E /* LifecycleV2StateManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD255B026CE51EA00532B1E /* LifecycleV2StateManagerTests.swift */; };
@@ -990,6 +991,7 @@
 		9DE12D90D1BAF0798BC007AB /* Pods-AEPCore.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPCore.release.xcconfig"; path = "Target Support Files/Pods-AEPCore/Pods-AEPCore.release.xcconfig"; sourceTree = "<group>"; };
 		A5F5A65742E1DBDC25CF9F98 /* Pods-AEPIdentityTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPIdentityTests.debug.xcconfig"; path = "Target Support Files/Pods-AEPIdentityTests/Pods-AEPIdentityTests.debug.xcconfig"; sourceTree = "<group>"; };
 		AA4461A0B65C5DFE219540A5 /* Pods-TestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestApp.release.xcconfig"; path = "Target Support Files/Pods-TestApp/Pods-TestApp.release.xcconfig"; sourceTree = "<group>"; };
+		AC1089C826DD87C0004ABAC4 /* XDMLanguage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XDMLanguage.swift; sourceTree = "<group>"; };
 		AC4D8D4526D9AC0200A86435 /* EventTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventTests.swift; sourceTree = "<group>"; };
 		AC838996795DECE800B0A11B /* Pods-AEPIdentityTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPIdentityTests.release.xcconfig"; path = "Target Support Files/Pods-AEPIdentityTests/Pods-AEPIdentityTests.release.xcconfig"; sourceTree = "<group>"; };
 		ACD255AE26CE353000532B1E /* LifecycleV2StateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleV2StateManager.swift; sourceTree = "<group>"; };
@@ -1990,6 +1992,7 @@
 				21248116265D5E1C006CF300 /* XDMEnvironment.swift */,
 				212480A8265D591A006CF300 /* XDMEnvironmentType.swift */,
 				212480E6265D5A4E006CF300 /* XDMFormatters.swift */,
+				AC1089C826DD87C0004ABAC4 /* XDMLanguage.swift */,
 				21248126265D606A006CF300 /* XDMMobileLifecycleDetails.swift */,
 			);
 			path = LifecycleV2;
@@ -3250,6 +3253,7 @@
 				212480A9265D591A006CF300 /* XDMEnvironmentType.swift in Sources */,
 				212480E7265D5A4E006CF300 /* XDMFormatters.swift in Sources */,
 				3FE6DE0E24C630EB0065EA05 /* LifecycleState.swift in Sources */,
+				AC1089C926DD87C0004ABAC4 /* XDMLanguage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AEPLifecycle/Sources/LifecycleV2/LifecycleV2Constants.swift
+++ b/AEPLifecycle/Sources/LifecycleV2/LifecycleV2Constants.swift
@@ -18,7 +18,7 @@ enum LifecycleV2Constants {
     static let STATE_UPDATE_TIMEOUT_SEC = TimeInterval(2)
     static let CACHE_TIMEOUT_SECONDS = TimeInterval(2)
 
-    enum EventType {
+    enum XDMEventType {
         static let APP_LAUNCH = "application.launch"
         static let APP_CLOSE = "application.close"
     }

--- a/AEPLifecycle/Sources/LifecycleV2/LifecycleV2MetricsBuilder.swift
+++ b/AEPLifecycle/Sources/LifecycleV2/LifecycleV2MetricsBuilder.swift
@@ -19,6 +19,7 @@ import AEPServices
 ///  - XMD Device datatype
 ///  - XDM Application datatype
 class LifecycleV2MetricsBuilder {
+
     private var xdmDeviceInfo: XDMDevice?
     private var xdmEnvironmentInfo: XDMEnvironment?
 
@@ -34,7 +35,7 @@ class LifecycleV2MetricsBuilder {
         appLaunchXDMData.application = computeAppLaunchData(isInstall: isInstall, isUpgrade: isUpgrade)
         appLaunchXDMData.device = computeDeviceData()
         appLaunchXDMData.environment = computeEnvironmentData()
-        appLaunchXDMData.eventType = LifecycleV2Constants.EventType.APP_LAUNCH
+        appLaunchXDMData.eventType = LifecycleV2Constants.XDMEventType.APP_LAUNCH
         appLaunchXDMData.timestamp = launchDate
 
         return appLaunchXDMData.asDictionary()
@@ -51,7 +52,7 @@ class LifecycleV2MetricsBuilder {
         var appCloseXDMData = XDMMobileLifecycleDetails()
 
         appCloseXDMData.application = computeAppCloseData(launchDate: launchDate, closeDate: closeDate, isCloseUnknown: isCloseUnknown)
-        appCloseXDMData.eventType = LifecycleV2Constants.EventType.APP_CLOSE
+        appCloseXDMData.eventType = LifecycleV2Constants.XDMEventType.APP_CLOSE
         appCloseXDMData.timestamp = closeDate ?? fallbackCloseDate
 
         return appCloseXDMData.asDictionary()
@@ -120,7 +121,7 @@ class LifecycleV2MetricsBuilder {
         xdmEnvironmentInfo?.type = XDMEnvironmentType.from(runMode: systemInfoService.getRunMode())
         xdmEnvironmentInfo?.operatingSystem = systemInfoService.getOperatingSystemName()
         xdmEnvironmentInfo?.operatingSystemVersion = systemInfoService.getOperatingSystemVersion()
-        xdmEnvironmentInfo?.language = XDMLifecycleLanguage(language: systemInfoService.getFormattedLocale())
+        xdmEnvironmentInfo?.language = XDMLanguage(language: systemInfoService.getFormattedLocale())
 
         return xdmEnvironmentInfo
     }

--- a/AEPLifecycle/Sources/LifecycleV2/XDMEnvironment.swift
+++ b/AEPLifecycle/Sources/LifecycleV2/XDMEnvironment.swift
@@ -21,7 +21,7 @@ struct XDMEnvironment: Encodable {
     var carrier: String?
 
     /// The language of the environment to represent the user's linguistic, geographical, or cultural preferences for data presentation.
-    var language: XDMLifecycleLanguage?
+    var language: XDMLanguage?
 
     /// The name of the operating system used when the observation was made.
     var operatingSystem: String?
@@ -39,10 +39,4 @@ struct XDMEnvironment: Encodable {
         case operatingSystemVersion
         case type
     }
-
-}
-
-/// Helper struct to encode the language properly in the `XDMEnvironment`
-struct XDMLifecycleLanguage: Encodable {
-    let language: String?
 }

--- a/AEPLifecycle/Sources/LifecycleV2/XDMLanguage.swift
+++ b/AEPLifecycle/Sources/LifecycleV2/XDMLanguage.swift
@@ -1,0 +1,19 @@
+/*
+ Copyright 2021 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import AEPServices
+import Foundation
+
+/// Represents the language of the environment to represent the user's linguistic, geographical, or cultural preferences for data presentation.
+struct XDMLanguage: Encodable {
+    let language: String?
+}

--- a/AEPLifecycle/Tests/XDMEnvironmentTests.swift
+++ b/AEPLifecycle/Tests/XDMEnvironmentTests.swift
@@ -21,7 +21,7 @@ class XDMEnvironmentTests: XCTestCase {
         // setup
         var env = XDMEnvironment()
         env.operatingSystem = "test-os"
-        env.language = XDMLifecycleLanguage(language: "en-US")
+        env.language = XDMLanguage(language: "en-US")
         env.carrier = "test-carrier"
         env.operatingSystemVersion = "test-os-version"
         env.operatingSystem = "test-os-name"

--- a/AEPLifecycle/Tests/XDMMobileLifecycleDetailsTests.swift
+++ b/AEPLifecycle/Tests/XDMMobileLifecycleDetailsTests.swift
@@ -28,7 +28,7 @@ class XDMMobileLifecycleDetailsTests: XCTestCase {
         lifecycleDetails.application?.isUpgrade = true
         lifecycleDetails.environment = XDMEnvironment()
         lifecycleDetails.environment?.operatingSystem = "test-os"
-        lifecycleDetails.environment?.language = XDMLifecycleLanguage(language: "en-US")
+        lifecycleDetails.environment?.language = XDMLanguage(language: "en-US")
         lifecycleDetails.environment?.carrier = "test-carrier"
         lifecycleDetails.environment?.operatingSystemVersion = "test-os-version"
         lifecycleDetails.environment?.operatingSystem = "test-os-name"


### PR DESCRIPTION
Rename XDMLifecycleLanguage to XDMLanguage and move it to separate file.
Rename EventType enum to XDMEventType

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
