### PR TITLE
Make it possible to override the loggingService

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		2E36F6CA26C1D8D200B194D9 /* LifecycleV2DataStoreCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E36F6C926C1D8D200B194D9 /* LifecycleV2DataStoreCacheTests.swift */; };
 		2EF8B38226BCC69C009D6475 /* LifecycleV2DataStoreCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF8B38126BCC69C009D6475 /* LifecycleV2DataStoreCache.swift */; };
 		3080C53E015AAAF2AC268368 /* Pods_AEPIdentityTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE1AFF2E227272FC92CF7ABE /* Pods_AEPIdentityTests.framework */; };
+		31DF174F297030D300B4B07F /* MockLoggingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DF174E297030D300B4B07F /* MockLoggingService.swift */; };
 		380ECFBFE9B4654A66A8F119 /* Pods_AEPIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D855F28C43DD8DA6A4B6ACFE /* Pods_AEPIntegrationTests.framework */; };
 		3F03979024BE5DD30019F095 /* AEPServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F03978724BE5DD30019F095 /* AEPServices.framework */; };
 		3F0397C324BE5FF30019F095 /* Caching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F0397A024BE5FF30019F095 /* Caching.swift */; };
@@ -789,6 +790,7 @@
 		2E36F6C926C1D8D200B194D9 /* LifecycleV2DataStoreCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleV2DataStoreCacheTests.swift; sourceTree = "<group>"; };
 		2EE8956F25F8D2BD27B6D4D8 /* Pods-AEPCore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPCore.debug.xcconfig"; path = "Target Support Files/Pods-AEPCore/Pods-AEPCore.debug.xcconfig"; sourceTree = "<group>"; };
 		2EF8B38126BCC69C009D6475 /* LifecycleV2DataStoreCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleV2DataStoreCache.swift; sourceTree = "<group>"; };
+		31DF174E297030D300B4B07F /* MockLoggingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLoggingService.swift; sourceTree = "<group>"; };
 		39282143E012E30EEE6674F2 /* Pods_AEPCoreTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AEPCoreTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3DCBEB2BB8208D5CED73869A /* Pods-AEPCoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPCoreTests.debug.xcconfig"; path = "Target Support Files/Pods-AEPCoreTests/Pods-AEPCoreTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3F03978724BE5DD30019F095 /* AEPServices.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AEPServices.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1510,6 +1512,7 @@
 				24CE74AA26D401EC008F9EFD /* MockFullscreenListener.swift */,
 				215C859C24C6492800CCCD26 /* MockHitProcessor.swift */,
 				215C859B24C6492800CCCD26 /* MockHitQueue.swift */,
+				31DF174E297030D300B4B07F /* MockLoggingService.swift */,
 				24CE74AC26D40239008F9EFD /* MockMessagingDelegate.swift */,
 				3FE6DDE924C62F610065EA05 /* MockNetworkServiceOverrider.swift */,
 				3FE6DDEE24C62F610065EA05 /* MockSystemInfoService.swift */,
@@ -3389,6 +3392,7 @@
 				92027B9925C9EAF2007BE140 /* MockUIService.swift in Sources */,
 				3FE6DDF324C62F610065EA05 /* MockDataStore.swift in Sources */,
 				3FE6DDF624C62F620065EA05 /* MockSystemInfoService.swift in Sources */,
+				31DF174F297030D300B4B07F /* MockLoggingService.swift in Sources */,
 				24543A1424E1DAFC002D8D9A /* MockURLService.swift in Sources */,
 				3FE6DDF124C62F610065EA05 /* MockNetworkServiceOverrider.swift in Sources */,
 			);

--- a/AEPServices/Mocks/MockLoggingService.swift
+++ b/AEPServices/Mocks/MockLoggingService.swift
@@ -1,0 +1,20 @@
+//
+// Copyright 2023 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+@testable import AEPServices
+import Foundation
+
+public class MockLoggingService: Logging {
+    public init() {}
+
+    public func log(level: AEPServices.LogLevel, label: String, message: String) {}
+}

--- a/AEPServices/Sources/ServiceProvider.swift
+++ b/AEPServices/Sources/ServiceProvider.swift
@@ -34,6 +34,7 @@ public class ServiceProvider {
     private var defaultDataQueueService = DataQueueService()
     private var overrideCacheService: Caching?
     private var defaultCacheService = DiskCacheService()
+    private var overrideLoggingService: Logging?
     private var defaultLoggingService = LoggingService()
 
     // Don't allow init of ServiceProvider outside the class
@@ -99,8 +100,15 @@ public class ServiceProvider {
     }
 
     public var loggingService: Logging {
-        return queue.sync {
-            return defaultLoggingService
+        get {
+            return queue.sync {
+                return overrideLoggingService ?? defaultLoggingService
+            }
+        }
+        set {
+            queue.async {
+                self.overrideLoggingService = newValue
+            }
         }
     }
 
@@ -117,6 +125,7 @@ public class ServiceProvider {
             self.overrideKeyValueService = nil
             self.overrideNetworkService = nil
             self.overrideCacheService = nil
+            self.overrideLoggingService = nil
         }
     }
 }

--- a/AEPServices/Tests/services/ServiceProviderTests.swift
+++ b/AEPServices/Tests/services/ServiceProviderTests.swift
@@ -69,6 +69,19 @@ class ServiceProviderTests: XCTestCase {
         XCTAssertTrue(ServiceProvider.shared.cacheService is DiskCacheService)
     }
     
+    func testOverridingLoggingService() {
+        let mockLoggingService = MockLoggingService()
+        ServiceProvider.shared.loggingService = mockLoggingService
+        XCTAssertEqual(Unmanaged.passUnretained(mockLoggingService).toOpaque(), Unmanaged.passUnretained(ServiceProvider.shared.loggingService as! MockLoggingService).toOpaque())
+    }
+    
+    func testResettingLoggingService() {
+        let mockLoggingService = MockLoggingService()
+        ServiceProvider.shared.loggingService = mockLoggingService
+        ServiceProvider.shared.reset()
+        XCTAssertTrue(ServiceProvider.shared.loggingService is LoggingService)
+    }
+    
     #if os(iOS)
         func testOverridingAppOnlyServices() {
             let mockUIService = MockUIService()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

According to the [documentation](https://github.com/adobe/aepsdk-core-ios/tree/main/Documentation/Services#overriding-a-service) this should be possible, but the implementation was a get-only property.
<!--- Describe your changes in detail -->

## Related Issue

https://github.com/adobe/aepsdk-core-ios/issues/874
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

First of all it is mentioned as an example in the documentation of the ServiceProvider but the main reason is that we have a use case for writing the logs somewhere else for automated testing purposes.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

I wrote a unit test.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

I am not entirely sure how to categorise this. If we take the documentation as the source of truth it would be a bug, else it is a non-breaking new feature. 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
