### PR TITLE
Configuration retry improvements

### DIFF
--- a/AEPCore/Sources/configuration/Configuration.swift
+++ b/AEPCore/Sources/configuration/Configuration.swift
@@ -148,6 +148,7 @@ class Configuration: NSObject, Extension {
                 guard let self = self else { return }
                 Log.trace(label: self.name, "Downloading config failed, trying again")
                 self.retryQueue.asyncAfter(deadline: .now() + (self.retryConfigurationCounter * 2)) {
+                    print("retrying: \(self.retryConfigurationCounter)")
                     let event = Event(name: CoreConstants.EventNames.CONFIGURE_WITH_APP_ID, type: EventType.configuration, source: EventSource.requestContent,
                                       data: [CoreConstants.Keys.JSON_APP_ID: appId, CoreConstants.Keys.IS_INTERNAL_EVENT: true])
                     self.dispatch(event: event)

--- a/AEPCore/Sources/configuration/Configuration.swift
+++ b/AEPCore/Sources/configuration/Configuration.swift
@@ -148,7 +148,6 @@ class Configuration: NSObject, Extension {
                 guard let self = self else { return }
                 Log.trace(label: self.name, "Downloading config failed, trying again")
                 self.retryQueue.asyncAfter(deadline: .now() + (self.retryConfigurationCounter * 2)) {
-                    print("retrying: \(self.retryConfigurationCounter)")
                     let event = Event(name: CoreConstants.EventNames.CONFIGURE_WITH_APP_ID, type: EventType.configuration, source: EventSource.requestContent,
                                       data: [CoreConstants.Keys.JSON_APP_ID: appId, CoreConstants.Keys.IS_INTERNAL_EVENT: true])
                     self.dispatch(event: event)

--- a/AEPCore/Sources/configuration/Configuration.swift
+++ b/AEPCore/Sources/configuration/Configuration.swift
@@ -146,8 +146,10 @@ class Configuration: NSObject, Extension {
             } else {
                 // If downloading config failed try again later
                 guard let self = self else { return }
-                Log.trace(label: self.name, "Downloading config failed, trying again")
-                self.retryQueue.asyncAfter(deadline: .now() + (self.retryConfigurationCounter * 2)) {
+                sharedStateResolver(self.configState.environmentAwareConfiguration)
+                let retryInterval = self.retryConfigurationCounter * 5
+                Log.trace(label: self.name, "Downloading config failed, trying again after \(retryInterval) secs")
+                self.retryQueue.asyncAfter(deadline: .now() + retryInterval) {
                     let event = Event(name: CoreConstants.EventNames.CONFIGURE_WITH_APP_ID, type: EventType.configuration, source: EventSource.requestContent,
                                       data: [CoreConstants.Keys.JSON_APP_ID: appId, CoreConstants.Keys.IS_INTERNAL_EVENT: true])
                     self.dispatch(event: event)

--- a/AEPCore/Tests/FunctionalTests/Configuration/ConfigurationAppIDTests.swift
+++ b/AEPCore/Tests/FunctionalTests/Configuration/ConfigurationAppIDTests.swift
@@ -20,11 +20,11 @@ import XCTest
 class ConfigurationAppIDTests: XCTestCase {
     var mockRuntime: TestableExtensionRuntime!
     var configuration: Configuration!
-    
+
     var mockDataStore: MockDataStore {
         return ServiceProvider.shared.namedKeyValueService as! MockDataStore
     }
-    
+
     override func setUp() {
         UserDefaults.clear()
         ServiceProvider.shared.namedKeyValueService = MockDataStore()
@@ -35,46 +35,46 @@ class ConfigurationAppIDTests: XCTestCase {
     }
 
     // MARK: configureWith(appId) tests
-    
+
     /// When network service returns a valid response configure with appId succeeds
     func testConfigureWithAppId() {
         // setup
         let mockNetworkService = MockConfigurationDownloaderNetworkService(responseType: .success)
         ServiceProvider.shared.networkService = mockNetworkService
         let appIdEvent = ConfigurationAppIDTests.createConfigAppIdEvent(appId: "valid-app-id")
-        
+
         // test
         mockRuntime.simulateComingEvents(appIdEvent)
-        
+
         // verify
         XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
         XCTAssertEqual(1, mockRuntime.createdSharedStates.count)
         XCTAssertEqual(EventType.configuration, mockRuntime.firstEvent?.type)
         XCTAssertEqual(EventSource.responseContent, mockRuntime.firstEvent?.source)
-        
+
         XCTAssertEqual(16, mockRuntime.firstEvent?.data?.count)
         XCTAssertEqual(16, mockRuntime.firstSharedState?.count)
     }
-    
+
     func testConfigureWithEmptyAppIdRemovesFromPersistence() {
         let mockNetworkService = MockConfigurationDownloaderNetworkService(responseType: .success)
         ServiceProvider.shared.networkService = mockNetworkService
         let validAppId = "valid-app-id"
         let appIdEvent = ConfigurationAppIDTests.createConfigAppIdEvent(appId: validAppId)
-        
+
         // test
         mockRuntime.simulateComingEvents(appIdEvent)
-        
+
         // Should be in storage
         XCTAssertEqual(validAppId, mockDataStore.dict[ConfigurationConstants.DataStoreKeys.PERSISTED_APPID] as? String)
-        
+
         let appIdEvent2 = ConfigurationAppIDTests.createConfigAppIdEvent(appId: "")
-        
+
         mockRuntime.simulateComingEvents(appIdEvent2)
-        
+
         // Should have been removed from storage
         XCTAssertNil(mockDataStore.dict[ConfigurationConstants.DataStoreKeys.PERSISTED_APPID] as Any?)
-        
+
     }
 
     // Tests that when we hit the retry queue, we properly send a configuration request event
@@ -86,40 +86,85 @@ class ConfigurationAppIDTests: XCTestCase {
 
         mockRuntime.simulateComingEvents(appIdEvent)
 
-        sleep(4)
+        // Sleep for the retryInterval
+        sleep(6)
         // verify
         XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
-        XCTAssertEqual(0, mockRuntime.createdSharedStates.count)
+        XCTAssertEqual(1, mockRuntime.createdSharedStates.count)
         XCTAssertEqual(EventType.configuration, mockRuntime.firstEvent?.type)
         XCTAssertEqual(EventSource.requestContent, mockRuntime.firstEvent?.source)
 
         XCTAssertEqual(2, mockRuntime.firstEvent?.data?.count)
         XCTAssertTrue(mockRuntime.firstEvent?.data?[CoreConstants.Keys.IS_INTERNAL_EVENT] as! Bool)
         XCTAssertEqual(appId, mockRuntime.firstEvent?.data?[CoreConstants.Keys.JSON_APP_ID] as! String)
-
     }
-    
+
+    func testConfigureWithAppIdFirstOnlineThenOffline() {
+        let mockNetworkService = MockConfigurationDownloaderNetworkService(responseType: .success)
+        ServiceProvider.shared.networkService = mockNetworkService
+        let validAppId = "valid-app-id"
+        let invalidAppId = "invalid-app-id"
+        let appIdEvent = ConfigurationAppIDTests.createConfigAppIdEvent(appId: validAppId)
+        let invalidAppIdEvent = ConfigurationAppIDTests.createConfigAppIdEvent(appId: invalidAppId)
+        // test
+        mockRuntime.simulateComingEvents(appIdEvent)
+
+        // simulate offline
+        ServiceProvider.shared.networkService = MockConfigurationDownloaderNetworkService(responseType: .error)
+        mockRuntime.simulateComingEvents(invalidAppIdEvent)
+
+        // Sleep for the retryInterval
+        sleep(6)
+
+        // verify
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
+        XCTAssertEqual(2, mockRuntime.createdSharedStates.count)
+        XCTAssertEqual(EventType.configuration, mockRuntime.firstEvent?.type)
+        XCTAssertEqual(EventSource.responseContent, mockRuntime.firstEvent?.source)
+        XCTAssertEqual(EventType.configuration, mockRuntime.secondEvent?.type)
+        XCTAssertEqual(EventSource.requestContent, mockRuntime.secondEvent?.source)
+
+        XCTAssertEqual(16, mockRuntime.firstEvent?.data?.count)
+        XCTAssertEqual(16, mockRuntime.firstSharedState?.count)
+        XCTAssertEqual(2, mockRuntime.secondEvent?.data?.count)
+        XCTAssertTrue(mockRuntime.secondEvent?.data?[CoreConstants.Keys.IS_INTERNAL_EVENT] as! Bool)
+        XCTAssertEqual(invalidAppId, mockRuntime.secondEvent?.data?[CoreConstants.Keys.JSON_APP_ID] as! String)
+        XCTAssertEqual(16, mockRuntime.secondSharedState?.count)
+    }
+
     /// Tests that we can re-try network requests, and it will succeed when the network comes back online
     func testConfigureWithAppIdNetworkDownThenComesOnline() {
         // setup
         let mockNetworkService = MockConfigurationDownloaderNetworkService(responseType: .error)
         ServiceProvider.shared.networkService = mockNetworkService
-        
-        let appIdEvent = ConfigurationAppIDTests.createConfigAppIdEvent(appId: "valid-app-id")
-        let invalidAppIdEvent = ConfigurationAppIDTests.createConfigAppIdEvent(appId: "invalid-app-id")
+        let validAppId = "valid-app-id"
+        let invalidAppId = "invalid-app-id"
+        let appIdEvent = ConfigurationAppIDTests.createConfigAppIdEvent(appId: validAppId)
+        let invalidAppIdEvent = ConfigurationAppIDTests.createConfigAppIdEvent(appId: invalidAppId)
+
         // test
         mockRuntime.simulateComingEvents(invalidAppIdEvent)
+
+        // Sleep for retryInterval
+        sleep(6)
+
         ServiceProvider.shared.networkService = MockConfigurationDownloaderNetworkService(responseType: .success) // setup a valid network response
         mockRuntime.simulateComingEvents(appIdEvent)
-        
+
         // verify
-        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
-        XCTAssertEqual(1, mockRuntime.createdSharedStates.count)
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
+        XCTAssertEqual(2, mockRuntime.createdSharedStates.count)
         XCTAssertEqual(EventType.configuration, mockRuntime.firstEvent?.type)
-        XCTAssertEqual(EventSource.responseContent, mockRuntime.firstEvent?.source)
-        
-        XCTAssertEqual(16, mockRuntime.firstEvent?.data?.count)
-        XCTAssertEqual(16, mockRuntime.firstSharedState?.count)
+        XCTAssertEqual(EventSource.requestContent, mockRuntime.firstEvent?.source)
+        XCTAssertEqual(EventType.configuration, mockRuntime.secondEvent?.type)
+        XCTAssertEqual(EventSource.responseContent, mockRuntime.secondEvent?.source)
+
+        XCTAssertEqual(2, mockRuntime.firstEvent?.data?.count)
+        XCTAssertTrue(mockRuntime.firstEvent?.data?[CoreConstants.Keys.IS_INTERNAL_EVENT] as! Bool)
+        XCTAssertEqual(invalidAppId, mockRuntime.firstEvent?.data?[CoreConstants.Keys.JSON_APP_ID] as! String)
+        XCTAssertEqual(0, mockRuntime.firstSharedState?.count)
+        XCTAssertEqual(16, mockRuntime.secondEvent?.data?.count)
+        XCTAssertEqual(16, mockRuntime.secondSharedState?.count)
     }
 
     static func createConfigAppIdEvent(appId: String) -> Event {

--- a/AEPIntegrationTests/ConfigurationIntegrationTests.swift
+++ b/AEPIntegrationTests/ConfigurationIntegrationTests.swift
@@ -53,7 +53,7 @@ class ConfigurationIntegrationTests: XCTestCase {
         MobileCore.registerExtensions([Identity.self, Lifecycle.self, Signal.self]) {
             initExpectation.fulfill()
         }
-        wait(for: [initExpectation], timeout: 1)
+        wait(for: [initExpectation], timeout: 2)
     }
 
     func testConfigLocalFile() {


### PR DESCRIPTION
#712 Improves configuration retry logic by sending a configuration request event on retry instead of recursively calling the processor. Also scales the retry by increasing the retry deadline after every retry.