### PR TITLE
Fix a bug in persisting Date object

### DIFF
--- a/AEPServices/Sources/storage/NamedCollectionDataStore.swift
+++ b/AEPServices/Sources/storage/NamedCollectionDataStore.swift
@@ -183,16 +183,10 @@ public class NamedCollectionDataStore {
     }
 
     public func getObject<T: Codable>(key: String, fallback: T? = nil) -> T? {
-        // https://bugs.swift.org/browse/SR-6163
-        // JSON Encoder shipped as part of Swift standard library in iOS versions < 13 fails to encode top level fragments. Persist date as double in iOS versions < 13
-        if T.self == Date.self {
-            guard #available(iOS 13.0, tvOS 13.0, *) else {
-                if let date = getDouble(key: key) {
-                    return Date(timeIntervalSince1970: date) as? T
-                } else {
-                    return fallback
-                }
-            }
+        // We persist date as double in iOS versions < 13.
+        // First attempt reading date as double to see if they were persisted from earlier OS versions.
+        if T.self == Date.self, let date = getDouble(key: key) {
+            return Date(timeIntervalSince1970: date) as? T
         }
 
         if let savedData = get(key: key) as? Data {

--- a/AEPServices/Sources/storage/NamedCollectionDataStore.swift
+++ b/AEPServices/Sources/storage/NamedCollectionDataStore.swift
@@ -183,8 +183,8 @@ public class NamedCollectionDataStore {
     }
 
     public func getObject<T: Codable>(key: String, fallback: T? = nil) -> T? {
-        // We persist date as double in iOS versions < 13.
-        // First attempt reading date as double to see if they were persisted from earlier OS versions.
+        // setObject persists date as double in iOS versions < 13.
+        // Try reading date as double first to see if they were persisted from earlier OS versions.
         if T.self == Date.self, let date = getDouble(key: key) {
             return Date(timeIntervalSince1970: date) as? T
         }

--- a/AEPServices/Tests/services/NamedCollectionDataStoreTest.swift
+++ b/AEPServices/Tests/services/NamedCollectionDataStoreTest.swift
@@ -397,20 +397,30 @@ class NamedCollectionDataStoreTest: XCTestCase {
             XCTAssertEqual(mockKeyValueService.setValue as? Double, date.timeIntervalSince1970)
         }
     }
-    func testGetDateCodable() {
-        let date = Date()
-        mockKeyValueService.getResult = try? JSONEncoder().encode(date)
 
-        let persistedDate: Date? = store?.getObject(key: OBJ_KEY)
-        XCTAssertEqual(persistedDate, date)
+    func testGetDatePersistedAsCodable() {
+        // Date can not be persisted as Codable in iOS versions < 13
+        if #available(iOS 13, tvOS 13, *) {
+            let date = Date()
+            mockKeyValueService.getResult = try? JSONEncoder().encode(date)
+
+            if let persistedDate: Date = store?.getObject(key: OBJ_KEY) {
+                XCTAssertEqual(date.timeIntervalSince1970, persistedDate.timeIntervalSince1970, accuracy: Double.ulpOfOne)
+            } else {
+                XCTFail("Unable to read persisted Date")
+            }
+        }
     }
 
-    func testGetDateDouble() {
+    func testGetDatePersistedAsDouble() {
         let date = Date()
         mockKeyValueService.getResult = date.timeIntervalSince1970
 
-        let persistedDate: Date? = store?.getObject(key: OBJ_KEY)
-        XCTAssertEqual(persistedDate, date)
+        if let persistedDate: Date = store?.getObject(key: OBJ_KEY) {
+            XCTAssertEqual(date.timeIntervalSince1970, persistedDate.timeIntervalSince1970, accuracy: Double.ulpOfOne)
+        } else {
+            XCTFail("Unable to read persisted Date")
+        }
     }
 
     func testRemoveEmptyKey() {

--- a/AEPServices/Tests/services/NamedCollectionDataStoreTest.swift
+++ b/AEPServices/Tests/services/NamedCollectionDataStoreTest.swift
@@ -385,6 +385,34 @@ class NamedCollectionDataStoreTest: XCTestCase {
         XCTAssertEqual(subscriptResult?.id, val2.id)
     }
 
+    func testGetSetDate() {
+        let date = Date()
+        store?.setObject(key: OBJ_KEY, value: date)
+
+        XCTAssertTrue(mockKeyValueService.setCalled)
+        if #available(iOS 13, tvOS 13, *) {
+            let encodedDate = try? JSONEncoder().encode(date)
+            XCTAssertEqual(mockKeyValueService.setValue as? Data, encodedDate)
+        } else {
+            XCTAssertEqual(mockKeyValueService.setValue as? Double, date.timeIntervalSince1970)
+        }
+    }
+    func testGetDateCodable() {
+        let date = Date()
+        mockKeyValueService.getResult = try? JSONEncoder().encode(date)
+
+        let persistedDate: Date? = store?.getObject(key: OBJ_KEY)
+        XCTAssertEqual(persistedDate, date)
+    }
+
+    func testGetDateDouble() {
+        let date = Date()
+        mockKeyValueService.getResult = date.timeIntervalSince1970
+
+        let persistedDate: Date? = store?.getObject(key: OBJ_KEY)
+        XCTAssertEqual(persistedDate, date)
+    }
+
     func testRemoveEmptyKey() {
         store?.remove(key: "")
         XCTAssertFalse(mockKeyValueService.removeCalled)

--- a/AEPServices/Tests/services/NamedCollectionDataStoreTest.swift
+++ b/AEPServices/Tests/services/NamedCollectionDataStoreTest.swift
@@ -404,11 +404,8 @@ class NamedCollectionDataStoreTest: XCTestCase {
             let date = Date()
             mockKeyValueService.getResult = try? JSONEncoder().encode(date)
 
-            if let persistedDate: Date = store?.getObject(key: OBJ_KEY) {
-                XCTAssertEqual(date.timeIntervalSince1970, persistedDate.timeIntervalSince1970, accuracy: Double.ulpOfOne)
-            } else {
-                XCTFail("Unable to read persisted Date")
-            }
+            let persistedDate: Date? = store?.getObject(key: OBJ_KEY)
+            XCTAssertTrue(date.equal(other: persistedDate))
         }
     }
 
@@ -416,11 +413,8 @@ class NamedCollectionDataStoreTest: XCTestCase {
         let date = Date()
         mockKeyValueService.getResult = date.timeIntervalSince1970
 
-        if let persistedDate: Date = store?.getObject(key: OBJ_KEY) {
-            XCTAssertEqual(date.timeIntervalSince1970, persistedDate.timeIntervalSince1970, accuracy: Double.ulpOfOne)
-        } else {
-            XCTFail("Unable to read persisted Date")
-        }
+        let persistedDate: Date? = store?.getObject(key: OBJ_KEY)
+        XCTAssertTrue(date.equal(other: persistedDate))
     }
 
     func testRemoveEmptyKey() {
@@ -492,5 +486,18 @@ struct MockCoding: Codable {
     init(id: Int, name: String) {
         self.id = id
         self.name = name
+    }
+}
+
+
+private extension Date {
+    func equal(other: Date?) -> Bool {
+        guard let other = other else {
+            return false;
+        }
+
+        // As date stores the timestamp in milliseconds, compare double value with accuracy greater than milliseconds.
+        let accuracy = 0.00001;
+        return abs(self.timeIntervalSince1970 - other.timeIntervalSince1970) < accuracy;
     }
 }

--- a/AEPServices/Tests/services/NamedCollectionDataStoreTest.swift
+++ b/AEPServices/Tests/services/NamedCollectionDataStoreTest.swift
@@ -385,7 +385,7 @@ class NamedCollectionDataStoreTest: XCTestCase {
         XCTAssertEqual(subscriptResult?.id, val2.id)
     }
 
-    func testGetSetDate() {
+    func testSetDate() {
         let date = Date()
         store?.setObject(key: OBJ_KEY, value: date)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

JSON Encoder shipped as part of Swift standard library in iOS, tvOS versions < 13 fails to encode top level fragments. Persist date as double in iOS, tvOS versions < 13. 



## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
