### PR TITLE
-[PLATIR-35547] - fix temp html usage in fullscreen message and add logging around event history

### DIFF
--- a/AEPCore/Sources/eventhub/history/EventHistory.swift
+++ b/AEPCore/Sources/eventhub/history/EventHistory.swift
@@ -11,6 +11,7 @@
  */
 
 import Foundation
+import AEPServices
 
 /// Provides CRUD support for storing `Event` objects in a local database.
 class EventHistory {
@@ -62,6 +63,7 @@ class EventHistory {
                 let from = previousEventOldestOccurrence ?? event.fromDate
                 let semaphore = DispatchSemaphore(value: 0)
                 db.select(hash: eventHash, from: from, to: event.toDate) { result in
+                    Log.debug(label: "EventHistory", "EventHistoryRequest[\(event.hashValue)] - request for events with hash (\(eventHash)) between (\(from?.millisecondsSince1970 ?? 0)) and (\(event.toDate?.millisecondsSince1970 ?? 0)) with enforceOrder enabled returned \(result.count) record(s).")
                     previousEventOldestOccurrence = result.oldestOccurrence
                     results.append(result)
                     semaphore.signal()
@@ -73,6 +75,7 @@ class EventHistory {
                 let semaphore = DispatchSemaphore(value: 0)
                 let eventHash = event.mask.fnv1a32()
                 db.select(hash: eventHash, from: event.fromDate, to: event.toDate) { result in
+                    Log.debug(label: "EventHistory", "EventHistoryRequest[\(event.hashValue)] - request for events with hash (\(eventHash)) between (\(event.fromDate?.millisecondsSince1970 ?? 0)) and (\(event.toDate?.millisecondsSince1970 ?? 0)) with enforceOrder disabled returned \(result.count) record(s).")
                     results.append(result)
                     semaphore.signal()
                 }

--- a/AEPCore/Sources/eventhub/history/EventHistoryDatabase.swift
+++ b/AEPCore/Sources/eventhub/history/EventHistoryDatabase.swift
@@ -113,11 +113,11 @@ class EventHistoryDatabase {
             AND \(self.columnTimestamp) <= \(to?.millisecondsSince1970 ?? Date().millisecondsSince1970)
             """
 
-            // a nil result means there was no query results to be returned
+            // a nil result means something went wrong with the database query
             guard let result = SQLiteWrapper.query(database: connection, sql: selectStatement),
                   let row = result.first else {
-                Log.trace(label: self.LOG_PREFIX, "No query results were returned for event '\(hash)' between \(String(describing: from)) and \(String(describing: to)).")
-                handler(EventHistoryResult(count: 0))
+                Log.warning(label: self.LOG_PREFIX, "An error occurred when attempting to query for event(s) '\(hash)' between \(String(describing: from)) and \(String(describing: to)).")
+                handler(EventHistoryResult(count: -1))
                 return
             }
 

--- a/AEPCore/Sources/eventhub/history/EventHistoryDatabase.swift
+++ b/AEPCore/Sources/eventhub/history/EventHistoryDatabase.swift
@@ -101,7 +101,7 @@ class EventHistoryDatabase {
             // first verify we can get a connection handle
             guard let connection = self.connection else {
                 Log.warning(label: self.LOG_PREFIX, "Unable to get a connection to the event history database.")
-                handler(EventHistoryResult(count: 0))
+                handler(EventHistoryResult(count: -1))
                 return
             }
 

--- a/AEPCore/Tests/EventHubTests/HistoryTests/EventHistoryDatabaseTests.swift
+++ b/AEPCore/Tests/EventHubTests/HistoryTests/EventHistoryDatabaseTests.swift
@@ -93,7 +93,7 @@ class EventHistoryDatabaseTests: XCTestCase {
                 
         eventHistoryDatabase.select(hash: testHash, from: nil, to: nil) { result in
             XCTAssertNotNil(result)
-            XCTAssertEqual(0, result.count)
+            XCTAssertEqual(-1, result.count)
             XCTAssertNil(result.newestOccurrence)
             XCTAssertNil(result.oldestOccurrence)
             selectExpectation.fulfill()

--- a/AEPServices/Mocks/MockMessagingDelegate.swift
+++ b/AEPServices/Mocks/MockMessagingDelegate.swift
@@ -12,8 +12,11 @@
 #if os(iOS)
     import Foundation
     import AEPServices
+    import XCTest
 
     public class MockMessagingDelegate: MessagingDelegate {
+        var expectation: XCTestExpectation? = nil
+        
         var onShowCalled = false
         var onDismissCalled = false
         var shouldShowMessageCalled = false
@@ -24,16 +27,24 @@
     
         var valueShouldShowMessage = true
     
+        public func setExpectation(_ expectation: XCTestExpectation) {
+            self.expectation = expectation
+        }
+        
         public func onShow(message: Showable) {
             onShowCalled = true
             paramMessage = message
+            expectation?.fulfill()
         }
     
         public func onDismiss(message: Showable) {
             onDismissCalled = true
             paramMessage = message
+            expectation?.fulfill()
         }
-    
+            
+        // intentionally not fulfilling expectation here -
+        // omit setting the expectation if you only expect `shouldShowMessage` to be called
         public func shouldShowMessage(message: Showable) -> Bool {
             shouldShowMessageCalled = true
             paramMessage = message
@@ -44,6 +55,7 @@
             urlLoadedCalled = true
             paramUrl = url
             paramMessage = message
+            expectation?.fulfill()
         }
     }
 #endif

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
@@ -133,7 +133,7 @@
                     if self.isLocalImageUsed, let file = tempHTMLFile {
                         // We have to use loadFileURL so we can allow read access to these image files in the cache but loadFileURL
                         // expects a file URL and not the string representation of the HTML payload. As a workaround, we can write the
-                        // payload string to a temporary HTML file located at cachePath/adbdownloadcache/temp_[EPOCH_TIMESTAMP].html
+                        // payload string to a temporary HTML file located at cachePath/adbdownloadcache/temp_[self.hash].html
                         // and pass that file URL to loadFileURL.
                         do {
                             try FileManager.default.createDirectory(atPath: cacheFolderURL?.path ?? "", withIntermediateDirectories: true, attributes: nil)

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
@@ -128,7 +128,7 @@
                 let cacheFolder: URL? = self.fileManager.getCacheDirectoryPath()
                 if cacheFolder != nil {
                     cacheFolderURL = cacheFolder?.appendingPathComponent(self.DOWNLOAD_CACHE)
-                    let tempHTMLFileName = "\(self.TEMP_FILE_NAME)_\(Date().millisecondsSince1970)"
+                    let tempHTMLFileName = "\(self.TEMP_FILE_NAME)_\(self.hash)"
                     tempHTMLFile = cacheFolderURL?.appendingPathComponent(tempHTMLFileName).appendingPathExtension(self.HTML_EXTENSION)
                     if self.isLocalImageUsed, let file = tempHTMLFile {
                         // We have to use loadFileURL so we can allow read access to these image files in the cache but loadFileURL

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
@@ -128,12 +128,13 @@
                 let cacheFolder: URL? = self.fileManager.getCacheDirectoryPath()
                 if cacheFolder != nil {
                     cacheFolderURL = cacheFolder?.appendingPathComponent(self.DOWNLOAD_CACHE)
-                    tempHTMLFile = cacheFolderURL?.appendingPathComponent(self.TEMP_FILE_NAME).appendingPathExtension(self.HTML_EXTENSION)
+                    let tempHTMLFileName = "\(self.TEMP_FILE_NAME)_\(Date().millisecondsSince1970)"
+                    tempHTMLFile = cacheFolderURL?.appendingPathComponent(tempHTMLFileName).appendingPathExtension(self.HTML_EXTENSION)
                     if self.isLocalImageUsed, let file = tempHTMLFile {
                         // We have to use loadFileURL so we can allow read access to these image files in the cache but loadFileURL
                         // expects a file URL and not the string representation of the HTML payload. As a workaround, we can write the
-                        // payload string to a temporary HTML file located at cachePath/adbdownloadcache/temp.html and pass that file
-                        // URL to loadFileURL.
+                        // payload string to a temporary HTML file located at cachePath/adbdownloadcache/temp_[EPOCH_TIMESTAMP].html
+                        // and pass that file URL to loadFileURL.
                         do {
                             try FileManager.default.createDirectory(atPath: cacheFolderURL?.path ?? "", withIntermediateDirectories: true, attributes: nil)
                             var tempHtml: Data?

--- a/AEPServices/Tests/services/FullscreenMessageTests.swift
+++ b/AEPServices/Tests/services/FullscreenMessageTests.swift
@@ -21,7 +21,8 @@
     class FullscreenMessageTests : XCTestCase {
         let mockHtml = "somehtml"
         var fullscreenMessage : FullscreenMessage?
-        var expectation: XCTestExpectation?
+        var fullscreenListenerExpectation: XCTestExpectation?
+        var messagingDelegateExpectation: XCTestExpectation?
         var webViewExpectation: XCTestExpectation?
         var webViewContent: String?
         var mockUIService: UIService?
@@ -50,7 +51,7 @@
             handler = { content in
                 self.handlerCalled = true
                 self.handlerContent = content
-                self.expectation?.fulfill()
+                self.fullscreenListenerExpectation?.fulfill()
             }
         }
 
@@ -70,45 +71,54 @@
         }
 
         func testDismiss() {
-            expectation = XCTestExpectation(description: "Testing Dismiss FullscreenMessage")
-            mockFullscreenListener.setExpectation(expectation!)
+            fullscreenListenerExpectation = XCTestExpectation(description: "Testing Dismiss FullscreenMessage")
+            mockFullscreenListener.setExpectation(fullscreenListenerExpectation!)
+            messagingDelegateExpectation = XCTestExpectation(description: "Testing Dismiss FullscreenMessage")
+            mockMessagingDelegate.setExpectation(messagingDelegateExpectation!)
             messageMonitor.displayMessage()
             fullscreenMessage?.dismiss()
-            wait(for: [expectation!], timeout: 2.0)
+            wait(for: [fullscreenListenerExpectation!, messagingDelegateExpectation!], timeout: 2.0)
             XCTAssertTrue(mockFullscreenListener.onDismissCalled)
             XCTAssertTrue(mockMessagingDelegate.onDismissCalled)
         }
     
         func testDismissNoMessageVisible() {
-            expectation = XCTestExpectation(description: "Testing Dismiss FullscreenMessage")
-            expectation?.isInverted = true
-            mockFullscreenListener.setExpectation(expectation!)
+            fullscreenListenerExpectation = XCTestExpectation(description: "Testing Dismiss FullscreenMessage")
+            fullscreenListenerExpectation?.isInverted = true
+            mockFullscreenListener.setExpectation(fullscreenListenerExpectation!)
+            messagingDelegateExpectation = XCTestExpectation(description: "Testing Dismiss FullscreenMessage")
+            messagingDelegateExpectation?.isInverted = true
+            mockMessagingDelegate.setExpectation(messagingDelegateExpectation!)
             fullscreenMessage?.dismiss()
-            wait(for: [expectation!], timeout: 1.0)
+            wait(for: [fullscreenListenerExpectation!, messagingDelegateExpectation!], timeout: 1.0)
             XCTAssertFalse(mockFullscreenListener.onDismissCalled)
             XCTAssertFalse(mockMessagingDelegate.onDismissCalled)
         }
 
         func testShow() {
-            expectation = XCTestExpectation(description: "Testing Show FullscreenMessage")
-            mockFullscreenListener.setExpectation(expectation!)
+            fullscreenListenerExpectation = XCTestExpectation(description: "Testing Show FullscreenMessage")
+            mockFullscreenListener.setExpectation(fullscreenListenerExpectation!)
+            messagingDelegateExpectation = XCTestExpectation(description: "Testing Show FullscreenMessage")
+            mockMessagingDelegate.setExpectation(messagingDelegateExpectation!)
             fullscreenMessage?.scriptHandlers["testScript"] = handler
             messageMonitor.dismissMessage()
             fullscreenMessage?.show()
-            wait(for: [expectation!], timeout: 2.0)
+            wait(for: [fullscreenListenerExpectation!, messagingDelegateExpectation!], timeout: 2.0)
             XCTAssertTrue(mockFullscreenListener.onShowCalled)
             XCTAssertTrue(mockMessagingDelegate.shouldShowMessageCalled)
             XCTAssertTrue(mockMessagingDelegate.onShowCalled)
         }
     
         func testShowWithUITakeover() {
-            expectation = XCTestExpectation(description: "Testing Show FullscreenMessage")
-            mockFullscreenListener.setExpectation(expectation!)
+            fullscreenListenerExpectation = XCTestExpectation(description: "Testing Show FullscreenMessage")
+            mockFullscreenListener.setExpectation(fullscreenListenerExpectation!)
+            messagingDelegateExpectation = XCTestExpectation(description: "Testing Show FullscreenMessage")
+            mockMessagingDelegate.setExpectation(messagingDelegateExpectation!)
             mockMessageSettings.setUiTakeover(true)
             mockMessageSettings.setBackdropColor("000000")
             mockMessageSettings.setBackdropOpacity(0.3)
             fullscreenMessage?.show()
-            wait(for: [expectation!], timeout: 2.0)
+            wait(for: [fullscreenListenerExpectation!, messagingDelegateExpectation!], timeout: 2.0)
             XCTAssertTrue(mockFullscreenListener.onShowCalled)
             XCTAssertTrue(mockMessagingDelegate.shouldShowMessageCalled)
             XCTAssertTrue(mockMessagingDelegate.onShowCalled)
@@ -119,11 +129,13 @@
         }
     
         func testShowWithCornerRadius() {
-            expectation = XCTestExpectation(description: "Testing Show FullscreenMessage")
-            mockFullscreenListener.setExpectation(expectation!)
+            fullscreenListenerExpectation = XCTestExpectation(description: "Testing Show FullscreenMessage")
+            mockFullscreenListener.setExpectation(fullscreenListenerExpectation!)
+            messagingDelegateExpectation = XCTestExpectation(description: "Testing Show FullscreenMessage")
+            mockMessagingDelegate.setExpectation(messagingDelegateExpectation!)
             mockMessageSettings.setCornerRadius(15.0)
             fullscreenMessage?.show()
-            wait(for: [expectation!], timeout: 2.0)
+            wait(for: [fullscreenListenerExpectation!, messagingDelegateExpectation!], timeout: 2.0)
             XCTAssertTrue(mockFullscreenListener.onShowCalled)
             XCTAssertTrue(mockMessagingDelegate.shouldShowMessageCalled)
             XCTAssertTrue(mockMessagingDelegate.onShowCalled)
@@ -132,27 +144,31 @@
         }
     
         func testShowWithPayloadUsingLocalAssets() throws {
-            expectation = XCTestExpectation(description: "Testing Show FullscreenMessage")
-            mockFullscreenListener.setExpectation(expectation!)
+            fullscreenListenerExpectation = XCTestExpectation(description: "Testing Show FullscreenMessage")
+            mockFullscreenListener.setExpectation(fullscreenListenerExpectation!)
+            messagingDelegateExpectation = XCTestExpectation(description: "Testing Show FullscreenMessage")
+            mockMessagingDelegate.setExpectation(messagingDelegateExpectation!)
             fullscreenMessage?.scriptHandlers["testScript"] = handler
             fullscreenMessage?.isLocalImageUsed = true
             fullscreenMessage?.payloadUsingLocalAssets = "use me instead"
             messageMonitor.dismissMessage()
             fullscreenMessage?.show()
-            wait(for: [expectation!], timeout: 2.0)
+            wait(for: [fullscreenListenerExpectation!, messagingDelegateExpectation!], timeout: 2.0)
             XCTAssertTrue(mockFullscreenListener.onShowCalled)
             XCTAssertTrue(mockMessagingDelegate.shouldShowMessageCalled)
             XCTAssertTrue(mockMessagingDelegate.onShowCalled)
         }
     
         func testShowWithGestures() {
-            expectation = XCTestExpectation(description: "Testing Show FullscreenMessage")
-            mockFullscreenListener.setExpectation(expectation!)
+            fullscreenListenerExpectation = XCTestExpectation(description: "Testing Show FullscreenMessage")
+            mockFullscreenListener.setExpectation(fullscreenListenerExpectation!)
+            messagingDelegateExpectation = XCTestExpectation(description: "Testing Show FullscreenMessage")
+            mockMessagingDelegate.setExpectation(messagingDelegateExpectation!)
             mockMessageSettings.setGestures([
                 .swipeUp: URL(string: "https://adobe.com")!
             ])
             fullscreenMessage?.show()
-            wait(for: [expectation!], timeout: 2.0)
+            wait(for: [fullscreenListenerExpectation!, messagingDelegateExpectation!], timeout: 2.0)
             XCTAssertTrue(mockFullscreenListener.onShowCalled)
             XCTAssertTrue(mockMessagingDelegate.shouldShowMessageCalled)
             XCTAssertTrue(mockMessagingDelegate.onShowCalled)
@@ -176,53 +192,55 @@
         }
  
         func testOnShowDelegateReturnsFalse() throws {
-            expectation = XCTestExpectation(description: "Testing show failed")
-            mockFullscreenListener.setExpectation(expectation!)
+            fullscreenListenerExpectation = XCTestExpectation(description: "Testing show failed")
+            mockFullscreenListener.setExpectation(fullscreenListenerExpectation!)            
             mockMessagingDelegate.valueShouldShowMessage = false
             fullscreenMessage?.show()
-            wait(for: [expectation!], timeout: 2.0)
+            wait(for: [fullscreenListenerExpectation!], timeout: 2.0)
             XCTAssertTrue(mockFullscreenListener.onShowFailureCalled)
             XCTAssertTrue(mockMessagingDelegate.shouldShowMessageCalled)
         }
     
         func testShowWhenWebviewAlreadyExists() throws {
-            expectation = XCTestExpectation(description: "Testing show when webview already exists")
-            mockFullscreenListener.setExpectation(expectation!)
+            fullscreenListenerExpectation = XCTestExpectation(description: "Testing show when webview already exists")
+            mockFullscreenListener.setExpectation(fullscreenListenerExpectation!)
+            messagingDelegateExpectation = XCTestExpectation(description: "Testing show when webview already exists")
+            mockMessagingDelegate.setExpectation(messagingDelegateExpectation!)
             fullscreenMessage?.webView = WKWebView()
             fullscreenMessage?.show()
-            wait(for: [expectation!], timeout: 2.0)
+            wait(for: [fullscreenListenerExpectation!, messagingDelegateExpectation!], timeout: 2.0)
             XCTAssertTrue(mockFullscreenListener.onShowCalled)
             XCTAssertTrue(mockMessagingDelegate.shouldShowMessageCalled)
             XCTAssertTrue(mockMessagingDelegate.onShowCalled)
         }
     
         func testShowWhenWebviewAlreadyExistsDelegateReturnsFalse() throws {
-            expectation = XCTestExpectation(description: "Testing show when webview already exists")
-            mockFullscreenListener.setExpectation(expectation!)
+            fullscreenListenerExpectation = XCTestExpectation(description: "Testing show when webview already exists")
+            mockFullscreenListener.setExpectation(fullscreenListenerExpectation!)
             fullscreenMessage?.webView = WKWebView()
             mockMessagingDelegate.valueShouldShowMessage = false
             fullscreenMessage?.show()
-            wait(for: [expectation!], timeout: 2.0)
+            wait(for: [fullscreenListenerExpectation!], timeout: 2.0)
             XCTAssertTrue(mockFullscreenListener.onShowFailureCalled)
             XCTAssertTrue(mockMessagingDelegate.shouldShowMessageCalled)
         }
     
         func testHandleJavascriptMessageHappy() throws {
-            expectation = XCTestExpectation(description: "Testing handler is properly set")
+            fullscreenListenerExpectation = XCTestExpectation(description: "Testing handler is properly set")
             fullscreenMessage?.handleJavascriptMessage("testScript", withHandler: handler)
         
             // above code runs on mt, dispatch validation on mt
             DispatchQueue.main.async {
                 XCTAssertEqual(1, self.fullscreenMessage?.scriptHandlers.count)
                 self.fullscreenMessage?.scriptHandlers["testScript"]!("content")
-                self.wait(for: [self.expectation!], timeout: 2.0)
+                self.wait(for: [self.fullscreenListenerExpectation!], timeout: 2.0)
                 XCTAssertTrue(self.handlerCalled)
                 XCTAssertEqual("content", self.handlerContent as? String)
             }
         }
     
         func testHandleJavascriptMessageWebviewExists() throws {
-            expectation = XCTestExpectation(description: "Testing handler is properly set")
+            fullscreenListenerExpectation = XCTestExpectation(description: "Testing handler is properly set")
             fullscreenMessage?.webView = WKWebView()
             fullscreenMessage?.handleJavascriptMessage("testScript", withHandler: handler)
         
@@ -230,7 +248,7 @@
             DispatchQueue.main.async {
                 XCTAssertEqual(1, self.fullscreenMessage?.scriptHandlers.count)
                 self.fullscreenMessage?.scriptHandlers["testScript"]!("content")
-                self.wait(for: [self.expectation!], timeout: 2.0)
+                self.wait(for: [self.fullscreenListenerExpectation!], timeout: 2.0)
                 XCTAssertTrue(self.handlerCalled)
                 XCTAssertEqual("content", self.handlerContent as? String)
             }
@@ -287,27 +305,27 @@
         }
     
         func testUserContentControllerWithScriptHandler() throws {
-            expectation = XCTestExpectation(description: "JavaScript handler was called")
+            fullscreenListenerExpectation = XCTestExpectation(description: "JavaScript handler was called")
             let controller = WKUserContentController()
             let message = MockWKScriptMessage(name: "testScript", body: "body")
             fullscreenMessage?.handleJavascriptMessage("testScript", withHandler: handler)
             // above code runs on mt, dispatch validation on mt
             DispatchQueue.main.async {
                 self.fullscreenMessage?.userContentController(controller, didReceive: message)
-                self.wait(for: [self.expectation!], timeout: 1.0)
+                self.wait(for: [self.fullscreenListenerExpectation!], timeout: 1.0)
                 XCTAssertTrue(self.handlerCalled)
                 XCTAssertEqual("body", self.handlerContent as? String)
             }
         }
     
         func testUserContentControllerNoMatchingScriptHandler() throws {
-            expectation = XCTestExpectation(description: "JavaScript handler was called")
-            expectation?.isInverted = true
+            fullscreenListenerExpectation = XCTestExpectation(description: "JavaScript handler was called")
+            fullscreenListenerExpectation?.isInverted = true
             let controller = WKUserContentController()
             let message = MockWKScriptMessage(name: "not a matching message", body: "body")
             fullscreenMessage?.handleJavascriptMessage("testScript", withHandler: handler)
             fullscreenMessage?.userContentController(controller, didReceive: message)
-            wait(for: [expectation!], timeout: 1.0)
+            wait(for: [fullscreenListenerExpectation!], timeout: 1.0)
             XCTAssertFalse(handlerCalled)
             XCTAssertNil(handlerContent)
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Also modified some of the code for event history lookups.  If we don't get a result from the sqlite wrapper, the event history lookup will now return a result with `-1` as the count.  Eventually, we'd like to use this `JSONRulesParser.extractHistoricalCondition` to have a "fast fail" condition when the function operand returns a specific value.  This will likely require a change in the AEPRulesEngine code.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
