### PR TITLE
Deprecate get application version

### DIFF
--- a/AEPServices/Sources/SystemInfoService.swift
+++ b/AEPServices/Sources/SystemInfoService.swift
@@ -90,7 +90,7 @@ public protocol SystemInfoService {
     /// Returns the application version.
     /// - Return: `String` Application version
     // TODO: - Include planned deprecation version in message
-    @available(*, deprecated, message: "Please use getApplicationVersionNumber instead")
+    @available(*, deprecated, renamed: "getApplicationVersionNumber")
     func getApplicationVersion() -> String?
 
     /// Returns the current orientation of the device

--- a/AEPServices/Sources/SystemInfoService.swift
+++ b/AEPServices/Sources/SystemInfoService.swift
@@ -89,6 +89,8 @@ public protocol SystemInfoService {
 
     /// Returns the application version.
     /// - Return: `String` Application version
+    // TODO: - Include planned deprecation version in message
+    @available(*, deprecated, message: "Please use getApplicationVersionNumber instead")
     func getApplicationVersion() -> String?
 
     /// Returns the current orientation of the device


### PR DESCRIPTION
Marks getApplicationVersion as deprecated. We still need to come up with proper messaging for when it will be removed. #714 