### PR TITLE
Fix Lifecycle issues

### DIFF
--- a/AEPLifecycle/Sources/LifecycleState.swift
+++ b/AEPLifecycle/Sources/LifecycleState.swift
@@ -139,7 +139,7 @@ struct LifecycleState {
 
     /// Returns true if the current app version does not equal the app version stored in the data store
     private func isUpgrade() -> Bool {
-        let appVersion = ServiceProvider.shared.systemInfoService.getApplicationVersionNumber()
+        let appVersion = ServiceProvider.shared.systemInfoService.getApplicationBuildNumber()
         return dataStore.getString(key: LifecycleConstants.DataStoreKeys.LAST_VERSION) != appVersion
     }
 
@@ -148,7 +148,7 @@ struct LifecycleState {
     private func persistLifecycleContextData(startDate: Date) {
         dataStore.setObject(key: LifecycleConstants.DataStoreKeys.LIFECYCLE_DATA, value: lifecycleContextData)
         dataStore.setObject(key: LifecycleConstants.DataStoreKeys.LAST_LAUNCH_DATE, value: startDate)
-        let appVersion = ServiceProvider.shared.systemInfoService.getApplicationVersionNumber()
+        let appVersion = ServiceProvider.shared.systemInfoService.getApplicationBuildNumber()
         dataStore.set(key: LifecycleConstants.DataStoreKeys.LAST_VERSION, value: appVersion)
     }
 }

--- a/AEPLifecycle/Sources/LifecycleV2/LifecycleV2Constants.swift
+++ b/AEPLifecycle/Sources/LifecycleV2/LifecycleV2Constants.swift
@@ -15,7 +15,7 @@ import Foundation
 /// Constants for `LifecycleV2`
 enum LifecycleV2Constants {
 
-    static let STATE_UPDATE_TIMEOUT_SEC = TimeInterval(2)
+    static let STATE_UPDATE_TIMEOUT_SEC = TimeInterval(0.5)
     static let CACHE_TIMEOUT_SECONDS = TimeInterval(2)
 
     enum XDMEventType {

--- a/AEPLifecycle/Tests/FunctionalTests/LifecycleFunctionalTests.swift
+++ b/AEPLifecycle/Tests/FunctionalTests/LifecycleFunctionalTests.swift
@@ -45,7 +45,7 @@ class LifecycleFunctionalTests: XCTestCase {
         mockSystemInfoService.runMode = "Application"
         mockSystemInfoService.mobileCarrierName = "Test Carrier"
         mockSystemInfoService.applicationName = "Test app name"
-        mockSystemInfoService.applicationBuildNumber = "12345"
+        mockSystemInfoService.applicationBuildNumber = "1.1.1.12345"
         mockSystemInfoService.applicationVersionNumber = "1.1.1"
         mockSystemInfoService.deviceName = "Test device name"
         mockSystemInfoService.operatingSystemName = "Test OS"
@@ -77,7 +77,7 @@ class LifecycleFunctionalTests: XCTestCase {
         XCTAssertEqual(mockSystemInfoService.runMode, dispatchedEvent.lifecycleContextData["runmode"] as? String)
         XCTAssertEqual(mockSystemInfoService.activeLocaleName, dispatchedEvent.lifecycleContextData["locale"] as? String)
         XCTAssertEqual(expectedOSValue, dispatchedEvent.lifecycleContextData["osversion"] as? String)
-        XCTAssertEqual("Test app name 1.1.1 (12345)", dispatchedEvent.lifecycleContextData["appid"] as? String)
+        XCTAssertEqual("Test app name 1.1.1 (1.1.1.12345)", dispatchedEvent.lifecycleContextData["appid"] as? String)
         XCTAssertEqual(mockSystemInfoService.deviceName, dispatchedEvent.lifecycleContextData["devicename"] as? String)
 
         // shared state
@@ -88,7 +88,7 @@ class LifecycleFunctionalTests: XCTestCase {
         XCTAssertEqual(mockSystemInfoService.runMode, lifecycleData?["runmode"] as? String)
         XCTAssertEqual(mockSystemInfoService.activeLocaleName, lifecycleData?["locale"] as? String)
         XCTAssertEqual(expectedOSValue, lifecycleData?["osversion"] as? String)
-        XCTAssertEqual("Test app name 1.1.1 (12345)", lifecycleData?["appid"] as? String)
+        XCTAssertEqual("Test app name 1.1.1 (1.1.1.12345)", lifecycleData?["appid"] as? String)
         XCTAssertEqual(mockSystemInfoService.deviceName, lifecycleData?["devicename"] as? String)
     }
 
@@ -300,13 +300,15 @@ class LifecycleFunctionalTests: XCTestCase {
         mockRuntime.simulateComingEvents(startEvent1, pauseEvent)
 
         // simulate a new start
-        mockSystemInfoService.applicationVersionNumber = "1.2"
+        mockSystemInfoService.applicationBuildNumber = "1.1.1.13000"
         let lifecycleSession2 = Lifecycle(runtime: mockRuntimeSession2)
         lifecycleSession2.onRegistered()
         mockRuntimeSession2.simulateComingEvents(startEvent2)
 
         // verify
-        XCTAssertEqual("UpgradeEvent", (mockRuntimeSession2.dispatchedEvents[0].data?["lifecyclecontextdata"] as? [String: Any])?["upgradeevent"] as? String)
+        let upgradeEvent = mockRuntimeSession2.dispatchedEvents[0]
+        XCTAssertEqual("UpgradeEvent", upgradeEvent.lifecycleContextData["upgradeevent"] as? String)
+        XCTAssertEqual("Test app name 1.1.1 (1.1.1.13000)", upgradeEvent.lifecycleContextData["appid"] as? String)
 
         let sharedState = mockRuntimeSession2.createdSharedStates[1]
         let lifecycleData = sharedState?["lifecyclecontextdata"] as? [String: Any]

--- a/AEPLifecycle/Tests/FunctionalTests/LifecycleV2FunctionalTests.swift
+++ b/AEPLifecycle/Tests/FunctionalTests/LifecycleV2FunctionalTests.swift
@@ -19,6 +19,9 @@ import XCTest
 
 /// Functional tests for the Lifecycle extension
 class LifecycleV2FunctionalTests: XCTestCase {
+
+    static let PAUSE_UPDATE_TIMEOUT = LifecycleV2Constants.STATE_UPDATE_TIMEOUT_SEC + 0.20
+
     var mockSystemInfoService: MockSystemInfoService!
     var mockRuntime: TestableExtensionRuntime!
     var lifecycle: Lifecycle!
@@ -134,7 +137,7 @@ class LifecycleV2FunctionalTests: XCTestCase {
         waitForProcessing(interval: 1.1) // app close after 1 sec
         // application close
         mockRuntime.simulateComingEvents(createPauseEvent())
-        waitForProcessing(interval: 2.5)
+        waitForProcessing(interval: Self.PAUSE_UPDATE_TIMEOUT)
 
         // verify
         XCTAssertEqual(2, mockRuntime.dispatchedEvents.count) //application launch, application close
@@ -165,7 +168,7 @@ class LifecycleV2FunctionalTests: XCTestCase {
         waitForProcessing()
         // application close
         mockRuntime.simulateComingEvents(createPauseEvent())
-        waitForProcessing(interval: 2.5)
+        waitForProcessing(interval: Self.PAUSE_UPDATE_TIMEOUT)
 
         // Update app version
         mockSystemInfoService.applicationBuildNumber = "next-build-number"
@@ -203,7 +206,7 @@ class LifecycleV2FunctionalTests: XCTestCase {
         waitForProcessing()
         // application close
         mockRuntime.simulateComingEvents(createPauseEvent())
-        waitForProcessing(interval: 2.5)
+        waitForProcessing(interval: Self.PAUSE_UPDATE_TIMEOUT)
 
         // application launch upgrade hit
         mockRuntime.simulateComingEvents(createStartEvent())

--- a/AEPLifecycle/Tests/LifecycleStateTests.swift
+++ b/AEPLifecycle/Tests/LifecycleStateTests.swift
@@ -51,7 +51,7 @@ class LifecycleStateTests: XCTestCase {
         mockSystemInfoService.runMode = "Application"
         mockSystemInfoService.mobileCarrierName = "Test Carrier"
         mockSystemInfoService.applicationName = "Test app name"
-        mockSystemInfoService.applicationBuildNumber = "12345"
+        mockSystemInfoService.applicationBuildNumber = "1.1.1.12345"
         mockSystemInfoService.applicationVersionNumber = "1.1.1"
         mockSystemInfoService.deviceName = "Test device name"
         mockSystemInfoService.operatingSystemName = "Test OS"
@@ -137,7 +137,7 @@ class LifecycleStateTests: XCTestCase {
         persistedContext.pauseDate = currentDateMinusOneSecond
         persistedContext.startDate = currentDateMinusTenMin
         dataStore.setObject(key: LifecycleConstants.DataStoreKeys.PERSISTED_CONTEXT, value: persistedContext)
-        dataStore.set(key: LifecycleConstants.DataStoreKeys.LAST_VERSION, value: "1.1.1")
+        dataStore.set(key: LifecycleConstants.DataStoreKeys.LAST_VERSION, value: "1.1.1.12345")
 
         let expectedAppId = "new-app-id"
         var contextData = LifecycleContextData()
@@ -169,7 +169,7 @@ class LifecycleStateTests: XCTestCase {
         // verify
         let actualContextData = lifecycleState.getContextData()
 
-        XCTAssertEqual("Test app name 1.1.1 (12345)", actualContextData?.lifecycleMetrics.appId)
+        XCTAssertEqual("Test app name 1.1.1 (1.1.1.12345)", actualContextData?.lifecycleMetrics.appId)
         XCTAssertEqual(mockSystemInfoService.getMobileCarrierName(), actualContextData?.lifecycleMetrics.carrierName)
         XCTAssertTrue(actualContextData?.lifecycleMetrics.dailyEngagedEvent ?? false)
         XCTAssertNotNil(actualContextData?.lifecycleMetrics.dayOfTheWeek)
@@ -193,7 +193,7 @@ class LifecycleStateTests: XCTestCase {
     func testStartAppResumeVersionsAreSame() {
         // setup
         let appName = "test app name"
-        let testAppVersion = "1.1.0"
+        let testAppVersion = "1.1.1.12345"
         let expectedAppId = "\(appName) \(testAppVersion)"
 
         var persistedContext = LifecyclePersistedContext()
@@ -206,7 +206,7 @@ class LifecycleStateTests: XCTestCase {
 
         dataStore.setObject(key: LifecycleConstants.DataStoreKeys.PERSISTED_CONTEXT, value: persistedContext)
         dataStore.setObject(key: LifecycleConstants.DataStoreKeys.LIFECYCLE_DATA, value: contextData)
-        dataStore.set(key: LifecycleConstants.DataStoreKeys.LAST_VERSION, value: "1.1.1")
+        dataStore.set(key: LifecycleConstants.DataStoreKeys.LAST_VERSION, value: testAppVersion)
 
         // test
         let prevSessionInfo = lifecycleState.start(date: currentDate, additionalContextData: nil, adId: nil, sessionTimeout: 200, isInstall: false)
@@ -219,7 +219,7 @@ class LifecycleStateTests: XCTestCase {
 
     func testStartOverTimeoutAdditionalData() {
         // setup
-        let appVersion = "1.1.1"
+        let appVersion = "1.1.1.12345"
 
         var persistedContext = LifecyclePersistedContext()
         persistedContext.pauseDate = currentDateMinusTenMin

--- a/AEPLifecycle/Tests/LifecycleV2StateManagerTests.swift
+++ b/AEPLifecycle/Tests/LifecycleV2StateManagerTests.swift
@@ -18,8 +18,8 @@ import XCTest
 
 class LifecycleV2StateManagerTests: XCTestCase {
 
-    static let STATE_UPDATE_TIMEOUT_SEC = LifecycleV2Constants.STATE_UPDATE_TIMEOUT_SEC
-
+    static let PAUSE_UPDATE_TIMEOUT = LifecycleV2Constants.STATE_UPDATE_TIMEOUT_SEC + 0.20
+    
     var stateManager: LifecycleV2StateManager!
     
     override func setUp() {        
@@ -67,7 +67,7 @@ class LifecycleV2StateManagerTests: XCTestCase {
             stateManager.update(state: .PAUSE, callback: callback)
         }
         
-        wait(for: [expectation], timeout: Self.STATE_UPDATE_TIMEOUT_SEC + 0.25)
+        wait(for: [expectation], timeout: Self.PAUSE_UPDATE_TIMEOUT)
         
         XCTAssertTrue(updates[0])
         XCTAssertTrue(updates[times])
@@ -93,7 +93,7 @@ class LifecycleV2StateManagerTests: XCTestCase {
         stateManager.update(state: .PAUSE, callback: callback)
         stateManager.update(state: .START, callback: callback)
         
-        wait(for: [expectation], timeout: Self.STATE_UPDATE_TIMEOUT_SEC + 0.25)
+        wait(for: [expectation], timeout: Self.PAUSE_UPDATE_TIMEOUT)
         
         XCTAssertTrue(updates[0])
         for i in 1...4 {
@@ -115,7 +115,7 @@ class LifecycleV2StateManagerTests: XCTestCase {
         stateManager.update(state: .START, callback: callback)
         stateManager.update(state: .PAUSE, callback: callback)
         
-        wait(for: [expectation], timeout: Self.STATE_UPDATE_TIMEOUT_SEC + 0.25)
+        wait(for: [expectation], timeout: Self.PAUSE_UPDATE_TIMEOUT)
         
         XCTAssertTrue(updates[0])
         XCTAssertTrue(updates[1])
@@ -126,7 +126,7 @@ class LifecycleV2StateManagerTests: XCTestCase {
         stateManager.update(state: .START, callback: callback)
         stateManager.update(state: .PAUSE, callback: callback)
         
-        wait(for: [expectation], timeout: Self.STATE_UPDATE_TIMEOUT_SEC + 0.25)
+        wait(for: [expectation], timeout: Self.PAUSE_UPDATE_TIMEOUT)
         
         XCTAssertTrue(updates[0])
         XCTAssertTrue(updates[1])


### PR DESCRIPTION
Fix upgrade detection in Lifecycle standard workflow. It now detects Upgrade event based on changes to `CFBundleVersion` instead of `CFBundleShortVersion`

Reduce LifecycleV2StateManager state update timeout to 500ms

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
