### PR TITLE
add process method to rules engine that allows callback function

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -1949,21 +1949,21 @@
 		3FB66AB324CA004400502CAF /* rules */ = {
 			isa = PBXGroup;
 			children = (
+				3F278C4C262E1FAB00E955E5 /* CachedRules.swift */,
 				BB00E26724D8C94600C578C1 /* Dictionary+Flatten.swift */,
 				3F08FF9424D9F1D200D34DE3 /* EventDataMerger.swift */,
 				3FB66AB824CA004400502CAF /* JSONRulesParser.swift */,
 				3FB66AB424CA004400502CAF /* LaunchRule.swift */,
-				3F2B1DA52631E7FE0030F50B /* RuleConsequence.swift */,
 				3F5D45F7251903020040E298 /* LaunchRuleTransformer.swift */,
 				3FB66AB624CA004400502CAF /* LaunchRulesEngine.swift */,
 				3F2B1DC4263221580030F50B /* LaunchRulesEngine+Downloader.swift */,
+				3F2B1DA52631E7FE0030F50B /* RuleConsequence.swift */,
 				3F16761324E1B0630041B970 /* RulesConstants.swift */,
 				3FB66AB524CA004400502CAF /* RulesDownloader.swift */,
 				BB0E397124FD56100050C181 /* RulesEngineNativeLogging.swift */,
 				3FB66AB724CA004400502CAF /* RulesLoader.swift */,
 				BB00E26624D8C94600C578C1 /* TokenFinder.swift */,
 				BB00E26C24D9BF6C00C578C1 /* URLUtility.swift */,
-				3F278C4C262E1FAB00E955E5 /* CachedRules.swift */,
 			);
 			path = rules;
 			sourceTree = "<group>";

--- a/AEPCore/Sources/rules/LaunchRulesEngine.swift
+++ b/AEPCore/Sources/rules/LaunchRulesEngine.swift
@@ -90,10 +90,8 @@ public class LaunchRulesEngine {
     }
 
     /// Evaluates all the current rules against the supplied `Event`.
-    /// - Parameters:
-    ///   - event: the `Event` against which to evaluate the rules
-    ///   - sharedStates: the `SharedState`s registered to the `EventHub`
-    /// - Returns: the  processed`Event`
+    /// - Parameter event: the `Event` against which to evaluate the rules
+    /// - Returns: the processed `Event`
     @discardableResult
     public func process(event: Event) -> Event {
         rulesQueue.sync {
@@ -114,6 +112,56 @@ public class LaunchRulesEngine {
             }
             return evaluateRules(for: event)
         }
+    }
+
+    /// Evaluates the current rules against the supplied `Event`.
+    /// Instead of dispatching consequence `Event`s for matching rules, this method calls
+    /// `completion` with an array of `RuleConsequence` objects.
+    ///
+    /// - Parameters:
+    ///   - event: the `Event` against which to evaluate the rules
+    ///   - completion: callback method that will contain an array of `RuleConsequence` objects resulting from `event` being processed.
+    public func process(event: Event, completion: (([RuleConsequence]?) -> Void )) {
+        rulesQueue.sync {
+            // if our waitingEvents array is nil, we know we have rules registered and can skip to evaluation
+            guard let currentWaitingEvents = waitingEvents else {
+                return evaluateRulesBatch(for: event, completion: completion)
+            }
+
+            // check if this is an event to kick processing of waitingEvents
+            // otherwise, add the event to waitingEvents
+            if (event.data?[RulesConstants.Keys.RULES_ENGINE_NAME] as? String) == name, event.source == EventSource.requestReset, event.type == EventType.rulesEngine {
+                for currentEvent in currentWaitingEvents {
+                    _ = evaluateRules(for: currentEvent)
+                }
+                waitingEvents = nil
+            } else {
+                waitingEvents?.append(event)
+            }
+
+            evaluateRulesBatch(for: event, completion: completion)
+        }
+    }
+
+    /// Evaluates rules for an `Event` but calls the provided `completion` method with matching `RuleConsequence` instead of dispatching consequence `Event`s
+    ///
+    /// - Parameters:
+    ///   - event: the `Event` against which to evaluate the rules
+    ///   - completion: callback method that will contain an array of `RuleConsequence` objects resulting from `event` being processed.
+    private func evaluateRulesBatch(for event: Event, completion: (([RuleConsequence]?) -> Void)) {
+        let traversableTokenFinder = TokenFinder(event: event, extensionRuntime: extensionRuntime)
+        let matchedRules = rulesEngine.evaluate(data: traversableTokenFinder)
+        guard !matchedRules.isEmpty else {
+            completion(nil)
+            return
+        }
+
+        var tokenReplacedConsequences: [RuleConsequence] = []
+        for rule in matchedRules {
+            tokenReplacedConsequences.append(contentsOf: rule.consequences.map({ replaceToken(for: $0, data: traversableTokenFinder)}))
+        }
+
+        completion(tokenReplacedConsequences)
     }
 
     private func evaluateRules(for event: Event) -> Event {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AEPRulesEngine (1.2.0)
+  - AEPRulesEngine (1.2.2)
   - SwiftLint (0.44.0)
 
 DEPENDENCIES:
@@ -12,9 +12,9 @@ SPEC REPOS:
     - SwiftLint
 
 SPEC CHECKSUMS:
-  AEPRulesEngine: 71228dfdac24c9ded09be13e3257a7eb22468ccc
+  AEPRulesEngine: 354b4374edefaf5bdfa3336ab9a41a07cbae4afe
   SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
 
-PODFILE CHECKSUM: d5ebdd60e861450030157bc4c5d28329246e2f6f
+PODFILE CHECKSUM: 47a7e71f34adf3352f349bc16c56ee02dd1ed2b3
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3


### PR DESCRIPTION
## Description

Messaging extension would like to create a rules engine which can process events and determine for itself what to do with any resulting consequences.  This task is to add functionality for 

1. A "process" method that takes a completion function, returning an array of RuleConsequence objects
2. An internal method that evaluates rules in a batch rather than one at a time.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
