### PR TITLE
[MOB-19790] Fix encoded data in migration

### DIFF
--- a/AEPCore/Sources/migration/UserDefaultsMigrator.swift
+++ b/AEPCore/Sources/migration/UserDefaultsMigrator.swift
@@ -31,7 +31,10 @@ struct UserDefaultsMigrator {
             Log.debug(label: LOG_TAG, "Beginning UserDefaults migration")
             for (collectionName, keys) in constants.migrationDict {
                 for key in keys {
-                    if let valueToMigrate = getAndDelete(key: keyWithPrefix(datastoreName: collectionName, key: key)) {
+                    if var valueToMigrate = getAndDelete(key: keyWithPrefix(datastoreName: collectionName, key: key)) {
+                        if valueToMigrate is Data {
+                            valueToMigrate = String(data: valueToMigrate as! Data, encoding: .utf8) as Any
+                        }
                         dataStore.set(collectionName: collectionName, key: key, value: valueToMigrate)
                     }
                 }

--- a/AEPCore/Tests/MigrationTests/UserDefaultMigratorTests.swift
+++ b/AEPCore/Tests/MigrationTests/UserDefaultMigratorTests.swift
@@ -97,8 +97,8 @@ class UserDefaultMigratorTests: XCTestCase {
         let identityPushEnabledKey = keyWithPrefix(datastoreName: identityStoreName, key: identityKeys.PUSH_ENABLED.rawValue)
         let identityAnalyticsPushEnabledKey = keyWithPrefix(datastoreName: identityStoreName, key: identityKeys.ANALYTICS_PUSH_ENABLED.rawValue)
         let encoder = JSONEncoder()
-        if let encodedValue = try? encoder.encode(properties), let encodedString = String(data: encodedValue, encoding: .utf8) {
-            defaults.set(encodedString, forKey: identityPropertyKey)
+        if let encodedValue = try? encoder.encode(properties) {
+            defaults.set(encodedValue, forKey: identityPropertyKey)
         }
         defaults.set(true, forKey: identityPushEnabledKey)
         defaults.set(false, forKey: identityAnalyticsPushEnabledKey)
@@ -148,8 +148,8 @@ class UserDefaultMigratorTests: XCTestCase {
         persistedContext.startDate = mockDate
         persistedContext.successfulClose = true
         let encoder = JSONEncoder()
-        if let encodedValue = try? encoder.encode(persistedContext), let encodedString = String(data: encodedValue, encoding: .utf8) {
-            defaults.set(encodedString, forKey: persistedContextKey)
+        if let encodedValue = try? encoder.encode(persistedContext) {
+            defaults.set(encodedValue, forKey: persistedContextKey)
         }
         var lifecycleMetrics = LifecycleMetrics()
         lifecycleMetrics.appId = "appID"
@@ -158,8 +158,8 @@ class UserDefaultMigratorTests: XCTestCase {
         lifecycleContextData.additionalContextData = ["additionalContextDataKey": "additionalContextDataVal"]
         lifecycleContextData.lifecycleMetrics = lifecycleMetrics
         lifecycleContextData.advertisingIdentifier = "advertisingID"
-        if let encodedValue = try? encoder.encode(lifecycleContextData), let encodedString = String(data: encodedValue, encoding: .utf8) {
-            defaults.set(encodedString, forKey: lifecycleDataKey)
+        if let encodedValue = try? encoder.encode(lifecycleContextData) {
+            defaults.set(encodedValue, forKey: lifecycleDataKey)
         }
         let lastVersion = "1.0.0"
         defaults.set(mockDate, forKey: installDateKey)

--- a/AEPServices/Sources/storage/FileSystemNamedCollection.swift
+++ b/AEPServices/Sources/storage/FileSystemNamedCollection.swift
@@ -45,12 +45,16 @@ class FileSystemNamedCollection: NamedCollectionProcessing {
                 return
             }
             dict[key] = value
-            if let updatedStorageData = try? JSONSerialization.data(withJSONObject: dict) {
-                do {
-                    try updatedStorageData.write(to: fileUrl, options: .atomic)
-                } catch {
-                    Log.warning(label: self.LOG_TAG, "Error '\(error)' when writing '\(key)' to collection '\(collectionName)'")
+            if JSONSerialization.isValidJSONObject(dict) {
+                if let updatedStorageData = try? JSONSerialization.data(withJSONObject: dict) {
+                    do {
+                        try updatedStorageData.write(to: fileUrl, options: .atomic)
+                    } catch {
+                        Log.warning(label: self.LOG_TAG, "Error '\(error)' when writing '\(key)' to collection '\(collectionName)'")
+                    }
                 }
+            } else {
+                Log.warning(label: self.LOG_TAG, "Setting value: \(String(describing: value)) with dict: \(dict) failed. Not serializable.")
             }
         }
     }

--- a/TestApps/AEPCoreTestApp.xcodeproj/xcshareddata/xcschemes/TestApp_Swift.xcscheme
+++ b/TestApps/AEPCoreTestApp.xcodeproj/xcshareddata/xcschemes/TestApp_Swift.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1230"
-   version = "2.0">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -39,8 +39,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      launchAutomaticallySubstyle = "1">
+      allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/TestApps/TestApp_Swift/AppDelegate.swift
+++ b/TestApps/TestApp_Swift/AppDelegate.swift
@@ -27,7 +27,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         let appState = application.applicationState
         MobileCore.setLogLevel(.trace)
-        MobileCore.setAppGroup("group.com.adobe.aepsampleapp")
         let extensions = [Identity.self,
                           Lifecycle.self,
                           Signal.self]
@@ -40,6 +39,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         })
         
+        // If testing background, edit test app scheme -> options -> background fetch -> Check "launch app due to background fetch event"
         BGTaskScheduler.shared.register(forTaskWithIdentifier: "testBackground", using: nil) { task in
             // Check if we can retrieve from file from background
             self.backgroundTask()


### PR DESCRIPTION
Fixes crash which happened when trying to set Data in FileSystemNamedCollection. 

The crash occurred because the JSONSerialization.data(:_) method crashes internally when a top level fragment is not an accepted type. See [here](https://developer.apple.com/documentation/foundation/jsonserialization). When we attempted to set encoded data, the crash occurs. 

To avoid the crash, we use the `JSONSerialization.isValidJSONObject` to check if the value can be used. 
To successfully migrate the encoded data, we now encode the data as a string in the migrator before migrating it.