### PR TITLE
Reverts to use UserDefaultsNamedCollection on tvOS

### DIFF
--- a/AEPCore/Sources/core/MobileCore.swift
+++ b/AEPCore/Sources/core/MobileCore.swift
@@ -47,7 +47,7 @@ public final class MobileCore: NSObject {
         V4Migrator(idParser: idParser).migrate() // before starting SDK, migrate from v4 if needed
         V5Migrator(idParser: idParser).migrate() // before starting SDK, migrate from v5 if needed
         #if os(iOS)
-        UserDefaultsMigrator().migrate() // before starting SDK, migrate from UserDefaults if needed
+            UserDefaultsMigrator().migrate() // before starting SDK, migrate from UserDefaults if needed
         #endif
         // Invoke registerExtension on legacy extensions
         let legacyExtensions = extensions.filter {!($0.self is Extension.Type)} // All extensions that do not conform to `Extension`

--- a/AEPCore/Sources/core/MobileCore.swift
+++ b/AEPCore/Sources/core/MobileCore.swift
@@ -46,7 +46,9 @@ public final class MobileCore: NSObject {
         let idParser = IDParser()
         V4Migrator(idParser: idParser).migrate() // before starting SDK, migrate from v4 if needed
         V5Migrator(idParser: idParser).migrate() // before starting SDK, migrate from v5 if needed
+        #if os(iOS)
         UserDefaultsMigrator().migrate() // before starting SDK, migrate from UserDefaults if needed
+        #endif
         // Invoke registerExtension on legacy extensions
         let legacyExtensions = extensions.filter {!($0.self is Extension.Type)} // All extensions that do not conform to `Extension`
         let registerSelector = Selector(("registerExtension"))

--- a/AEPCore/Sources/migration/UserDefaultMigrationConstants.swift
+++ b/AEPCore/Sources/migration/UserDefaultMigrationConstants.swift
@@ -9,7 +9,7 @@
  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
-*/
+ */
 
 import Foundation
 
@@ -177,7 +177,7 @@ enum UserDefaultMigratorConstants {
         static let DATASTORE_NAME = "com.adobe.edge.identity"
         
         enum DataStoreKeys: String, CaseIterable {
-           case IDENTITY_PROPERTIES = "identity.properties"
+            case IDENTITY_PROPERTIES = "identity.properties"
         }
     }
     
@@ -185,7 +185,7 @@ enum UserDefaultMigratorConstants {
         static let DATASTORE_NAME = "com.adobe.edge.consent"
         
         enum DataStoreKeys: String, CaseIterable {
-           case CONSENT_PREFERENCES = "consent.preferences"
+            case CONSENT_PREFERENCES = "consent.preferences"
         }
     }
 }

--- a/AEPCore/Sources/migration/UserDefaultsMigrator.swift
+++ b/AEPCore/Sources/migration/UserDefaultsMigrator.swift
@@ -9,7 +9,7 @@
  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
-*/
+ */
 
 import Foundation
 import AEPServices

--- a/AEPCore/Tests/MigrationTests/UserDefaultMigratorTests.swift
+++ b/AEPCore/Tests/MigrationTests/UserDefaultMigratorTests.swift
@@ -9,7 +9,7 @@
  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
-*/
+ */
 
 import XCTest
 @testable import AEPCore

--- a/AEPCore/Tests/MobileCoreTests.swift
+++ b/AEPCore/Tests/MobileCoreTests.swift
@@ -439,9 +439,8 @@ class MobileCoreTests: XCTestCase {
         // test
         MobileCore.setAppGroup(appGroup)
 
-        // verify
-        let keyValueService = ServiceProvider.shared.namedKeyValueService as? FileSystemNamedCollection
-        XCTAssertEqual(appGroup, keyValueService?.getAppGroup())
+        let keyValueService = ServiceProvider.shared.namedKeyValueService
+        XCTAssertEqual(appGroup, keyValueService.getAppGroup())
     }
 
     // MARK: collectMessageInfo(...) tests

--- a/AEPIntegrationTests/IdentityIntegrationTests.swift
+++ b/AEPIntegrationTests/IdentityIntegrationTests.swift
@@ -359,17 +359,17 @@ class IdentityIntegrationTests: XCTestCase {
         MobileCore.resetIdentities()
 
         wait(for: [resetHitExpectation], timeout: 2)
-        
+
         // Wait for 500ms so that the new ECID gets persisted and to avoid race conditions
         usleep(500)
-        
+
         // assert new ECID on last hit
         props.loadFromPersistence()
         guard let newEcid = props.ecid else {
             XCTFail("New ECID is not generated")
             return
         }
-        
+
         XCTAssertNotEqual(firstEcid.ecidString, newEcid.ecidString)
         XCTAssertTrue(mockNetworkService.requests[0].url.absoluteString.contains(newEcid.ecidString))
         XCTAssertFalse(mockNetworkService.requests[0].url.absoluteString.contains(firstEcid.ecidString))

--- a/AEPServices/Sources/ServiceProvider.swift
+++ b/AEPServices/Sources/ServiceProvider.swift
@@ -28,7 +28,11 @@ public class ServiceProvider {
     private var overrideSystemInfoService: SystemInfoService?
     private var defaultSystemInfoService = ApplicationSystemInfoService()
     private var overrideKeyValueService: NamedCollectionProcessing?
+    #if os(iOS)
     private var defaultKeyValueService = FileSystemNamedCollection()
+    #elseif os(tvOS)
+    private var defaultKeyValueService = UserDefaultsNamedCollection()
+    #endif
     private var overrideNetworkService: Networking?
     private var defaultNetworkService = NetworkService()
     private var defaultDataQueueService = DataQueueService()
@@ -115,7 +119,11 @@ public class ServiceProvider {
     internal func reset() {
         queue.async {
             self.defaultSystemInfoService = ApplicationSystemInfoService()
+            #if os(iOS)
             self.defaultKeyValueService = FileSystemNamedCollection()
+            #elseif os(tvOS)
+            self.defaultKeyValueService = UserDefaultsNamedCollection()
+            #endif
             self.defaultNetworkService = NetworkService()
             self.defaultCacheService = DiskCacheService()
             self.defaultDataQueueService = DataQueueService()

--- a/AEPServices/Sources/ServiceProvider.swift
+++ b/AEPServices/Sources/ServiceProvider.swift
@@ -29,9 +29,9 @@ public class ServiceProvider {
     private var defaultSystemInfoService = ApplicationSystemInfoService()
     private var overrideKeyValueService: NamedCollectionProcessing?
     #if os(iOS)
-    private var defaultKeyValueService = FileSystemNamedCollection()
+        private var defaultKeyValueService = FileSystemNamedCollection()
     #elseif os(tvOS)
-    private var defaultKeyValueService = UserDefaultsNamedCollection()
+        private var defaultKeyValueService = UserDefaultsNamedCollection()
     #endif
     private var overrideNetworkService: Networking?
     private var defaultNetworkService = NetworkService()
@@ -120,9 +120,9 @@ public class ServiceProvider {
         queue.async {
             self.defaultSystemInfoService = ApplicationSystemInfoService()
             #if os(iOS)
-            self.defaultKeyValueService = FileSystemNamedCollection()
+                self.defaultKeyValueService = FileSystemNamedCollection()
             #elseif os(tvOS)
-            self.defaultKeyValueService = UserDefaultsNamedCollection()
+                self.defaultKeyValueService = UserDefaultsNamedCollection()
             #endif
             self.defaultNetworkService = NetworkService()
             self.defaultCacheService = DiskCacheService()

--- a/AEPServices/Sources/cache/DiskCacheService.swift
+++ b/AEPServices/Sources/cache/DiskCacheService.swift
@@ -28,12 +28,12 @@ class DiskCacheService: Caching {
         try createDirectoryIfNeeded(cacheName: cacheName)
         let path = filePath(for: cacheName, with: key)
         _ = fileManager.createFile(atPath: path, contents: entry.data, attributes: nil)
-        
+
         var newMetadata = [METADATA_KEY_PATH: path]
         if let meta = entry.metadata, !meta.isEmpty {
             newMetadata.merge(meta) { current, _ in current }
         }
-        
+
         var attributes: [String: Any] = [
             EXPIRY_DATE: entry.expiry.date.timeIntervalSince1970,
             METADATA: newMetadata

--- a/AEPServices/Sources/storage/FileSystemNamedCollection.swift
+++ b/AEPServices/Sources/storage/FileSystemNamedCollection.swift
@@ -104,7 +104,7 @@ class FileSystemNamedCollection: NamedCollectionProcessing {
             Log.warning(label: LOG_TAG, "Failed to read dictionary from collection '\(collectionName)'")
             return nil
         }
-        
+
         return jsonResult
     }
 

--- a/AEPServices/Tests/services/DiskCacheServiceTests.swift
+++ b/AEPServices/Tests/services/DiskCacheServiceTests.swift
@@ -83,7 +83,7 @@ class DiskCacheServiceTests: XCTestCase {
         let storedEntry = diskCache.get(cacheName: CACHE_NAME, key: ENTRY_KEY)
         XCTAssertTrue(originalEntry(entry, equals: storedEntry!))
     }
-    
+
     func testSetGetMissingAttributes() {
         // setup
         let data = "Test".data(using: .utf8)!
@@ -97,7 +97,7 @@ class DiskCacheServiceTests: XCTestCase {
         // verify
         XCTAssertNil(diskCache.get(cacheName: CACHE_NAME, key: ENTRY_KEY))
     }
-    
+
     func testSetGetMissingExpiryDate() {
         // setup
         let data = "Test".data(using: .utf8)!

--- a/AEPServices/Tests/services/FileSystemNamedCollectionTest.swift
+++ b/AEPServices/Tests/services/FileSystemNamedCollectionTest.swift
@@ -15,6 +15,7 @@ import XCTest
 @testable import AEPServices
 @testable import AEPServicesMocks
 
+@available(tvOS, unavailable)
 class FileSystemNamedCollectionTest: XCTestCase {
     let service = FileSystemNamedCollection()
 

--- a/AEPServices/Tests/services/ServiceProviderTests.swift
+++ b/AEPServices/Tests/services/ServiceProviderTests.swift
@@ -40,7 +40,11 @@ class ServiceProviderTests: XCTestCase {
         let mockNamedKeyValueService = MockKeyValueService()
         ServiceProvider.shared.namedKeyValueService = mockNamedKeyValueService
         ServiceProvider.shared.reset()
+        #if os(iOS)
         XCTAssertTrue(ServiceProvider.shared.namedKeyValueService is FileSystemNamedCollection)
+        #elseif os(tvOS)
+        XCTAssertTrue(ServiceProvider.shared.namedKeyValueService is UserDefaultsNamedCollection)
+        #endif
     }
     
     func testOverridingNetworkService() {

--- a/AEPServices/Tests/services/ServiceProviderTests.swift
+++ b/AEPServices/Tests/services/ServiceProviderTests.swift
@@ -41,9 +41,9 @@ class ServiceProviderTests: XCTestCase {
         ServiceProvider.shared.namedKeyValueService = mockNamedKeyValueService
         ServiceProvider.shared.reset()
         #if os(iOS)
-        XCTAssertTrue(ServiceProvider.shared.namedKeyValueService is FileSystemNamedCollection)
+            XCTAssertTrue(ServiceProvider.shared.namedKeyValueService is FileSystemNamedCollection)
         #elseif os(tvOS)
-        XCTAssertTrue(ServiceProvider.shared.namedKeyValueService is UserDefaultsNamedCollection)
+            XCTAssertTrue(ServiceProvider.shared.namedKeyValueService is UserDefaultsNamedCollection)
         #endif
     }
     

--- a/TestApps/TestApp_Swift/AppDelegate.swift
+++ b/TestApps/TestApp_Swift/AppDelegate.swift
@@ -38,7 +38,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 MobileCore.lifecycleStart(additionalContextData: nil)
             }
         })
-        
+
         // If testing background, edit test app scheme -> options -> background fetch -> Check "launch app due to background fetch event"
         BGTaskScheduler.shared.register(forTaskWithIdentifier: "testBackground", using: nil) { task in
             // Check if we can retrieve from file from background
@@ -48,11 +48,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         return true
     }
-    
+
     func backgroundTask() {
         // Provide the task you want to test in the background here
     }
-    
+
     func scheduleAppRefresh() {
         let request = BGAppRefreshTaskRequest(identifier: "testBackground")
 

--- a/TestApps/TestApp_Swift/SceneDelegate.swift
+++ b/TestApps/TestApp_Swift/SceneDelegate.swift
@@ -67,7 +67,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"testBackground"]
         (UIApplication.shared.delegate as! AppDelegate).scheduleAppRefresh()
     }
-    
+
 
 
 }


### PR DESCRIPTION
tvOS does not support FileSystem storage for persistence. Works on simulator but not on a real device.