### PR TITLE
Fix app version format in Lifecycle::applicationLaunch event

### DIFF
--- a/AEPLifecycle/Sources/LifecycleV2/LifecycleV2.swift
+++ b/AEPLifecycle/Sources/LifecycleV2/LifecycleV2.swift
@@ -147,7 +147,7 @@ class LifecycleV2 {
 
     /// - Returns: Bool indicating whether the app has been upgraded
     private func isUpgrade() -> Bool {
-        if let currentAppVersion = systemInfoService.getApplicationVersion(),
+        if let currentAppVersion = systemInfoService.getApplicationBuildNumber(),
            let previousAppVersion = dataStore.getString(key: LifecycleV2Constants.DataStoreKeys.LAST_APP_VERSION) {
             return previousAppVersion != currentAppVersion
         }
@@ -157,7 +157,7 @@ class LifecycleV2 {
 
     /// Persist the application version into dataStore
     private func persistAppVersion() {
-        guard let currentAppVersion = systemInfoService.getApplicationVersion() else { return }
+        guard let currentAppVersion = systemInfoService.getApplicationBuildNumber() else { return }
         dataStore.set(key: LifecycleV2Constants.DataStoreKeys.LAST_APP_VERSION, value: currentAppVersion)
     }
 }

--- a/AEPLifecycle/Sources/LifecycleV2/LifecycleV2MetricsBuilder.swift
+++ b/AEPLifecycle/Sources/LifecycleV2/LifecycleV2MetricsBuilder.swift
@@ -102,10 +102,9 @@ class LifecycleV2MetricsBuilder {
     /// Returns the application version in the format appVersion (versionCode). Example: 2.3 (10)
     /// - Returns: the app version as a `String` formatted in the specified format.
     private func getAppVersion() -> String {
-        let appVersion = systemInfoService.getApplicationVersion() ?? ""
+        let appBuildNumber = systemInfoService.getApplicationBuildNumber() ?? ""
         let appVersionNumber = systemInfoService.getApplicationVersionNumber() ?? ""
-
-        return "\(appVersion) (\(appVersionNumber))".replacingOccurrences(of: "  ", with: " ").replacingOccurrences(of: "()", with: "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return "\(appVersionNumber) (\(appBuildNumber))".replacingOccurrences(of: "  ", with: " ").replacingOccurrences(of: "()", with: "").trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     /// Returns information related to the running environment. This data is computed once, when it is first used, then

--- a/AEPLifecycle/Tests/FunctionalTests/LifecycleV2FunctionalTests.swift
+++ b/AEPLifecycle/Tests/FunctionalTests/LifecycleV2FunctionalTests.swift
@@ -69,8 +69,8 @@ class LifecycleV2FunctionalTests: XCTestCase {
         mockSystemInfoService.runMode = "Application"
         mockSystemInfoService.mobileCarrierName = "test-carrier"
         mockSystemInfoService.applicationName = "test-app-name"
-        mockSystemInfoService.applicationBuildNumber = "12345"
-        mockSystemInfoService.applicationVersionNumber = "123"
+        mockSystemInfoService.applicationBuildNumber = "build-number"
+        mockSystemInfoService.applicationVersionNumber = "version-number"
         mockSystemInfoService.deviceName = "test-device-name"
         mockSystemInfoService.deviceModelNumber = "test-device-model"
         mockSystemInfoService.operatingSystemName = "test-os-name"
@@ -88,7 +88,7 @@ class LifecycleV2FunctionalTests: XCTestCase {
         mockRuntime.simulateSharedState(for: "com.adobe.module.configuration", data: ([:], .set))
         let expectedApplicationInfo = [
             "name": "test-app-name",
-            "version": "1.0.0 (123)",
+            "version": "version-number (build-number)",
             "isInstall": true,
             "isLaunch": true
         ] as [String : Any]
@@ -154,7 +154,7 @@ class LifecycleV2FunctionalTests: XCTestCase {
         mockRuntime.simulateSharedState(for: "com.adobe.module.configuration", data: ([:], .set))
         let expectedApplicationInfo = [
             "name": "test-app-name",
-            "version": "1.0.1 (123)",
+            "version": "version-number (next-build-number)",
             "isUpgrade": true,
             "isLaunch": true
         ] as [String : Any]
@@ -168,7 +168,7 @@ class LifecycleV2FunctionalTests: XCTestCase {
         waitForProcessing(interval: 2.5)
 
         // Update app version
-        mockSystemInfoService.appVersion = "1.0.1"
+        mockSystemInfoService.applicationBuildNumber = "next-build-number"
         // application launch upgrade hit
         mockRuntime.simulateComingEvents(createStartEvent())
         waitForProcessing()
@@ -193,7 +193,7 @@ class LifecycleV2FunctionalTests: XCTestCase {
         mockRuntime.simulateSharedState(for: "com.adobe.module.configuration", data: ([:], .set))
         let expectedApplicationInfo = [
             "name": "test-app-name",
-            "version": "1.0.0 (123)",
+            "version": "version-number (build-number)",
             "isLaunch": true
         ] as [String : Any]
 

--- a/AEPLifecycle/Tests/LifecycleV2MetricsBuilderTests.swift
+++ b/AEPLifecycle/Tests/LifecycleV2MetricsBuilderTests.swift
@@ -44,8 +44,8 @@ class LifecycleV2MetricsBuilderTests: XCTestCase {
         let mockSystemInfoService = MockSystemInfoService()
         mockSystemInfoService.appId = "test-app-id"
         mockSystemInfoService.applicationName = "test-app-name"
-        mockSystemInfoService.appVersion = "test-version"
-        mockSystemInfoService.applicationVersionNumber = "12345"
+        mockSystemInfoService.applicationBuildNumber = "build-number"
+        mockSystemInfoService.applicationVersionNumber = "version-number"
         mockSystemInfoService.mobileCarrierName = "test-carrier"
         mockSystemInfoService.platformName = "test-platform"
         mockSystemInfoService.operatingSystemName = "test-os-name"
@@ -65,7 +65,7 @@ class LifecycleV2MetricsBuilderTests: XCTestCase {
         // verify
         let application = [
             "name": "test-app-name",
-            "version": "test-version (12345)",
+            "version": "version-number (build-number)",
             "isInstall": true,
             "isLaunch": true,
             "id": "test-app-id"
@@ -86,7 +86,7 @@ class LifecycleV2MetricsBuilderTests: XCTestCase {
         // verify
         let application = [
             "name": "test-app-name",
-            "version": "test-version (12345)",
+            "version": "version-number (build-number)",
             "isUpgrade": true,
             "isLaunch": true,
             "id": "test-app-id"
@@ -107,7 +107,7 @@ class LifecycleV2MetricsBuilderTests: XCTestCase {
         // verify
         let application = [
             "name": "test-app-name",
-            "version": "test-version (12345)",
+            "version": "version-number (build-number)",
             "isLaunch": true,
             "id": "test-app-id"
         ] as [String : Any]


### PR DESCRIPTION
Fix app version format in Lifecycle::applicationLaunch event from `CFBundleVersion (CFBundleShortVersion) ` to `CFBundleShortVersion (CFBundleVersion)`
Replace usage of `getApplicationVersion` with `getApplicationBuildNumber`. Both the functions currently read `CFBundleVersion`

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
