### PR TITLE
[MOB-15600] Rename wrapper type to names defined in XDM Implementation Details

### DIFF
--- a/AEPCore/Sources/core/CoreConstants.swift
+++ b/AEPCore/Sources/core/CoreConstants.swift
@@ -72,7 +72,7 @@ enum CoreConstants {
         static let FLUTTER = "flutter"
         static let CORDOVA = "cordova"
         static let UNITY = "unity"
-        static let XAMARIN = "xamerin"
+        static let XAMARIN = "xamarin"
         static let NONE = "none"
     }
     

--- a/AEPCore/Sources/core/CoreConstants.swift
+++ b/AEPCore/Sources/core/CoreConstants.swift
@@ -65,7 +65,19 @@ enum CoreConstants {
         static let OPT_IN = "optedin"
     }
 
+    // Wrapper type names need to be consistent with the values defined in the XDM Implementation Details name enum
+    // https://github.com/adobe/xdm/blob/master/components/datatypes/industry-verticals/implementationdetails.schema.json
     enum WrapperType {
+        static let REACT_NATIVE = "reactnative"
+        static let FLUTTER = "flutter"
+        static let CORDOVA = "cordova"
+        static let UNITY = "unity"
+        static let XAMARIN = "xamerin"
+        static let NONE = "none"
+    }
+    
+    // Deprecated - will be removed in a later version. Currently used in MobileCore.extensionVersion
+    enum WrapperTypeShortName {
         static let REACT_NATIVE = "R"
         static let FLUTTER = "F"
         static let CORDOVA = "C"

--- a/AEPCore/Sources/core/MobileCore.swift
+++ b/AEPCore/Sources/core/MobileCore.swift
@@ -24,7 +24,7 @@ public final class MobileCore: NSObject {
             return ConfigurationConstants.EXTENSION_VERSION
         }
 
-        return ConfigurationConstants.EXTENSION_VERSION + "-" + wrapperType.rawValue
+        return ConfigurationConstants.EXTENSION_VERSION + "-" + wrapperType.shortName
     }
 
     @objc public static var messagingDelegate: MessagingDelegate? {
@@ -217,5 +217,25 @@ public final class MobileCore: NSObject {
         let eventData = [CoreConstants.Signal.EventDataKeys.CONTEXT_DATA: data]
         let event = Event(name: CoreConstants.EventNames.COLLECT_PII, type: EventType.genericPii, source: EventSource.requestContent, data: eventData)
         MobileCore.dispatch(event: event)
+    }
+}
+
+/// Convenience function to get the single character wrapper type name. 
+extension WrapperType {
+    var shortName: String {
+        switch self {
+        case .none:
+            return CoreConstants.WrapperTypeShortName.NONE
+        case .reactNative:
+            return CoreConstants.WrapperTypeShortName.REACT_NATIVE
+        case .flutter:
+            return CoreConstants.WrapperTypeShortName.FLUTTER
+        case .cordova:
+            return CoreConstants.WrapperTypeShortName.CORDOVA
+        case .unity:
+            return CoreConstants.WrapperTypeShortName.UNITY
+        case .xamarin:
+            return CoreConstants.WrapperTypeShortName.XAMARIN
+        }
     }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Rename the wrapper type set in the EventHub shared state to the names defined in the XDM Implementation Details schema.
Preserves the existing wrapper type appended to the MobileCore.extensionVersion.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
