### PR TITLE
Change "legacy" to "ACP" in our logs

### DIFF
--- a/AEPCore/Sources/core/MobileCore.swift
+++ b/AEPCore/Sources/core/MobileCore.swift
@@ -50,7 +50,7 @@ public final class MobileCore: NSObject {
         let registerSelector = Selector(("registerExtension"))
 
         if NSClassFromString("ACPBridgeExtension") == nil && !legacyExtensions.isEmpty {
-            Log.error(label: LOG_TAG, "Attempting to register legacy extensions: \(legacyExtensions), without the compatibility layer present. Can be included via github.com/adobe/aepsdk-compatibility-ios")
+            Log.error(label: LOG_TAG, "Attempting to register ACP extensions: \(legacyExtensions), without the compatibility layer present. Can be included via github.com/adobe/aepsdk-compatibility-ios")
         } else {
             for legacyExtension in legacyExtensions {
                 if legacyExtension.responds(to: registerSelector) {


### PR DESCRIPTION
The term "legacy" should only be used internally, could be misleading to customers. #746 