### PR TITLE
Fix Identity.getIdentifiers API to return Identifiers list instead of AEPError

### DIFF
--- a/AEPIdentity/Sources/CustomIdentity.swift
+++ b/AEPIdentity/Sources/CustomIdentity.swift
@@ -31,6 +31,14 @@ class CustomIdentity: Identifiable, Codable {
         self.authenticationState = authenticationState
     }
 
+    init(dict: [String: Any]) {
+        self.type = dict[CodingKeys.type.rawValue] as? String
+        self.origin = dict[CodingKeys.origin.rawValue] as? String
+        self.identifier = dict[CodingKeys.identifier.rawValue] as? String
+        let rawState = dict[CodingKeys.authenticationState.rawValue] as? Int
+        self.authenticationState = MobileVisitorAuthenticationState(rawValue: rawState ?? MobileVisitorAuthenticationState.unknown.rawValue) ?? .unknown
+    }
+
     enum CodingKeys: String, CodingKey {
         case origin = "id_origin"
         case type = "id_type"

--- a/AEPIdentity/Sources/Identity+PublicAPI.swift
+++ b/AEPIdentity/Sources/Identity+PublicAPI.swift
@@ -54,7 +54,7 @@ import Foundation
                 return
             }
 
-            guard var eventData: [String: Any] = responseEvent.data else {
+            guard let eventData: [String: Any] = responseEvent.data else {
                 completion(nil, AEPError.unexpected)
                 return
             }

--- a/AEPIdentity/Sources/Identity+PublicAPI.swift
+++ b/AEPIdentity/Sources/Identity+PublicAPI.swift
@@ -53,23 +53,23 @@ import Foundation
                 completion(nil, AEPError.callbackTimeout)
                 return
             }
-            
+
             guard var eventData: [String: Any] = responseEvent.data else {
                 completion(nil, AEPError.unexpected)
                 return
             }
-            
+
             // return empty list if no Customer Identifiers in response data
             if eventData[IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] == nil {
                 completion([], nil)
                 return
             }
-            
+
             guard let identifiersDict = eventData[IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [[String: Any]] else {
                 completion(nil, AEPError.unexpected)
                 return
             }
-            
+
             let identifiers = identifiersDict.map { CustomIdentity.from(dict: $0) }.compactMap { $0 }
 
             completion(identifiers, .none)
@@ -159,13 +159,13 @@ import Foundation
 
 extension CustomIdentity {
     internal static func from(dict: [String: Any]) -> CustomIdentity? {
-            guard let type = dict[CodingKeys.type.rawValue] as? String,
-                  let origin = dict[CodingKeys.origin.rawValue] as? String,
-                  let identifier = dict[CodingKeys.identifier.rawValue] as? String,
-                  let rawState = dict[CodingKeys.authenticationState.rawValue] as? Int,
-                  !identifier.isEmpty else {
-                      return nil
-                  }
+        guard let type = dict[CodingKeys.type.rawValue] as? String,
+              let origin = dict[CodingKeys.origin.rawValue] as? String,
+              let identifier = dict[CodingKeys.identifier.rawValue] as? String,
+              let rawState = dict[CodingKeys.authenticationState.rawValue] as? Int,
+              !identifier.isEmpty else {
+            return nil
+        }
         let state = MobileVisitorAuthenticationState(rawValue: rawState) ?? MobileVisitorAuthenticationState.unknown
         return CustomIdentity(origin: origin, type: type, identifier: identifier, authenticationState: state)
     }

--- a/AEPIdentity/Sources/Identity+PublicAPI.swift
+++ b/AEPIdentity/Sources/Identity+PublicAPI.swift
@@ -10,6 +10,7 @@
  */
 
 import AEPCore
+import AEPServices
 import Foundation
 
 /// Defines the public interface for the Identity extension
@@ -66,11 +67,12 @@ import Foundation
             }
 
             guard let identifiersDict = eventData[IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [[String: Any]] else {
+                Log.warning(label: "\(IdentityConstants.EXTENSION_NAME):\(#function)", "Failed to retrieve visitor identifiers from event response as object type is not a map.")
                 completion(nil, AEPError.unexpected)
                 return
             }
 
-            let identifiers = identifiersDict.map { CustomIdentity.from(dict: $0) }.compactMap { $0 }
+            let identifiers = identifiersDict.map { CustomIdentity(dict: $0) }.compactMap { $0 }
 
             completion(identifiers, .none)
         }
@@ -154,19 +156,5 @@ import Foundation
             let urlVariables = responseEvent.data?[IdentityConstants.EventDataKeys.URL_VARIABLES] as? String
             completion(urlVariables, .none)
         }
-    }
-}
-
-extension CustomIdentity {
-    internal static func from(dict: [String: Any]) -> CustomIdentity? {
-        guard let type = dict[CodingKeys.type.rawValue] as? String,
-              let origin = dict[CodingKeys.origin.rawValue] as? String,
-              let identifier = dict[CodingKeys.identifier.rawValue] as? String,
-              let rawState = dict[CodingKeys.authenticationState.rawValue] as? Int,
-              !identifier.isEmpty else {
-            return nil
-        }
-        let state = MobileVisitorAuthenticationState(rawValue: rawState) ?? MobileVisitorAuthenticationState.unknown
-        return CustomIdentity(origin: origin, type: type, identifier: identifier, authenticationState: state)
     }
 }

--- a/AEPIdentity/Sources/Identity+PublicAPI.swift
+++ b/AEPIdentity/Sources/Identity+PublicAPI.swift
@@ -53,11 +53,24 @@ import Foundation
                 completion(nil, AEPError.callbackTimeout)
                 return
             }
-
-            guard let identifiers = responseEvent.data?[IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [Identifiable] else {
+            
+            guard var eventData: [String: Any] = responseEvent.data else {
                 completion(nil, AEPError.unexpected)
                 return
             }
+            
+            // return empty list if no Customer Identifiers in response data
+            if eventData[IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] == nil {
+                completion([], nil)
+                return
+            }
+            
+            guard let identifiersDict = eventData[IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] as? [[String: Any]] else {
+                completion(nil, AEPError.unexpected)
+                return
+            }
+            
+            let identifiers = identifiersDict.map { CustomIdentity.from(dict: $0) }.compactMap { $0 }
 
             completion(identifiers, .none)
         }
@@ -141,5 +154,19 @@ import Foundation
             let urlVariables = responseEvent.data?[IdentityConstants.EventDataKeys.URL_VARIABLES] as? String
             completion(urlVariables, .none)
         }
+    }
+}
+
+extension CustomIdentity {
+    internal static func from(dict: [String: Any]) -> CustomIdentity? {
+            guard let type = dict[CodingKeys.type.rawValue] as? String,
+                  let origin = dict[CodingKeys.origin.rawValue] as? String,
+                  let identifier = dict[CodingKeys.identifier.rawValue] as? String,
+                  let rawState = dict[CodingKeys.authenticationState.rawValue] as? Int,
+                  !identifier.isEmpty else {
+                      return nil
+                  }
+        let state = MobileVisitorAuthenticationState(rawValue: rawState) ?? MobileVisitorAuthenticationState.unknown
+        return CustomIdentity(origin: origin, type: type, identifier: identifier, authenticationState: state)
     }
 }

--- a/AEPIdentity/Tests/CustomIdentityTests.swift
+++ b/AEPIdentity/Tests/CustomIdentityTests.swift
@@ -229,4 +229,96 @@ class CustomIdentityTests: XCTestCase {
         // test & verify
         XCTAssertFalse(id1 == id2)
     }
+    
+    // MARK: init(dict:) tests
+    
+    func testCustomIdentity_initFromDictionary() {
+        let dict: [String: Any] = [
+            "id_type": "test-type",
+            "id_origin": "test-origin",
+            "id": "test-id",
+            "authentication_state": 1
+        ]
+
+        let customId = CustomIdentity(dict: dict)
+        XCTAssertEqual("test-id", customId.identifier)
+        XCTAssertEqual("test-type", customId.type)
+        XCTAssertEqual(MobileVisitorAuthenticationState.authenticated, customId.authenticationState)
+        XCTAssertEqual("test-origin", customId.origin)
+    }
+
+    func testCustomIdentity_initFromDictionary_setStateToUnknown_whenInvalid() {
+        let dict: [String: Any] = [
+            "id_type": "test-type",
+            "id_origin": "test-origin",
+            "id": "test-id",
+            "authentication_state": 11
+        ]
+
+        let customId = CustomIdentity(dict: dict)
+        XCTAssertEqual("test-id", customId.identifier)
+        XCTAssertEqual("test-type", customId.type)
+        XCTAssertEqual(MobileVisitorAuthenticationState.unknown, customId.authenticationState)
+        XCTAssertEqual("test-origin", customId.origin)
+    }
+    
+    func testCustomIdentity_initFromDictionary_setStateToUnknown_whenEmpty() {
+        let dict: [String: Any] = [
+            "id_type": "test-type",
+            "id_origin": "test-origin",
+            "id": "test-id"
+        ]
+
+        let customId = CustomIdentity(dict: dict)
+        XCTAssertEqual("test-id", customId.identifier)
+        XCTAssertEqual("test-type", customId.type)
+        XCTAssertEqual(MobileVisitorAuthenticationState.unknown, customId.authenticationState)
+        XCTAssertEqual("test-origin", customId.origin)
+    }
+    
+    func testCustomIdentity_initFromDictionary_invalidId_returnsNilId() {
+        let dict: [String: Any] = [
+            "id_type": "test-type",
+            "id_origin": "test-origin",
+            "id": -1, // expected type String
+            "authentication_state": 1
+        ]
+
+        let customId = CustomIdentity(dict: dict)
+        XCTAssertNil(customId.identifier)
+        XCTAssertEqual("test-type", customId.type)
+        XCTAssertEqual(MobileVisitorAuthenticationState.authenticated, customId.authenticationState)
+        XCTAssertEqual("test-origin", customId.origin)
+    }
+
+    func testCustomIdentity_initFromDictionary_invalidType_returnsNilType() {
+        let dict: [String: Any] = [
+            "id_type": -1, // expected type String
+            "id_origin": "test-origin",
+            "id": "test-id",
+            "authentication_state": 1
+        ]
+
+        let customId = CustomIdentity(dict: dict)
+        XCTAssertEqual("test-id", customId.identifier)
+        XCTAssertNil(customId.type)
+        XCTAssertEqual(MobileVisitorAuthenticationState.authenticated, customId.authenticationState)
+        XCTAssertEqual("test-origin", customId.origin)
+    }
+    
+    func testCustomIdentity_initFromDictionary_invalidOrigin_returnsNilOrigin() {
+        let dict: [String: Any] = [
+            "id_type": "test-type",
+            "id_origin": -1, // expected type String
+            "id": "test-id",
+            "authentication_state": 1
+        ]
+
+        let customId = CustomIdentity(dict: dict)
+        XCTAssertEqual("test-id", customId.identifier)
+        XCTAssertEqual("test-type", customId.type)
+        XCTAssertEqual(MobileVisitorAuthenticationState.authenticated, customId.authenticationState)
+        XCTAssertNil(customId.origin)
+    }
+
 }

--- a/AEPIdentity/Tests/IdentityPublicAPITests.swift
+++ b/AEPIdentity/Tests/IdentityPublicAPITests.swift
@@ -275,47 +275,4 @@ class IdentityAPITests: XCTestCase {
         // verify
         wait(for: [expectation], timeout: 1)
     }
-
-    func testCustomIdentityFromDictionary_validValues() {
-        let dict: [String: Any] = [
-            "id_type": "test-type",
-            "id_origin": "test-origin",
-            "id": "test-id",
-            "authentication_state": 1
-        ]
-
-        let customId = CustomIdentity.from(dict: dict)
-        XCTAssertEqual("test-id", customId?.identifier)
-        XCTAssertEqual("test-type", customId?.type)
-        XCTAssertEqual(MobileVisitorAuthenticationState.authenticated, customId?.authenticationState)
-        XCTAssertEqual("test-origin", customId?.origin)
-    }
-
-    func testCustomIdentityFromDictionary_failsIfIdentifierIsEmpty() {
-        let dict: [String: Any] = [
-            "id_type": "test-type",
-            "id_origin": "test-origin",
-            "id": "",
-            "authentication_state": 1
-        ]
-
-        XCTAssertNil(CustomIdentity.from(dict: dict))
-
-    }
-
-    func testCustomIdentityFromDictionary_unknownAuthenticationWhenIncorrectValue() {
-        let dict: [String: Any] = [
-            "id_type": "test-type",
-            "id_origin": "test-origin",
-            "id": "test-id",
-            "authentication_state": 11
-        ]
-
-        let customId = CustomIdentity.from(dict: dict)
-        XCTAssertEqual("test-id", customId?.identifier)
-        XCTAssertEqual("test-type", customId?.type)
-        XCTAssertEqual(MobileVisitorAuthenticationState.unknown, customId?.authenticationState)
-        XCTAssertEqual("test-origin", customId?.origin)
-    }
-
 }

--- a/AEPIdentity/Tests/MobileIdentitiesTests.swift
+++ b/AEPIdentity/Tests/MobileIdentitiesTests.swift
@@ -15,6 +15,7 @@
 import XCTest
 
 class MobileIdentitiesTests: XCTestCase {
+    let ecid = ECID()
     let configurationSharedState = [ConfigurationConstants.Keys.EXPERIENCE_CLOUD_ORGID: "test-orgid"]
     var identitySharedState: [String: Any] {
         return buildIdentitySharedState()
@@ -30,18 +31,17 @@ class MobileIdentitiesTests: XCTestCase {
     ]
 
     private func buildIdentitySharedState() -> [String: Any] {
-        var identitySharedState = [String: Any]()
-        identitySharedState[IdentityConstants.EventDataKeys.VISITOR_ID_ECID] = "test-ecid"
-
         let customIdOne = CustomIdentity(origin: "origin1", type: "type1", identifier: "id1", authenticationState: .authenticated)
         let customIdTwo = CustomIdentity(origin: "origin2", type: "type2", identifier: "id2", authenticationState: .loggedOut)
         let customIdThree = CustomIdentity(origin: "origin3", type: "DSID_20915", identifier: "test-advertisingId", authenticationState: .loggedOut)
-
-        identitySharedState[IdentityConstants.EventDataKeys.VISITOR_IDS_LIST] = [customIdOne, customIdTwo, customIdThree].map({$0.asDictionary()})
-        identitySharedState[IdentityConstants.EventDataKeys.ADVERTISING_IDENTIFIER] = "test-advertisingId"
-        identitySharedState[IdentityConstants.EventDataKeys.PUSH_IDENTIFIER] = "test-pushid"
-
-        return identitySharedState
+        
+        var properties = IdentityProperties()
+        properties.ecid = ecid
+        properties.customerIds = [customIdOne, customIdTwo, customIdThree]
+        properties.advertisingIdentifier = "test-advertisingId"
+        properties.pushIdentifier = "test-pushid"
+        
+        return properties.toEventData()
     }
 
     // MARK: areSharedStatesReady() tests
@@ -115,7 +115,7 @@ class MobileIdentitiesTests: XCTestCase {
         let identifiers = String(data: encodedIdentities!, encoding: .utf8)
 
         // verify
-        let expected = "{\"users\":[{\"userIDs\":[{\"namespace\":\"4\",\"value\":\"test-ecid\",\"type\":\"namespaceId\"},{\"namespace\":\"type1\",\"value\":\"id1\",\"type\":\"integrationCode\"},{\"namespace\":\"type2\",\"value\":\"id2\",\"type\":\"integrationCode\"},{\"namespace\":\"DSID_20915\",\"value\":\"test-advertisingId\",\"type\":\"integrationCode\"},{\"namespace\":\"20920\",\"value\":\"test-pushid\",\"type\":\"integrationCode\"},{\"namespace\":\"AVID\",\"value\":\"test-aid\",\"type\":\"integrationCode\"},{\"namespace\":\"vid\",\"value\":\"test-vid\",\"type\":\"analytics\"},{\"namespace\":\"test-dpid\",\"value\":\"test-dpuuid\",\"type\":\"namespaceId\"},{\"namespace\":\"0\",\"value\":\"test-uuid\",\"type\":\"namespaceId\"}]}],\"companyContexts\":[{\"namespace\":\"imsOrgID\",\"marketingCloudId\":\"test-orgid\"}]}"
+        let expected = "{\"users\":[{\"userIDs\":[{\"namespace\":\"4\",\"value\":\"\(ecid.ecidString)\",\"type\":\"namespaceId\"},{\"namespace\":\"type1\",\"value\":\"id1\",\"type\":\"integrationCode\"},{\"namespace\":\"type2\",\"value\":\"id2\",\"type\":\"integrationCode\"},{\"namespace\":\"DSID_20915\",\"value\":\"test-advertisingId\",\"type\":\"integrationCode\"},{\"namespace\":\"20920\",\"value\":\"test-pushid\",\"type\":\"integrationCode\"},{\"namespace\":\"AVID\",\"value\":\"test-aid\",\"type\":\"integrationCode\"},{\"namespace\":\"vid\",\"value\":\"test-vid\",\"type\":\"analytics\"},{\"namespace\":\"test-dpid\",\"value\":\"test-dpuuid\",\"type\":\"namespaceId\"},{\"namespace\":\"0\",\"value\":\"test-uuid\",\"type\":\"namespaceId\"}]}],\"companyContexts\":[{\"namespace\":\"imsOrgID\",\"marketingCloudId\":\"test-orgid\"}]}"
         XCTAssertEqual(expected, identifiers)
     }
 
@@ -161,7 +161,7 @@ class MobileIdentitiesTests: XCTestCase {
         let identifiers = String(data: encodedIdentities!, encoding: .utf8)
 
         // verify
-        let expected = "{\"users\":[{\"userIDs\":[{\"namespace\":\"4\",\"value\":\"test-ecid\",\"type\":\"namespaceId\"},{\"namespace\":\"type1\",\"value\":\"id1\",\"type\":\"integrationCode\"},{\"namespace\":\"type2\",\"value\":\"id2\",\"type\":\"integrationCode\"},{\"namespace\":\"DSID_20915\",\"value\":\"test-advertisingId\",\"type\":\"integrationCode\"},{\"namespace\":\"20920\",\"value\":\"test-pushid\",\"type\":\"integrationCode\"}]}]}"
+        let expected = "{\"users\":[{\"userIDs\":[{\"namespace\":\"4\",\"value\":\"\(ecid.ecidString)\",\"type\":\"namespaceId\"},{\"namespace\":\"type1\",\"value\":\"id1\",\"type\":\"integrationCode\"},{\"namespace\":\"type2\",\"value\":\"id2\",\"type\":\"integrationCode\"},{\"namespace\":\"DSID_20915\",\"value\":\"test-advertisingId\",\"type\":\"integrationCode\"},{\"namespace\":\"20920\",\"value\":\"test-pushid\",\"type\":\"integrationCode\"}]}]}"
         XCTAssertEqual(expected, identifiers)
     }
 

--- a/AEPIdentity/Tests/MobileIdentitiesTests.swift
+++ b/AEPIdentity/Tests/MobileIdentitiesTests.swift
@@ -34,13 +34,13 @@ class MobileIdentitiesTests: XCTestCase {
         let customIdOne = CustomIdentity(origin: "origin1", type: "type1", identifier: "id1", authenticationState: .authenticated)
         let customIdTwo = CustomIdentity(origin: "origin2", type: "type2", identifier: "id2", authenticationState: .loggedOut)
         let customIdThree = CustomIdentity(origin: "origin3", type: "DSID_20915", identifier: "test-advertisingId", authenticationState: .loggedOut)
-        
+
         var properties = IdentityProperties()
         properties.ecid = ecid
         properties.customerIds = [customIdOne, customIdTwo, customIdThree]
         properties.advertisingIdentifier = "test-advertisingId"
         properties.pushIdentifier = "test-pushid"
-        
+
         return properties.toEventData()
     }
 

--- a/AEPIntegrationTests/IdentityIntegrationTests.swift
+++ b/AEPIntegrationTests/IdentityIntegrationTests.swift
@@ -169,6 +169,24 @@ class IdentityIntegrationTests: XCTestCase {
         }
         wait(for: [urlExpectation], timeout: 2)
     }
+    
+    func testGetIdentifiers() {
+        initExtensionsAndWait()
+
+        let urlExpectation = XCTestExpectation(description: "getSdkIdentities callback")
+        MobileCore.updateConfigurationWith(configDict: ["experienceCloud.org": "orgid", "experienceCloud.server": "test.com", "global.privacy": "optedin"])
+        Identity.syncIdentifier(identifierType: "type1", identifier: "id1", authenticationState: .authenticated)
+        Identity.getIdentifiers { identifiers, error in
+            XCTAssertNotNil(identifiers)
+            XCTAssertEqual(1, identifiers?.count)
+            XCTAssertEqual("id1", identifiers?[0].identifier)
+            XCTAssertEqual("type1", identifiers?[0].type)
+            XCTAssertEqual(MobileVisitorAuthenticationState.authenticated, identifiers?[0].authenticationState)
+            XCTAssertNil(error)
+            urlExpectation.fulfill()
+        }
+        wait(for: [urlExpectation], timeout: 2)
+    }
 
     func testSetPushIdentifier() {
         initExtensionsAndWait()

--- a/AEPIntegrationTests/IdentityIntegrationTests.swift
+++ b/AEPIntegrationTests/IdentityIntegrationTests.swift
@@ -169,7 +169,7 @@ class IdentityIntegrationTests: XCTestCase {
         }
         wait(for: [urlExpectation], timeout: 2)
     }
-    
+
     func testGetIdentifiers() {
         initExtensionsAndWait()
 
@@ -189,7 +189,7 @@ class IdentityIntegrationTests: XCTestCase {
         }
         wait(for: [urlExpectation], timeout: 2)
     }
-    
+
     func testGetIdentifiers_returnsEmptyList_whenNoIds() {
         initExtensionsAndWait()
 

--- a/AEPIntegrationTests/IdentityIntegrationTests.swift
+++ b/AEPIntegrationTests/IdentityIntegrationTests.swift
@@ -179,9 +179,25 @@ class IdentityIntegrationTests: XCTestCase {
         Identity.getIdentifiers { identifiers, error in
             XCTAssertNotNil(identifiers)
             XCTAssertEqual(1, identifiers?.count)
-            XCTAssertEqual("id1", identifiers?[0].identifier)
-            XCTAssertEqual("type1", identifiers?[0].type)
-            XCTAssertEqual(MobileVisitorAuthenticationState.authenticated, identifiers?[0].authenticationState)
+            let customId = identifiers?.first
+            XCTAssertEqual("id1", customId?.identifier)
+            XCTAssertEqual("type1", customId?.type)
+            XCTAssertEqual(MobileVisitorAuthenticationState.authenticated, customId?.authenticationState)
+            XCTAssertEqual("d_cid_ic", customId?.origin)
+            XCTAssertNil(error)
+            urlExpectation.fulfill()
+        }
+        wait(for: [urlExpectation], timeout: 2)
+    }
+    
+    func testGetIdentifiers_returnsEmptyList_whenNoIds() {
+        initExtensionsAndWait()
+
+        let urlExpectation = XCTestExpectation(description: "getSdkIdentities callback")
+        MobileCore.updateConfigurationWith(configDict: ["experienceCloud.org": "orgid", "experienceCloud.server": "test.com", "global.privacy": "optedin"])
+        Identity.getIdentifiers { identifiers, error in
+            XCTAssertNotNil(identifiers)
+            XCTAssertEqual(true, identifiers?.isEmpty)
             XCTAssertNil(error)
             urlExpectation.fulfill()
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Identity.getIdentifiers was attempting to cast the list of identifiers from the response event to an Identifiers list, which failed as the response event is encoded as [String: Any]. Therefore getIdentifiers always returned an AEPError. This fix gets the list of identifiers as [String: Any] then builds a list of Identifiers to return to the callback function. Also, if the response event does not contain a visitor identity entry, the API will return an empty list instead of an AEPError.

Internal ticket: MOB-15688

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
