### PR TITLE
Add attribute for fileprotection

### DIFF
--- a/AEPServices/Sources/storage/FileSystemNamedCollection.swift
+++ b/AEPServices/Sources/storage/FileSystemNamedCollection.swift
@@ -126,6 +126,7 @@ class FileSystemNamedCollection: NamedCollectionProcessing {
             let adobeBaseUrl = baseUrl.appendingPathComponent(adobeDirectory, isDirectory: true)
             do {
                 try fileManager.createDirectory(at: adobeBaseUrl, withIntermediateDirectories: true)
+                try fileManager.setAttributes([FileAttributeKey.protectionKey: FileProtectionType.none], ofItemAtPath: adobeBaseUrl.path)
             } catch {
                 Log.error(label: adobeDirectory, "Failed to create storage directory with error: \(error)")
                 return nil

--- a/TestApps/AEPCoreTestApp.xcodeproj/project.pbxproj
+++ b/TestApps/AEPCoreTestApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -278,6 +278,11 @@
 		73E4CE7F314740BC6AF3A5CA /* Pods-TestAppExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestAppExtension.debug.xcconfig"; path = "Target Support Files/Pods-TestAppExtension/Pods-TestAppExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		73F917DDAA83CF54D6804B96 /* Pods_TestAppExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestAppExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		752261872AA7826700D59847 /* TestApp_Swift.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TestApp_Swift.entitlements; sourceTree = "<group>"; };
+		754508902ADDD3C400865E75 /* AEPCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AEPCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		754508942ADDD3F000865E75 /* AEPIdentity.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AEPIdentity.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		754508952ADDD3F000865E75 /* AEPLifecycle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AEPLifecycle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		754508962ADDD3F000865E75 /* AEPServices.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AEPServices.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7545089D2ADDD3F800865E75 /* AEPSignal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AEPSignal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7808888026D56E8700F5A665 /* TestApp_Swift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestApp_Swift.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		780888A626D56F3800F5A665 /* LifecycleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LifecycleView.swift; sourceTree = "<group>"; };
 		780888A726D56F3800F5A665 /* MenuView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuView.swift; sourceTree = "<group>"; };
@@ -561,6 +566,11 @@
 		786D629D26D69E94000828FC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				7545089D2ADDD3F800865E75 /* AEPSignal.framework */,
+				754508942ADDD3F000865E75 /* AEPIdentity.framework */,
+				754508952ADDD3F000865E75 /* AEPLifecycle.framework */,
+				754508962ADDD3F000865E75 /* AEPServices.framework */,
+				754508902ADDD3C400865E75 /* AEPCore.framework */,
 				78A26DE8284A9F86004A91B9 /* AEPCore.framework */,
 				78A26DE9284A9F86004A91B9 /* AEPIdentity.framework */,
 				78A26DEA284A9F86004A91B9 /* AEPLifecycle.framework */,
@@ -886,7 +896,7 @@
 		3F912D9424E1A75C00E2AC84 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1320;
+				LastSwiftUpdateCheck = 1500;
 				LastUpgradeCheck = 1230;
 				ORGANIZATIONNAME = Adobe;
 				TargetAttributes = {

--- a/TestApps/AEPCoreTestApp.xcodeproj/xcshareddata/xcschemes/TestApp_Swift.xcscheme
+++ b/TestApps/AEPCoreTestApp.xcodeproj/xcshareddata/xcschemes/TestApp_Swift.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1230"
-   version = "1.3">
+   version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -39,7 +39,8 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "1">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/TestApps/TestAppExtension/Info.plist
+++ b/TestApps/TestAppExtension/Info.plist
@@ -5,7 +5,7 @@
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionFileProviderDocumentGroup</key>
-		<string>group.com.adobe.TestApp-Swift</string>
+		<string>group.com.adobe.aepsampleapp</string>
 		<key>NSExtensionFileProviderSupportsEnumeration</key>
 		<true/>
 		<key>NSExtensionPointIdentifier</key>

--- a/TestApps/TestAppExtension/TestAppExtension.entitlements
+++ b/TestApps/TestAppExtension/TestAppExtension.entitlements
@@ -2,9 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.application-groups</key>
-    <array>
-        <string>group.com.adobe.TestApp-Swift</string>
-    </array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.adobe.aepsampleapp</string>
+	</array>
 </dict>
 </plist>

--- a/TestApps/TestApp_Swift/AppDelegate.swift
+++ b/TestApps/TestApp_Swift/AppDelegate.swift
@@ -15,6 +15,7 @@ import AEPServices
 import AEPLifecycle
 import AEPSignal
 import AEPIdentity
+import BackgroundTasks
 
 @main
 @available(tvOSApplicationExtension, unavailable)
@@ -38,7 +39,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 MobileCore.lifecycleStart(additionalContextData: nil)
             }
         })
+        
+        BGTaskScheduler.shared.register(forTaskWithIdentifier: "testBackground", using: nil) { task in
+            // Check if we can retrieve from file from background
+            self.backgroundTask()
+            task.setTaskCompleted(success: true)
+            self.scheduleAppRefresh()
+        }
         return true
+    }
+    
+    func backgroundTask() {
+        // Provide the task you want to test in the background here
+    }
+    
+    func scheduleAppRefresh() {
+        let request = BGAppRefreshTaskRequest(identifier: "testBackground")
+
+        request.earliestBeginDate = nil // Refresh after 5 minutes.
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+        } catch {
+            print("Could not schedule app refresh task \(error.localizedDescription)")
+        }
     }
 
     // MARK: UISceneSession Lifecycle

--- a/TestApps/TestApp_Swift/Info.plist
+++ b/TestApps/TestApp_Swift/Info.plist
@@ -37,5 +37,16 @@
 			</array>
 		</dict>
 	</dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>testBackground</string>
+	</array>
+	<key>LSApplicationCategoryType</key>
+	<string></string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>processing</string>
+	</array>
 </dict>
 </plist>

--- a/TestApps/TestApp_Swift/SceneDelegate.swift
+++ b/TestApps/TestApp_Swift/SceneDelegate.swift
@@ -12,6 +12,8 @@
 import UIKit
 import SwiftUI
 import AEPCore
+import AEPServices
+import BackgroundTasks
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -61,7 +63,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
         MobileCore.lifecyclePause()
+        // To test background task, breakpoint below, and then enter the following command in to the debug console:
+        // e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"testBackground"]
+        (UIApplication.shared.delegate as! AppDelegate).scheduleAppRefresh()
     }
+    
 
 
 }


### PR DESCRIPTION
Adds an attribute for our FileSystem storage directory and sets the fileprotection to none. This is to avoid system restrictions during app backgrounding and other potential edge cases.

Also adds capabilities to our test app for testing backgrounding tasks.