### PR TITLE
Format Lifecycle v2 XDM language field to BCP 47

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -422,6 +422,7 @@
 		BBA512BB24F6C6CA0030DAD1 /* rules_testModifyData_invalidJson.json in Resources */ = {isa = PBXBuildFile; fileRef = BBA512BA24F6C6CA0030DAD1 /* rules_testModifyData_invalidJson.json */; };
 		BBE1294F24DBBBD60045CD8D /* Dictionary+FlattenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE1294E24DBBBD60045CD8D /* Dictionary+FlattenTests.swift */; };
 		BBE1295124DBCE870045CD8D /* TokenFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE1295024DBCE870045CD8D /* TokenFinderTests.swift */; };
+		BF38CD88294C4044006FF893 /* XDMLanguageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF38CD87294C4044006FF893 /* XDMLanguageTests.swift */; };
 		BF4A6EB826BB3B9D00612434 /* rules_testDispatchEventCopy.json in Resources */ = {isa = PBXBuildFile; fileRef = BF4A6EB726BB3B9D00612434 /* rules_testDispatchEventCopy.json */; };
 		BF4A6EE726BB47FE00612434 /* rules_testDispatchEventNewData.json in Resources */ = {isa = PBXBuildFile; fileRef = BF4A6EE626BB47FE00612434 /* rules_testDispatchEventNewData.json */; };
 		BF4A6F0526BB48A200612434 /* rules_testDispatchEventNewNoData.json in Resources */ = {isa = PBXBuildFile; fileRef = BF4A6F0426BB48A200612434 /* rules_testDispatchEventNewNoData.json */; };
@@ -1099,6 +1100,7 @@
 		BBA512BA24F6C6CA0030DAD1 /* rules_testModifyData_invalidJson.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_testModifyData_invalidJson.json; sourceTree = "<group>"; };
 		BBE1294E24DBBBD60045CD8D /* Dictionary+FlattenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+FlattenTests.swift"; sourceTree = "<group>"; };
 		BBE1295024DBCE870045CD8D /* TokenFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenFinderTests.swift; sourceTree = "<group>"; };
+		BF38CD87294C4044006FF893 /* XDMLanguageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XDMLanguageTests.swift; sourceTree = "<group>"; };
 		BF4A6EB726BB3B9D00612434 /* rules_testDispatchEventCopy.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_testDispatchEventCopy.json; sourceTree = "<group>"; };
 		BF4A6EE626BB47FE00612434 /* rules_testDispatchEventNewData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_testDispatchEventNewData.json; sourceTree = "<group>"; };
 		BF4A6F0426BB48A200612434 /* rules_testDispatchEventNewNoData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_testDispatchEventNewNoData.json; sourceTree = "<group>"; };
@@ -1436,6 +1438,7 @@
 				21BA2E0C265D8DB70011207C /* XDMDeviceTypeTests.swift */,
 				21BA2E6A265D946F0011207C /* XDMEnvironmentTests.swift */,
 				21BA2E1C265D8E480011207C /* XDMEnvironmentTypeTests.swift */,
+				BF38CD87294C4044006FF893 /* XDMLanguageTests.swift */,
 				21BA2E88265D96150011207C /* XDMMobileLifecycleDetailsTests.swift */,
 			);
 			name = Tests;
@@ -3431,6 +3434,7 @@
 				D42C98A026CCB024002E3184 /* XDMEnvironmentTests.swift in Sources */,
 				3FE6DE0224C630DF0065EA05 /* LifecycleMetricsTests.swift in Sources */,
 				2E36F6CA26C1D8D200B194D9 /* LifecycleV2DataStoreCacheTests.swift in Sources */,
+				BF38CD88294C4044006FF893 /* XDMLanguageTests.swift in Sources */,
 				2E00098F26D59EA100DE1F3B /* LifecycleV2FunctionalTests.swift in Sources */,
 				21BA2E2D265D8EC60011207C /* XDMApplicationTests.swift in Sources */,
 				21BA2E4D265D91830011207C /* XDMDeviceTests.swift in Sources */,

--- a/AEPLifecycle/Sources/LifecycleV2/LifecycleV2MetricsBuilder.swift
+++ b/AEPLifecycle/Sources/LifecycleV2/LifecycleV2MetricsBuilder.swift
@@ -120,7 +120,7 @@ class LifecycleV2MetricsBuilder {
         xdmEnvironmentInfo?.type = XDMEnvironmentType.from(runMode: systemInfoService.getRunMode())
         xdmEnvironmentInfo?.operatingSystem = systemInfoService.getOperatingSystemName()
         xdmEnvironmentInfo?.operatingSystemVersion = systemInfoService.getOperatingSystemVersion()
-        xdmEnvironmentInfo?.language = XDMLanguage(language: systemInfoService.getFormattedLocale())
+        xdmEnvironmentInfo?.language = XDMLanguage(language: systemInfoService.getFormattedLocaleBCPString())
 
         return xdmEnvironmentInfo
     }
@@ -163,4 +163,29 @@ class LifecycleV2MetricsBuilder {
         return sessionLength > 0 ? sessionLength : 0
     }
 
+}
+
+extension SystemInfoService {
+
+    /// Return a BCP-47 style formatted string for the given 'locale' identifier. The default locale is 'Locale.autoupdatingCurrent'.
+    /// - Return:  'String' representation of the given 'locale' using BCP-47 style formatting
+    func getFormattedLocaleBCPString() -> String? {
+        let locale = Locale(identifier: getActiveLocaleName())
+
+        if #available(iOS 16, *) {
+            return locale.identifier(.bcp47)
+        } else {
+            let language = locale.languageCode
+            let region = locale.regionCode
+
+            if let language = language {
+                if let region = region {
+                    return language + "-" + region
+                }
+                return language
+            }
+
+            return nil
+        }
+    }
 }

--- a/AEPLifecycle/Sources/LifecycleV2/XDMLanguage.swift
+++ b/AEPLifecycle/Sources/LifecycleV2/XDMLanguage.swift
@@ -15,5 +15,27 @@ import Foundation
 
 /// Represents the language of the environment to represent the user's linguistic, geographical, or cultural preferences for data presentation.
 struct XDMLanguage: Encodable {
+    static let languageRegex =         "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"
+
     let language: String?
+
+    init(language: String?) {
+        if let language = language {
+            if XDMLanguage.isValidLanguageTag(tag: language) {
+                self.language = language
+            } else {
+                self.language = nil
+                Log.warning(label: LifecycleConstants.LOG_TAG, "Language tag \(language) failed validation and will be dropped. Values for XDM field 'environment._dc.language' must conform to BCP 47.")
+            }
+        } else {
+            self.language = nil
+        }
+    }
+
+    /// Validate the language tag is formatted per the XDM Environment Schema pattern.
+    /// - Parameter tag: the language tag to validate
+    /// - Returns: true if the language tag matches the pattern
+    static func isValidLanguageTag(tag: String) -> Bool {
+        return tag.range(of: languageRegex, options: .regularExpression) != nil
+    }
 }

--- a/AEPLifecycle/Tests/LifecycleV2MetricsBuilderTests.swift
+++ b/AEPLifecycle/Tests/LifecycleV2MetricsBuilderTests.swift
@@ -38,10 +38,13 @@ class LifecycleV2MetricsBuilderTests: XCTestCase {
     
     override func setUp() {
         buildAndSetMockInfoService()
+        continueAfterFailure = true
     }
     
+    private let mockSystemInfoService = MockSystemInfoService()
+
     private func buildAndSetMockInfoService() {
-        let mockSystemInfoService = MockSystemInfoService()
+        //let mockSystemInfoService = MockSystemInfoService()
         mockSystemInfoService.appId = "test-app-id"
         mockSystemInfoService.applicationName = "test-app-name"
         mockSystemInfoService.applicationBuildNumber = "build-number"
@@ -182,6 +185,52 @@ class LifecycleV2MetricsBuilderTests: XCTestCase {
         
         XCTAssertTrue(NSDictionary(dictionary: actualAppCloseData ?? [:]).isEqual(to: expected))
     }
+    
+    // List of tests for verifying getFormattedLocaleBCPString function
+    // [$0: Locale identifier string to test, $1: expected result on iOS 16+, $2: expected result on iOS less than 16]
+    let localeBCPStringTests = [
+        ("es-US", "es-US", "es-US"), // language + region
+        ("en_US", "en-US", "en-US"), // language + region (underscore)
+        ("de", "de", "de"), // language only
+        ("-US", "und-US", nil), // region only
+        ("--POSIX", "und-u-va-posix", nil), // variant only
+        ("und", "und", "und"), // undefined
+        ("de-POSIX", "de-u-va-posix", "de"), // language + variant
+        ("de--POSIX", "de-u-va-posix", "de"), // language + variant (double hyphen)
+        ("de-DE-POSIX", "de-DE-u-va-posix", "de-DE"), // language + region + variant
+        ("de-Latn-DE-POSIX", "de-DE-u-va-posix", "de-DE"), // language + script + region + variant
+        ("zh-Hant-HK", "zh-Hant-HK", "zh-HK"), // Chinese Hong Kong
+        ("zh-Hans-CN", "zh-Hans-CN", "zh-CN"), // Chinese China
+        ("zh-Hans", "zh-Hans", "zh"), // language + script
+        ("-Hans-CN", "und-Hans-CN", nil), // script + region
+        ("no-NO-NY", "no-NO-x-lvariant-ny", "no-NO"), // Norwegian Nynorsk (special case)
+        ("sr-Latn-ME", "sr-Latn-ME", "sr-ME"), // Serbian Montenegro
+        ("it-Latn", "it", "it"), // langauge + variant
+        ("ja-JP-JP", "ja-JP-x-lvariant-jp", "ja-JP"), // Japanese (special case)
+        ("ja-JP-u-ca-japanese", "ja-JP-u-ca-japanese", "ja-JP"), // Japanese calendar BCP
+        ("ja-JP@calendar=japanese", "ja-JP-u-ca-japanese", "ja-JP"), // Japanese calender ICU
+        ("TH-TH-TH", "th-TH-x-lvariant-th", "th-TH"), // Thai (special case)
+        ("th-TH-u-ca-buddhist", "th-TH-u-ca-buddhist", "th-TH"), // Thai buddhist calendar BCP
+        ("th-TH@calendar=buddhist", "th-TH-u-ca-buddhist", "th-TH"), // Thai buddhist calendar ICU
+        ("en-US@calendar=buddhist", "en-US-u-ca-buddhist", "en-US"), // English US buddhist calendar ICU
+        ("en@calendar=buddhist;numbers=thai", "en-u-ca-buddhist-nu-thai", "en"), // English buddhist calendar with Thai numbers
+        ("i-klingon", "tlh", "tlh") // Grandfathered case Klingon
+    ]
+    
+    func testGetFormattedLocaleBCPString() {
+        XCTAssertFalse(localeBCPStringTests.isEmpty)
+        
+        localeBCPStringTests.forEach {
+            mockSystemInfoService.activeLocaleName = $0
+            let result = mockSystemInfoService.getFormattedLocaleBCPString()
+            if #available(iOS 16, *) {
+                XCTAssertEqual($1, result, "Locale '\($0)' failed on iOS 16 or greater!")
+            } else {
+                XCTAssertEqual($2, result, "Locale '\($0)' failed on iOS less than 16!")
+            }
+        }
+    }
+    
 }
 
 private extension Date {

--- a/AEPLifecycle/Tests/XDMLanguageTests.swift
+++ b/AEPLifecycle/Tests/XDMLanguageTests.swift
@@ -1,0 +1,120 @@
+/*
+ Copyright 2022 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+@testable import AEPLifecycle
+import XCTest
+
+class XDMLanguageTests: XCTestCase {
+
+    override func setUp() {
+        continueAfterFailure = true
+    }
+    
+    // MARK: Encodable tests
+
+    func testEncodeLanguage_whenValid() throws {
+        // setup
+        let lang = XDMLanguage(language: "en-US")
+        XCTAssertEqual("en-US", lang.language)
+
+        // test
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        let data = try XCTUnwrap(encoder.encode(lang))
+        let dataStr = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        // verify
+        let expected = """
+        {
+          "language" : "en-US"
+        }
+        """
+
+        XCTAssertEqual(expected, dataStr)
+    }
+    
+    func testEncodeLanguage_whenInvalid() throws {
+        // setup
+        let lang = XDMLanguage(language: "en-US@calendar=buddhist")
+        XCTAssertNil(lang.language)
+
+        // test
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        let data = try XCTUnwrap(encoder.encode(lang))
+        let dataStr = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        // verify
+        let expected = """
+        {
+        
+        }
+        """
+
+        XCTAssertEqual(expected, dataStr)
+    }
+    
+    // MARK: isValidLanguageTag tests
+    
+    // List of test langauge strings to verify isValidLanguageTag function
+    // [$0: language string to test, $1: expected is valid]
+    let isValidLanguageTagCases = [
+    ("en-US", true),
+    ("en", true),
+    ("und-US", true),
+    ("und-u-va-posix", true),
+    ("und-POSIX", true),
+    ("und", true),
+    ("de-u-va-posix", true),
+    ("de-DE-u-va-posix", true),
+    ("de-DE-POSIX", true),
+    ("de-POSIX", true),
+    ("de-Latn-POSIX", true),
+    ("zh-Hant-HK", true),
+    ("und-Hans-CN", true),
+    ("no-NO-x-lvariant-ny", true),
+    ("sr-Latn-ME", true),
+    ("sr-ME-x-lvariant-Latn", true),
+    ("ja-JP-x-lvariant-jp", true),
+    ("ja-JP-u-ca-japanese", true),
+    ("th-TH-x-lvariant-th", true),
+    ("th-TH-u-ca-buddhist", true),
+    ("en-u-ca-buddhist-nu-thai", true),
+    ("th-TH-u-ca-buddhist-nu-thai", true),
+    ("i-klingon", true),
+    ("en@calendar=buddhist;numbers=thai", false),
+    ("en-US@calendar=buddhist", false),
+    ("-US", false),
+    ("en_US", false),
+    ("de--POSIX", false),
+    ("zh-HK#Hant", false),
+    ("th-TH-TH-#u-nu-thai", false),
+    ("", false)
+    ]
+    
+    func testIsValidLanguageTag() throws {
+        XCTAssertFalse(isValidLanguageTagCases.isEmpty)
+        
+        isValidLanguageTagCases.forEach {
+            let lang = XDMLanguage(language: $0)
+            if $1 {
+                XCTAssertEqual($0, lang.language, "Expected input language '\($0)' to be valid.")
+            } else {
+                XCTAssertNil(lang.language, "Expected input language '\($0)' to be invalid.")
+            }
+        }
+        
+
+    }
+
+}
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Format the Lifecycle v2 field "environment._dc.language" to a BCP 47 style string. The current default format returned by `Locale.identifier` may not pass validation on the Edge Network for some Locale tags causing the Lifecycle hit to be dropped.

Changes LifecycleV2MetricsBuilder to format the language field using `Locale.identifier(.bcp47)` when using iOS 16+, or simply "`Locale.languageCode`-`Locale.regionCode`" when using less than iOS 16.
Adds a validation step to XDMLanguage to validate the `language` against the regex pattern used in the XDM Environment schema. Values which do not validate are dropped. As LifecycleV2MetricsBuilder is updated to set a BCP 47 style language string, the validation in XDMLanguage is a failsafe against unexpected invalid values.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Unit tests are added to cover the changes plus to validate against various language tags.
Some of the tests for `getFormattedLocaleBCPString` will expect different results when running on iOS 16 vs lower iOS versions. These tests were run on simulators using iOS 16 and iOS 13 to verify their correctness. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
