### PR TITLE
fix failing script by continuing on clean failure

### DIFF
--- a/Script/test-SPM.sh
+++ b/Script/test-SPM.sh
@@ -50,8 +50,8 @@ swift package resolve
 
 # This is nececery to avoid internal PIF error
 swift package dump-pif > /dev/null
-xcodebuild clean -scheme TestProject -destination 'generic/platform=iOS' > /dev/null
-xcodebuild clean -scheme TestProject -destination 'generic/platform=tvOS' > /dev/null
+(xcodebuild clean -scheme TestProject -destination 'generic/platform=iOS' > /dev/null) || :
+(xcodebuild clean -scheme TestProject -destination 'generic/platform=tvOS' > /dev/null) || :
 
 # Archive for generic iOS device
 echo '############# Archive for generic iOS device ###############'


### PR DESCRIPTION
The SPM script clean action fails sometimes. This will allow the script to continue without failing. 