### PR TITLE
Add constants for EdgeBridge events

### DIFF
--- a/AEPCore/Sources/eventhub/EventSource.swift
+++ b/AEPCore/Sources/eventhub/EventSource.swift
@@ -26,6 +26,8 @@ public class EventSource: NSObject {
     public static let responseIdentity = "com.adobe.eventSource.responseIdentity"
     public static let responseProfile = "com.adobe.eventSource.responseProfile"
     public static let sharedState = "com.adobe.eventSource.sharedState"
+    public static let startCapture = "com.adobe.eventSource.startCapture"
+    public static let stopCapture = "com.adobe.eventSource.stopCapture"
     public static let notification = "com.adobe.eventSource.notification"
     public static let updateConsent = "com.adobe.eventSource.updateConsent"
     public static let updateIdentity = "com.adobe.eventSource.updateIdentity"

--- a/AEPCore/Sources/eventhub/EventType.swift
+++ b/AEPCore/Sources/eventhub/EventType.swift
@@ -23,6 +23,7 @@ public class EventType: NSObject {
     public static let configuration = "com.adobe.eventType.configuration"
     public static let custom = "com.adobe.eventType.custom"
     public static let edge = "com.adobe.eventType.edge"
+    public static let edgeBridge = "com.adobe.eventType.edgeBridge"
     public static let edgeConsent = "com.adobe.eventType.edgeConsent"
     public static let edgeIdentity = "com.adobe.eventType.edgeIdentity"
     public static let genericData = "com.adobe.eventType.generic.data"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This update adds constants to `EventType` and `EventSource` required for EdgeBridge context data capture functionality as implemented in [this PR](https://github.com/adobe/aepsdk-edgebridge-ios/pull/7).

The new public APIs available in EdgeBridge extension require the new `EventType` specific to EdgeBridge, and the `EventSource` values for starting and stopping context data capture.

## Related Issue

Please see [MOB-16906](https://jira.corp.adobe.com/browse/MOB-16906) for additional details.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
