### PR TITLE
Update style guide with trailing closure naming 

### DIFF
--- a/Documentation/Contributing/StyleGuide.md
+++ b/Documentation/Contributing/StyleGuide.md
@@ -53,6 +53,13 @@ func receiveConfigurationRequest(event: Event)
 func readyForEvent(_ event: Event) -> Bool
 ```
 
+If your method has a trailing closure parameter, name it `completion:`.
+
+*Example:*
+```swift
+func processHit(entity: DataEntity, completion: @escaping (Bool) -> Void) 
+```
+
 #### Constants
 
 Prefer using case-less `enums` to store constants as static variables.


### PR DESCRIPTION
[Update style guide with completion syntax#832](https://github.com/adobe/aepsdk-core-ios/issues/832)

Update style guide to reflect team's decision to name all trailing closure parameters `completion:`