### PR TITLE
bump version to 3.6.0

### DIFF
--- a/AEPCore.podspec
+++ b/AEPCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AEPCore"
-  s.version          = "3.5.0"
+  s.version          = "3.6.0"
   s.summary          = "Core library for Adobe Experience Platform Mobile SDK. Written and maintained by Adobe."
   s.description      = <<-DESC
                         The core library provides the foundation for the Adobe Experience Platform SDK.  Having the core library installed is a pre-requisite for any other Adobe Experience Platform SDK extension to work.
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
 
   s.dependency 'AEPRulesEngine', '>= 1.1.0'
-  s.dependency 'AEPServices', '>= 3.5.0'
+  s.dependency 'AEPServices', '>= 3.6.0'
 
   s.source_files          = 'AEPCore/Sources/**/*.swift'
 

--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -3818,7 +3818,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.5.0;
+				MARKETING_VERSION = 3.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.core;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -3848,7 +3848,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.5.0;
+				MARKETING_VERSION = 3.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.core;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -3920,7 +3920,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.5.0;
+				MARKETING_VERSION = 3.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.signal;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -3948,7 +3948,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.5.0;
+				MARKETING_VERSION = 3.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.signal;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -4011,7 +4011,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.5.0;
+				MARKETING_VERSION = 3.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = come.adobe.aep.services;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -4038,7 +4038,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.5.0;
+				MARKETING_VERSION = 3.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = come.adobe.aep.services;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -4158,7 +4158,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.5.0;
+				MARKETING_VERSION = 3.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.AEPServicesMocks;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -4185,7 +4185,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.5.0;
+				MARKETING_VERSION = 3.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.AEPServicesMocks;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -4211,7 +4211,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.5.0;
+				MARKETING_VERSION = 3.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.lifecycle;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -4238,7 +4238,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.5.0;
+				MARKETING_VERSION = 3.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.lifecycle;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -4303,7 +4303,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.5.0;
+				MARKETING_VERSION = 3.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.identity;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -4330,7 +4330,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.5.0;
+				MARKETING_VERSION = 3.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.identity;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -4395,7 +4395,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.5.0;
+				MARKETING_VERSION = 3.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.AEPCoreMocks;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -4422,7 +4422,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.5.0;
+				MARKETING_VERSION = 3.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.AEPCoreMocks;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/AEPCore/Sources/configuration/ConfigurationConstants.swift
+++ b/AEPCore/Sources/configuration/ConfigurationConstants.swift
@@ -15,7 +15,7 @@ import Foundation
 struct ConfigurationConstants {
     static let EXTENSION_NAME = "com.adobe.module.configuration"
     static let FRIENDLY_NAME = "Configuration"
-    static let EXTENSION_VERSION = "3.5.0"
+    static let EXTENSION_VERSION = "3.6.0"
     static let DATA_STORE_NAME = EXTENSION_NAME
 
     static let CONFIG_URL_BASE = "https://assets.adobedtm.com/"

--- a/AEPCore/Sources/eventhub/EventHubConstants.swift
+++ b/AEPCore/Sources/eventhub/EventHubConstants.swift
@@ -17,7 +17,7 @@ enum EventHubConstants {
     static let XDM_STATE_CHANGE = "Shared state change (XDM)"
     static let NAME = "com.adobe.module.eventhub"
     static let FRIENDLY_NAME = "EventHub"
-    static let VERSION_NUMBER = "3.5.0"
+    static let VERSION_NUMBER = "3.6.0"
 
     enum EventDataKeys {
         static let VERSION = "version"

--- a/AEPCore/Tests/MobileCoreTests.swift
+++ b/AEPCore/Tests/MobileCoreTests.swift
@@ -207,7 +207,7 @@ class MobileCoreTests: XCTestCase {
               "friendlyName" : "mockExtension"
             },
             "com.adobe.module.configuration" : {
-              "version" : "3.5.0",
+              "version" : "3.6.0",
               "friendlyName" : "Configuration"
             },
             "com.adobe.mockExtensionTwo" : {

--- a/AEPIdentity.podspec
+++ b/AEPIdentity.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AEPIdentity"
-  s.version          = "3.5.0"
+  s.version          = "3.6.0"
   s.summary          = "Identity extension for Adobe Experience Platform Mobile SDK. Written and maintained by Adobe."
   s.description      = <<-DESC
                         The AEPIdentity extension provides APIs that allow use of the Visitor ID services in the Adobe Experience Cloud SDK.
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.swift_version = '5.1'
   s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
 
-  s.dependency 'AEPCore', '>= 3.5.0'
+  s.dependency 'AEPCore', '>= 3.6.0'
 
 end

--- a/AEPIdentity/Sources/IdentityConstants.swift
+++ b/AEPIdentity/Sources/IdentityConstants.swift
@@ -14,7 +14,7 @@ import Foundation
 enum IdentityConstants {
     static let EXTENSION_NAME = "com.adobe.module.identity"
     static let FRIENDLY_NAME = "Identity"
-    static let EXTENSION_VERSION = "3.5.0"
+    static let EXTENSION_VERSION = "3.6.0"
     static let DATASTORE_NAME = EXTENSION_NAME
 
     static let API_TIMEOUT = TimeInterval(0.5) // Get API requests timeout after half a second

--- a/AEPLifecycle.podspec
+++ b/AEPLifecycle.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AEPLifecycle"
-  s.version          = "3.5.0"
+  s.version          = "3.6.0"
   s.summary          = "Lifecycle extension for Adobe Experience Platform Mobile SDK. Written and maintained by Adobe."
   s.description      = <<-DESC
                         The AEPLifecycle extension is used to track application lifecycle including session metricss and device related data.
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.swift_version = '5.1'
   s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
 
-  s.dependency 'AEPCore', '>= 3.5.0'
+  s.dependency 'AEPCore', '>= 3.6.0'
 
 end

--- a/AEPLifecycle/Sources/LifecycleConstants.swift
+++ b/AEPLifecycle/Sources/LifecycleConstants.swift
@@ -16,7 +16,7 @@ import Foundation
 enum LifecycleConstants {
     static let EXTENSION_NAME = "com.adobe.module.lifecycle"
     static let FRIENDLY_NAME = "Lifecycle"
-    static let EXTENSION_VERSION = "3.5.0"
+    static let EXTENSION_VERSION = "3.6.0"
     static let DATA_STORE_NAME = LifecycleConstants.EXTENSION_NAME
 
     static let START = "start"

--- a/AEPServices.podspec
+++ b/AEPServices.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AEPServices"
-  s.version          = "3.5.0"
+  s.version          = "3.6.0"
   s.summary          = "Servcies library for Adobe Experience Platform Mobile SDK. Written and maintained by Adobe."
   s.description      = <<-DESC
                         The AEPServices library provides the platform services and utilities for the Adobe Experience Platform SDK.  Having the services library installed is a pre-requisite for any other Adobe Experience Platform SDK extension to work.

--- a/AEPSignal.podspec
+++ b/AEPSignal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AEPSignal"
-  s.version          = "3.5.0"
+  s.version          = "3.6.0"
   s.summary          = "Signal extension for Adobe Experience Platform Mobile SDK. Written and maintained by Adobe."
   s.description      = <<-DESC
                         The AEPSignal extension provides the support for Postback/PII/Open URL actions triggered by Core rules engine.
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.swift_version = '5.1'
   s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
 
-  s.dependency 'AEPCore', '>= 3.5.0'
+  s.dependency 'AEPCore', '>= 3.6.0'
 
 end

--- a/AEPSignal/Sources/SignalConstants.swift
+++ b/AEPSignal/Sources/SignalConstants.swift
@@ -15,7 +15,7 @@ import Foundation
 enum SignalConstants {
     static let EXTENSION_NAME = "com.adobe.module.signal"
     static let FRIENDLY_NAME = "Signal"
-    static let EXTENSION_VERSION = "3.5.0"
+    static let EXTENSION_VERSION = "3.6.0"
     static let DATASTORE_NAME = EXTENSION_NAME
     static let LOG_PREFIX = FRIENDLY_NAME
 


### PR DESCRIPTION
Bump Version to 3.6.0 in preparation for v.3.6.0 release which contains the following:
* Use cached images for FullScreen Messages
* Fix a bug preventing Fullscreen Messages from being dismissed in certain conditions
* App Extension Support
* Add a new API to the `Extension` protocol for getting latest non pending shared state
* Bundled Rules support