### PR TITLE
ConfigureWithAppId Changes

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -2847,7 +2847,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/zsh;
-			shellScript = "cd ${PROJECT_DIR}\nif which ./Pods/SwiftLint/swiftlint >/dev/null; then\n  ./Pods/SwiftLint/swiftlint\nelse\n  echo \"error: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "cd ${PROJECT_DIR}\nif which ./Pods/SwiftLint/swiftlint >/dev/null; then\n  ./Pods/SwiftLint/swiftlint\nelse\n  echo \"error: SwiftLint not installed, please run the pod install command from the project root directory.\"\nfi\n";
 		};
 		BB68130024E19C06007FDCF7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/AEPCore/Sources/configuration/Configuration.swift
+++ b/AEPCore/Sources/configuration/Configuration.swift
@@ -44,7 +44,6 @@ class Configuration: NSObject, Extension {
         registerPreprocessor(rulesEngine.process(event:))
 
         registerListener(type: EventType.configuration, source: EventSource.requestContent, listener: receiveConfigurationRequest(event:))
-        registerListener(type: EventType.lifecycle, source: EventSource.responseContent, listener: receiveLifecycleResponse(event:))
 
         // If we have an appId stored in persistence, kick off the configureWithAppId event
         if let appId = appIdManager.loadAppIdFromManifest(), !appId.isEmpty {
@@ -135,6 +134,7 @@ class Configuration: NSObject, Extension {
         guard !appId.isEmpty else {
             // Error: No appId provided or its empty, resolve pending shared state with current config
             Log.warning(label: name, "No AppID provided or it is empty, resolving pending shared state with current config")
+            appIdManager.removeAppIdFromPersistence()
             sharedStateResolver(configState.environmentAwareConfiguration)
             return
         }

--- a/AEPCore/Sources/configuration/Configuration.swift
+++ b/AEPCore/Sources/configuration/Configuration.swift
@@ -123,13 +123,6 @@ class Configuration: NSObject, Extension {
             return
         }
 
-        guard validateForInternalEventAppIdChange(event: event, newAppId: appId) else {
-            // error: app Id update already in-flight, resolve pending shared state with current config
-            Log.warning(label: name, "No AppID provided or it is empty, resolving pending shared state with current config")
-            sharedStateResolver(configState.environmentAwareConfiguration)
-            return
-        }
-
         // check if the configuration state has unexpired config associated with appId, if so early exit
         guard !configState.hasUnexpiredConfig(appId: appId) else {
             sharedStateResolver(configState.environmentAwareConfiguration)
@@ -223,25 +216,5 @@ class Configuration: NSObject, Extension {
         if let rulesURLString = newConfiguration[ConfigurationConstants.Keys.RULES_URL] as? String {
             rulesEngine.replaceRules(from: rulesURLString)
         }
-    }
-
-    // MARK: - Helpers
-
-    /// This method validates the appId for the SetAppIDInternalEvent
-    /// The purpose of the SetAppIDInternalEvent is to refresh the existing with the persisted appId
-    /// This method returns true if the persisted appId is same as the appId present in the eventData of internalEvent
-    /// returns true, if the persisted appId is same as the internalEvent appId present in the eventData
-    /// - Parameters:
-    ///   - event: event for the API call
-    ///   - newAppId: appId passed into the API
-    /// - Returns: true if there was a change to appId via the `IS_INTERNAL_EVENT` event
-    private func validateForInternalEventAppIdChange(event: Event, newAppId: String) -> Bool {
-        let isInternalEvent = event.data?[ConfigurationConstants.Keys.IS_INTERNAL_EVENT] as? Bool ?? false
-
-        if isInternalEvent, newAppId != appIdManager.loadAppId() {
-            return false
-        }
-
-        return true
     }
 }

--- a/AEPCore/Sources/configuration/Configuration.swift
+++ b/AEPCore/Sources/configuration/Configuration.swift
@@ -89,22 +89,6 @@ class Configuration: NSObject, Extension {
         }
     }
 
-    /// Invoked by the `eventQueue` each time a new lifecycle response event is received
-    /// - Parameter event: A lifecycle response event
-    private func receiveLifecycleResponse(event: Event) {
-        // Re-fetch the latest config if appId is present.
-        // Lifecycle does not load bundled/manual configuration if appId is absent.
-        guard let appId = appIdManager.loadAppId(), !appId.isEmpty else {
-            Log.debug(label: name, "Ignoring Lifecycle response event, app id already exists.")
-            return
-        }
-
-        // Dispatch an event with appId to start remote download
-        let data: [String: Any] = [ConfigurationConstants.Keys.JSON_APP_ID: appId,
-                                   ConfigurationConstants.Keys.IS_INTERNAL_EVENT: true]
-        dispatchConfigurationRequest(data: data)
-    }
-
     // MARK: - Event Processors
 
     /// Interacts with the `ConfigurationState` to update the configuration with the new configuration contained in `event`

--- a/AEPCore/Sources/configuration/LaunchIDManager.swift
+++ b/AEPCore/Sources/configuration/LaunchIDManager.swift
@@ -35,6 +35,11 @@ struct LaunchIDManager {
         dataStore.set(key: ConfigurationConstants.DataStoreKeys.PERSISTED_APPID, value: appId)
     }
 
+    /// Removes persisted appId from persistence
+    func removeAppIdFromPersistence() {
+        dataStore.remove(key: ConfigurationConstants.DataStoreKeys.PERSISTED_APPID)
+    }
+
     /// Loads the appId from the data store
     /// - Returns: appId loaded from persistence, nil if not present
     func loadAppIdFromPersistence() -> String? {

--- a/AEPCore/Tests/FunctionalTests/Configuration/ConfigurationAppIDTests.swift
+++ b/AEPCore/Tests/FunctionalTests/Configuration/ConfigurationAppIDTests.swift
@@ -56,7 +56,7 @@ class ConfigurationAppIDTests: XCTestCase {
         XCTAssertEqual(16, mockRuntime.firstSharedState?.count)
     }
     
-    func testConfigureWithAppIdNilAppIdRemovesFromPersistence() {
+    func testConfigureWithEmptyAppIdRemovesFromPersistence() {
         let mockNetworkService = MockConfigurationDownloaderNetworkService(responseType: .success)
         ServiceProvider.shared.networkService = mockNetworkService
         let validAppId = "valid-app-id"

--- a/AEPCore/Tests/FunctionalTests/Configuration/ConfigurationLifecycleResponseTests.swift
+++ b/AEPCore/Tests/FunctionalTests/Configuration/ConfigurationLifecycleResponseTests.swift
@@ -41,43 +41,4 @@ class ConfigurationLifecycleResponseTests: XCTestCase {
         XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
     }
 
-    /// Tests that configuration event is dispatched when a lifecycle response content event and an valid appId is stored in persistence
-    func testHandleLifecycleResponseValidAppidFromPersistance() {
-        // setup
-        let appIdEvent = ConfigurationAppIDTests.createConfigAppIdEvent(appId: "testappid")
-        let lifecycleEvent = Event(name: "Lifecycle response content", type: EventType.lifecycle, source: EventSource.responseContent, data: nil)
-
-        // test
-        mockRuntime.simulateComingEvents(appIdEvent)
-        mockRuntime.resetDispatchedEventAndCreatedSharedStates()
-        mockRuntime.simulateComingEvents(lifecycleEvent)
-
-        // verify
-        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
-        XCTAssertEqual(EventType.configuration, mockRuntime.firstEvent?.type)
-        XCTAssertEqual(EventSource.requestContent, mockRuntime.firstEvent?.source)
-        XCTAssertEqual("testappid", mockRuntime.firstEvent?.data?["config.appId"] as? String)
-    }
-
-    /// Tests that app id is loaded from manifest on lifecycle response event
-    func testHandleLifecycleResponseValidAppidFromManifest() {
-        let mockSystemInfoService = MockSystemInfoService()
-        mockSystemInfoService.property = "testappid"
-        ServiceProvider.shared.systemInfoService = mockSystemInfoService
-
-        let lifecycleEvent = Event(name: "Lifecycle response content", type: EventType.lifecycle, source: EventSource.responseContent, data: nil)
-
-        // test
-        mockRuntime.resetDispatchedEventAndCreatedSharedStates()
-        mockRuntime.simulateComingEvents(lifecycleEvent)
-
-        // verify
-        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
-        XCTAssertEqual(EventType.configuration, mockRuntime.firstEvent?.type)
-        XCTAssertEqual(EventSource.requestContent, mockRuntime.firstEvent?.source)
-        XCTAssertEqual("testappid", mockRuntime.firstEvent?.data?["config.appId"] as? String)
-
-        mockSystemInfoService.property = nil
-    }
-
 }


### PR DESCRIPTION
There are two changes being introduced as per #749.
1. We are no longer calling configureWithAppId in response to Lifecycle::ResponseContent. The reasoning for this change can be found here:[Configuration Network Findings](https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=~spujari&title=Configuration+Android+extension+testing%3A+Behavior+in+offline+scenarios). Essentially, this was overriding the set local file config unexpectedly.
2. We are now removing app id from persistence when an empty app id is passed into the API as requested by customers.