### PR TITLE
Modify cache to not read file modification date

### DIFF
--- a/AEPIntegrationTests/IdentityIntegrationTests.swift
+++ b/AEPIntegrationTests/IdentityIntegrationTests.swift
@@ -207,14 +207,16 @@ class IdentityIntegrationTests: XCTestCase {
     func testGetExperienceCloudIdWithinPermissibleTimeOnInstall() {
         initExtensionsAndWait()
 
-        let getECIDExpectation = XCTestExpectation(description: "getExperienceCloudId should return within 0.5 seconds when Configuration is available on Install")
+        let getECIDExpectation = XCTestExpectation(description: "getExperienceCloudId should return within 1 seconds when Configuration is available on Install")
         MobileCore.updateConfigurationWith(configDict: ["experienceCloud.org": "orgid", "experienceCloud.server": "test.com", "global.privacy": "optedin"])
         Identity.getExperienceCloudId { ecid, error in
             XCTAssertFalse(ecid!.isEmpty)
             XCTAssertNil(error)
             getECIDExpectation.fulfill()
         }
-        wait(for: [getECIDExpectation], timeout: 0.5)
+        // getExperienceCloudId returns within 0.5 sec when config is bundled with the app. 
+        // Increasing timeout to 1 sec to avoid race conditions
+        wait(for: [getECIDExpectation], timeout: 1)
     }
 
     func testGetExperienceCloudIdWithinPermissibleTimeOnLaunch() {
@@ -346,18 +348,9 @@ class IdentityIntegrationTests: XCTestCase {
         waitForBootupHit(initialConfig: ["experienceCloud.org": "orgid", "experienceCloud.server": "test.com", "global.privacy": "optedin"])
 
         let resetHitExpectation = XCTestExpectation(description: "new sync from reset identities")
-        resetHitExpectation.assertForOverFulfill = true
-
         let mockNetworkService = TestableNetworkService()
         ServiceProvider.shared.networkService = mockNetworkService
-
         mockNetworkService.mock { request in
-            // assert new ECID on last hit
-            props.loadFromPersistence()
-            XCTAssertNotEqual(firstEcid.ecidString, props.ecid?.ecidString)
-            XCTAssertTrue(request.url.absoluteString.contains(props.ecid!.ecidString))
-            XCTAssertFalse(request.url.absoluteString.contains(firstEcid.ecidString))
-
             resetHitExpectation.fulfill()
             return nil
         }
@@ -366,6 +359,20 @@ class IdentityIntegrationTests: XCTestCase {
         MobileCore.resetIdentities()
 
         wait(for: [resetHitExpectation], timeout: 2)
+        
+        // Wait for 500ms so that the new ECID gets persisted and to avoid race conditions
+        usleep(500)
+        
+        // assert new ECID on last hit
+        props.loadFromPersistence()
+        guard let newEcid = props.ecid else {
+            XCTFail("New ECID is not generated")
+            return
+        }
+        
+        XCTAssertNotEqual(firstEcid.ecidString, newEcid.ecidString)
+        XCTAssertTrue(mockNetworkService.requests[0].url.absoluteString.contains(newEcid.ecidString))
+        XCTAssertFalse(mockNetworkService.requests[0].url.absoluteString.contains(firstEcid.ecidString))
     }
 
     private func waitForBootupHit(initialConfig: [String: String]) {

--- a/AEPServices/Sources/ServiceProvider.swift
+++ b/AEPServices/Sources/ServiceProvider.swift
@@ -116,7 +116,6 @@ public class ServiceProvider {
         queue.async {
             self.defaultSystemInfoService = ApplicationSystemInfoService()
             self.defaultKeyValueService = FileSystemNamedCollection()
-//            self.defaultKeyValueService = UserDefaultsNamedCollection()
             self.defaultNetworkService = NetworkService()
             self.defaultCacheService = DiskCacheService()
             self.defaultDataQueueService = DataQueueService()

--- a/AEPServices/Sources/storage/FileSystemNamedCollection.swift
+++ b/AEPServices/Sources/storage/FileSystemNamedCollection.swift
@@ -49,7 +49,7 @@ class FileSystemNamedCollection: NamedCollectionProcessing {
                 do {
                     try updatedStorageData.write(to: fileUrl, options: .atomic)
                 } catch {
-                    Log.warning(label: self.LOG_TAG, "Error \(error) when writing \(key) to collection \(collectionName)")
+                    Log.warning(label: self.LOG_TAG, "Error '\(error)' when writing '\(key)' to collection '\(collectionName)'")
                 }
             }
         }
@@ -75,7 +75,7 @@ class FileSystemNamedCollection: NamedCollectionProcessing {
                     do {
                         try updatedStorageData.write(to: fileUrl, options: .atomic)
                     } catch {
-                        Log.warning(label: self.LOG_TAG, "Error \(error) when attempting to remove key \(key) from collection \(collectionName)")
+                        Log.warning(label: self.LOG_TAG, "Error '\(error)' when attempting to remove key '\(key)' from collection '\(collectionName)'")
                     }
                 }
             }
@@ -97,7 +97,7 @@ class FileSystemNamedCollection: NamedCollectionProcessing {
         }
 
         guard let jsonResult = try? JSONSerialization.jsonObject(with: storageData) as? [String: Any] else {
-            Log.warning(label: LOG_TAG, "Failed to read dictionary from collection \(collectionName)")
+            Log.warning(label: LOG_TAG, "Failed to read dictionary from collection '\(collectionName)'")
             return nil
         }
         

--- a/AEPServices/Sources/storage/FileSystemNamedCollection.swift
+++ b/AEPServices/Sources/storage/FileSystemNamedCollection.swift
@@ -49,7 +49,7 @@ class FileSystemNamedCollection: NamedCollectionProcessing {
                 do {
                     try updatedStorageData.write(to: fileUrl, options: .atomic)
                 } catch {
-                    Log.warning(label: self.LOG_TAG, "Error when writing to file: \(error)")
+                    Log.warning(label: self.LOG_TAG, "Error \(error) when writing \(key) to collection \(collectionName)")
                 }
             }
         }
@@ -75,7 +75,7 @@ class FileSystemNamedCollection: NamedCollectionProcessing {
                     do {
                         try updatedStorageData.write(to: fileUrl, options: .atomic)
                     } catch {
-                        Log.warning(label: self.LOG_TAG, "Error when attempting to remove value from file: \(error)")
+                        Log.warning(label: self.LOG_TAG, "Error \(error) when attempting to remove key \(key) from collection \(collectionName)")
                     }
                 }
             }
@@ -92,13 +92,16 @@ class FileSystemNamedCollection: NamedCollectionProcessing {
             return nil
         }
 
-        if let storageData = try? Data(contentsOf: fileUrl) {
-            if let jsonResult = try? JSONSerialization.jsonObject(with: storageData) as? [String: Any] {
-                return jsonResult
-            }
+        guard let storageData = try? Data(contentsOf: fileUrl) else {
+            return nil
         }
-        Log.warning(label: LOG_TAG, "Failed to get Dictionary from data store")
-        return nil
+
+        guard let jsonResult = try? JSONSerialization.jsonObject(with: storageData) as? [String: Any] else {
+            Log.warning(label: LOG_TAG, "Failed to read dictionary from collection \(collectionName)")
+            return nil
+        }
+        
+        return jsonResult
     }
 
     ///

--- a/AEPServices/Sources/utility/unzip/FileManager+ZIP.swift
+++ b/AEPServices/Sources/utility/unzip/FileManager+ZIP.swift
@@ -61,11 +61,12 @@ extension FileManager {
     class func attributes(from entry: ZipEntry) -> [FileAttributeKey: Any] {
         let centralDirectoryStructure = entry.centralDirectoryStructure
         let entryType = entry.type
-        let entryTime = centralDirectoryStructure.lastModFileTime
-        let entryDate = centralDirectoryStructure.lastModFileDate
         let defaultPermissions = FileUnzipperConstants.defaultFilePermissions
         var attributes = [.posixPermissions: defaultPermissions] as [FileAttributeKey: Any]
-        attributes[.modificationDate] = Date(dateTime: (entryDate, entryTime))
+        // `modificationDate` attribute is now marked as a restricted API. We will not set it as we don't have any use case based on this attribute.
+        // let entryTime = centralDirectoryStructure.lastModFileTime
+        // let entryDate = centralDirectoryStructure.lastModFileDate
+        // attributes[.modificationDate] = Date(dateTime: (entryDate, entryTime))
         let versionMadeBy = centralDirectoryStructure.versionMadeBy
         guard let osType = ZipEntry.OSType(rawValue: UInt(versionMadeBy >> 8)) else { return attributes }
 

--- a/AEPServices/Tests/services/DiskCacheServiceTests.swift
+++ b/AEPServices/Tests/services/DiskCacheServiceTests.swift
@@ -22,12 +22,15 @@ private struct Person: Codable, Equatable {
 
 class DiskCacheServiceTests: XCTestCase {
     var diskCache = DiskCacheService()
+    let DATA_STORE_NAME = "DiskCacheService"
     let CACHE_NAME = "DiskCacheServiceTests"
     let ENTRY_KEY = "testEntryKey"
+    var mockDataStore: MockDataStore!
     var dateOneMinInFuture: Date!
 
     override func setUp() {
-        ServiceProvider.shared.namedKeyValueService = MockDataStore()
+        mockDataStore = MockDataStore()
+        ServiceProvider.shared.namedKeyValueService = mockDataStore
         dateOneMinInFuture = Calendar.current.date(byAdding: .minute, value: 1, to: Date())
     }
 
@@ -39,7 +42,7 @@ class DiskCacheServiceTests: XCTestCase {
     }
 
     func originalEntry(_ original: CacheEntry, equals cached: CacheEntry) -> Bool {
-        guard original.data == cached.data, original.expiry == cached.expiry else {
+        guard original.data == cached.data, original.expiry.date.equal(other: cached.expiry.date) else {
             return false
         }
 
@@ -79,6 +82,34 @@ class DiskCacheServiceTests: XCTestCase {
         // verify
         let storedEntry = diskCache.get(cacheName: CACHE_NAME, key: ENTRY_KEY)
         XCTAssertTrue(originalEntry(entry, equals: storedEntry!))
+    }
+    
+    func testSetGetMissingAttributes() {
+        // setup
+        let data = "Test".data(using: .utf8)!
+        let entry = CacheEntry(data: data, expiry: .date(dateOneMinInFuture), metadata: nil)
+
+        // test
+        try! diskCache.set(cacheName: CACHE_NAME, key: ENTRY_KEY, entry: entry)
+        // remove attributes for this entry
+        mockDataStore.remove(collectionName: "DiskCacheService", key: diskCache.dataStoreKey(for: CACHE_NAME, with: ENTRY_KEY))
+
+        // verify
+        XCTAssertNil(diskCache.get(cacheName: CACHE_NAME, key: ENTRY_KEY))
+    }
+    
+    func testSetGetMissingExpiryDate() {
+        // setup
+        let data = "Test".data(using: .utf8)!
+        let entry = CacheEntry(data: data, expiry: .date(dateOneMinInFuture), metadata: nil)
+
+        // test
+        try! diskCache.set(cacheName: CACHE_NAME, key: ENTRY_KEY, entry: entry)
+        // overwrite attributes for this entry
+        mockDataStore.set(collectionName: DATA_STORE_NAME, key: diskCache.dataStoreKey(for: CACHE_NAME, with: ENTRY_KEY), value: ["key": "value"])
+
+        // verify
+        XCTAssertNil(diskCache.get(cacheName: CACHE_NAME, key: ENTRY_KEY))
     }
 
     func testSetGetNoMetadata() {
@@ -184,3 +215,16 @@ class DiskCacheServiceTests: XCTestCase {
         XCTAssertNil(diskCache.get(cacheName: CACHE_NAME, key: ENTRY_KEY))
     }
 }
+
+private extension Date {
+    func equal(other: Date?) -> Bool {
+        guard let other = other else {
+            return false;
+        }
+
+        // As date stores the timestamp in milliseconds, compare double value with accuracy greater than milliseconds.
+        let accuracy = 0.00001;
+        return abs(self.timeIntervalSince1970 - other.timeIntervalSince1970) < accuracy;
+    }
+}
+


### PR DESCRIPTION
- Modify CacheService to stop using fileModificationDate attribute to store cacheExpiry. 
- Clean up logs in FileSystemNamedCollection.

This change will cause a one time cache miss for currently cached content. 


Fixed `IdentityIntegrationTests .testGetExperienceCloudIdWithinPermissibleTimeOnInstall` - https://github.com/adobe/aepsdk-core-ios/issues/954