### PR TITLE
Don't send invalid timestamp values to lifecycle metrics

### DIFF
--- a/AEPLifecycle/Sources/LifecycleMetricsBuilder.swift
+++ b/AEPLifecycle/Sources/LifecycleMetricsBuilder.swift
@@ -69,7 +69,10 @@ class LifecycleMetricsBuilder {
                 return self
             }
 
-            lifecycleMetrics.daysSinceFirstLaunch = daysSinceFirstLaunch
+            if daysSinceFirstLaunch >= 0 {
+                lifecycleMetrics.daysSinceFirstLaunch = daysSinceFirstLaunch
+            }
+
             lifecycleMetrics.previousOsVersion = prevOsVersion
             lifecycleMetrics.previousAppId = prevAppId
         }
@@ -79,7 +82,10 @@ class LifecycleMetricsBuilder {
                 return self
             }
 
-            lifecycleMetrics.daysSinceLastLaunch = daysSinceLastLaunch
+            if daysSinceLastLaunch >= 0 {
+                lifecycleMetrics.daysSinceLastLaunch = daysSinceLastLaunch
+            }
+
             let currentDateComponents = Calendar.current.dateComponents([.day, .month, .year], from: date)
             let lastLaunchDateComponents = Calendar.current.dateComponents([.day, .month, .year], from: lastLaunchDate)
             // Check if we have launched this month already
@@ -125,14 +131,12 @@ class LifecycleMetricsBuilder {
     func addUpgradeData(upgrade: Bool) -> LifecycleMetricsBuilder {
         if upgrade {
             lifecycleMetrics.upgradeEvent = true
-        }
-
-        if upgrade {
             dataStore.setObject(key: KEYS.UPGRADE_DATE, value: date)
             dataStore.set(key: KEYS.LAUNCHES_SINCE_UPGRADE, value: 0)
         } else if let upgradeDate: Date = dataStore.getObject(key: KEYS.UPGRADE_DATE) {
-            let daysSinceLastUpgrade = Calendar.current.dateComponents([.day], from: upgradeDate, to: date).day
-            lifecycleMetrics.daysSinceLastUpgrade = daysSinceLastUpgrade
+            if let daysSinceLastUpgrade = Calendar.current.dateComponents([.day], from: upgradeDate, to: date).day, daysSinceLastUpgrade >= 0 {
+                lifecycleMetrics.daysSinceLastUpgrade = daysSinceLastUpgrade
+            }
             if var launchesSinceUpgrade = dataStore.getInt(key: KEYS.LAUNCHES_SINCE_UPGRADE, fallback: 0) {
                 launchesSinceUpgrade += 1
                 dataStore.set(key: KEYS.LAUNCHES_SINCE_UPGRADE, value: launchesSinceUpgrade)

--- a/AEPLifecycle/Tests/LifecycleMetricsBuilderTests.swift
+++ b/AEPLifecycle/Tests/LifecycleMetricsBuilderTests.swift
@@ -87,7 +87,7 @@ class LifecycleMetricsBuilderTests: XCTestCase {
         XCTAssertEqual(metrics?.previousOsVersion, osVersion)
         XCTAssertEqual(metrics?.previousAppId, appID)
     }
-    
+
     // Tests that adding an invalid timestamp will not lead to negative values for the dayssincelastuse
     func testAddLaunchDataInvalidTimestamp() {
         // Adding a day to current date will make us go into the future and create a negative value for last launch and first launch
@@ -158,7 +158,7 @@ class LifecycleMetricsBuilderTests: XCTestCase {
         XCTAssertEqual(dataStore?.setIntValues[0], launchesSinceLastUpgrade)
         XCTAssertEqual(metrics?.launchesSinceUpgrade, launchesSinceLastUpgrade)
     }
-    
+
     func testUpgradeWithInvalidTimestamp() {
         let futureDaysSinceUpgradeDate = Calendar.current.date(byAdding: .day, value: 1, to: date)
         dataStore?.getObjectValues.append(futureDaysSinceUpgradeDate!)


### PR DESCRIPTION
Please reference: https://jira.corp.adobe.com/browse/AMSDK-11141 and https://git.corp.adobe.com/dms-mobile/bourbon-core-java-lifecycle/pull/32/files

#560 Don't send invalid timestamp values (negative values) to dayssincelastuse and dayssincelastupgrade