### PR TITLE
Identity don't dispatch Analytics push event on privacy change

### DIFF
--- a/AEPIdentity/Sources/IdentityState.swift
+++ b/AEPIdentity/Sources/IdentityState.swift
@@ -269,14 +269,7 @@ class IdentityState {
         identityProperties.privacyStatus = newPrivacyStatus
 
         if newPrivacyStatus == .optedOut {
-            identityProperties.ecid = nil
-            identityProperties.advertisingIdentifier = nil
-            identityProperties.blob = nil
-            identityProperties.locationHint = nil
-            identityProperties.customerIds?.removeAll()
-            identityProperties.isAidSynced = false
-            identityProperties.pushIdentifier = nil
-            pushIdManager.updatePushId(pushId: nil)
+            clearIdentifiers()
             identityProperties.saveToPersistence()
             createSharedState(identityProperties.toEventData(), event)
         } else if identityProperties.ecid == nil {
@@ -337,15 +330,7 @@ class IdentityState {
     func resetIdentifiers(event: Event,
                           createSharedState: ([String: Any], Event) -> Void) {
         guard identityProperties.privacyStatus != .optedOut else { return }
-        // clear the properties
-        identityProperties.ecid = nil
-        identityProperties.advertisingIdentifier = nil
-        identityProperties.blob = nil
-        identityProperties.locationHint = nil
-        identityProperties.customerIds?.removeAll()
-        identityProperties.isAidSynced = false
-        identityProperties.pushIdentifier = nil
-        pushIdManager.resetPersistedFlags()
+        clearIdentifiers()
         hitQueue.clear() // clear hit queue
 
         // do a force sync to generate ECID, then save the properties to persistence.
@@ -478,5 +463,17 @@ class IdentityState {
             identityProperties.saveToPersistence()
             Log.trace(label: "\(LOG_TAG):\(#function)", "Generating new ECID value \(identityProperties.ecid?.ecidString ?? "nil")")
         }
+    }
+    
+    /// Clears identifiers in held `IdentityProperties` and resets flags in `PushIdManager`.
+    private func clearIdentifiers() {
+        identityProperties.ecid = nil
+        identityProperties.advertisingIdentifier = nil
+        identityProperties.blob = nil
+        identityProperties.locationHint = nil
+        identityProperties.customerIds?.removeAll()
+        identityProperties.isAidSynced = false
+        identityProperties.pushIdentifier = nil
+        pushIdManager.resetPersistedFlags()
     }
 }

--- a/AEPIdentity/Sources/PushIDManager.swift
+++ b/AEPIdentity/Sources/PushIDManager.swift
@@ -60,12 +60,13 @@ struct PushIDManager: PushIDManageable {
         properties.pushIdentifier = pushId
         properties.saveToPersistence()
 
-        if pushId?.isEmpty ?? true, !pushEnabled {
+        let isPushEnabled = pushEnabled
+        if pushId?.isEmpty ?? true, !isPushEnabled {
             updatePushStatusAndSendAnalyticsEvent(enabled: false)
             Log.trace(label: "\(LOG_TAG):\(#function)", "First time sending a.push.optin False")
-        } else if pushId?.isEmpty ?? true, pushEnabled {
+        } else if pushId?.isEmpty ?? true, isPushEnabled {
             updatePushStatusAndSendAnalyticsEvent(enabled: false)
-        } else if let pushId = pushId, !pushId.isEmpty, !pushEnabled {
+        } else if let pushId = pushId, !pushId.isEmpty, !isPushEnabled {
             updatePushStatusAndSendAnalyticsEvent(enabled: true)
         }
     }

--- a/AEPIdentity/Tests/IdentityFunctionalTests.swift
+++ b/AEPIdentity/Tests/IdentityFunctionalTests.swift
@@ -482,6 +482,7 @@ class IdentityFunctionalTests: XCTestCase {
         
         mockRuntime.simulateComingEvent(event: event)
         
+        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
         let dispatchedEvent = mockRuntime.dispatchedEvents.first
 
         XCTAssertEqual(EventType.analytics, dispatchedEvent?.type)
@@ -502,6 +503,7 @@ class IdentityFunctionalTests: XCTestCase {
         
         mockRuntime.simulateComingEvent(event: event)
         
+        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
         let dispatchedEvent = mockRuntime.dispatchedEvents.first
 
         XCTAssertEqual(EventType.analytics, dispatchedEvent?.type)

--- a/AEPIdentity/Tests/IdentityFunctionalTests.swift
+++ b/AEPIdentity/Tests/IdentityFunctionalTests.swift
@@ -513,7 +513,7 @@ class IdentityFunctionalTests: XCTestCase {
     }
     
     // Test calling resetIdentities will not trigger dispatch of Analytics event
-    func testResetIdentifiersDoesNotDispatcheAnalyticsForIdentityRequestEvent() {
+    func testResetIdentifiersDoesNotDispatchAnalyticsForIdentityRequestEvent() {
         identity.state?.identityProperties.ecid = ECID()
         XCTAssertNotNil(identity.state?.identityProperties.ecid)
         
@@ -529,7 +529,7 @@ class IdentityFunctionalTests: XCTestCase {
     }
     
     // Test changing privacy to opt-out will not trigger dispatch of Analytics event
-    func testPrivacyOptOutDoesNotDispatcheAnalyticsForIdentityRequestEvent() {
+    func testPrivacyOptOutDoesNotDispatchAnalyticsForIdentityRequestEvent() {
         identity.state?.identityProperties.ecid = ECID()
         XCTAssertNotNil(identity.state?.identityProperties.ecid)
         

--- a/AEPIdentity/Tests/IdentityFunctionalTests.swift
+++ b/AEPIdentity/Tests/IdentityFunctionalTests.swift
@@ -475,8 +475,7 @@ class IdentityFunctionalTests: XCTestCase {
         // Set valid config to allow sync to process
         identity.state?.lastValidConfig = [IdentityConstants.Configuration.GLOBAL_CONFIG_PRIVACY: PrivacyStatus.optedIn.rawValue]
         
-        let pushIdData = "test-push-id".data(using: .utf8)!
-        let encodedPushId = "746573742D707573682D6964"
+        let encodedPushId = "746573742D707573682D6964" // encoded value of string "test-push-id"
                 
         let data = ["pushidentifier": encodedPushId]
         let event = Event(name: "Set Push Identifier", type: EventType.genericIdentity, source: EventSource.requestContent, data: data)

--- a/AEPIdentity/Tests/IdentityFunctionalTests.swift
+++ b/AEPIdentity/Tests/IdentityFunctionalTests.swift
@@ -482,9 +482,16 @@ class IdentityFunctionalTests: XCTestCase {
         
         mockRuntime.simulateComingEvent(event: event)
         
+        // Verify push ID saved to persistence
+        let dataStore = NamedCollectionDataStore(name: "com.adobe.module.identity")
+        let identityProperties: IdentityProperties? = dataStore.getObject(key: "identity.properties")
+        XCTAssertEqual(encodedPushId,  identityProperties?.pushIdentifier)
+        
+        // Verify only one event dispatched
         XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
         let dispatchedEvent = mockRuntime.dispatchedEvents.first
 
+        // Verify dispatched event has expected data
         XCTAssertEqual(EventType.analytics, dispatchedEvent?.type)
         XCTAssertEqual(EventSource.requestContent, dispatchedEvent?.source)
         XCTAssertEqual("Push", dispatchedEvent?.data?["action"] as? String)
@@ -503,9 +510,16 @@ class IdentityFunctionalTests: XCTestCase {
         
         mockRuntime.simulateComingEvent(event: event)
         
+        // Verify push ID saved to persistence
+        let dataStore = NamedCollectionDataStore(name: "com.adobe.module.identity")
+        let identityProperties: IdentityProperties? = dataStore.getObject(key: "identity.properties")
+        XCTAssertEqual("",  identityProperties?.pushIdentifier)
+        
+        // Verify only one event dispatched
         XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
         let dispatchedEvent = mockRuntime.dispatchedEvents.first
 
+        // Verify dispatched event has expected data
         XCTAssertEqual(EventType.analytics, dispatchedEvent?.type)
         XCTAssertEqual(EventSource.requestContent, dispatchedEvent?.source)
         XCTAssertEqual("Push", dispatchedEvent?.data?["action"] as? String)

--- a/AEPIdentity/Tests/IdentityStateTests.swift
+++ b/AEPIdentity/Tests/IdentityStateTests.swift
@@ -1054,7 +1054,8 @@ class IdentityStateTests: XCTestCase {
         // verify
         wait(for: [sharedStateExpectation], timeout: 1)
         XCTAssertFalse(mockDataStore.dict.isEmpty) // identity properties should have been saved to persistence
-        XCTAssertTrue(mockPushIdManager.calledUpdatePushId)
+        XCTAssertFalse(mockPushIdManager.calledUpdatePushId)
+        XCTAssertTrue(mockPushIdManager.calledResetPersistedFlags)
         XCTAssertTrue(mockHitQueue.calledSuspend && mockHitQueue.calledClear) // we should suspend the queue and clear it
         XCTAssertEqual(PrivacyStatus.optedOut, state.identityProperties.privacyStatus) // privacy status should change to opt out
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updates the Identity extension to not dispatch the `AnalyticsForIdentityRequest` event when privacy status is changed to optedout.

The Identity extension is expected to dispatch the `AnalyticsForIdentityRequest` event when the push identifier changes or when push tracking is denied the first time. This event tells Analytics to dispatch an ADBINTERNAL:Push event with `a.push.optin` value of either `True` or `False`. The issue is in some cases changing the privacy status to optedout would trigger a dispatch of the `AnalyticsForIdentityRequest` event even though `setPushIdentifier` was never called.

This fix changes how Identity handles processing of an privacy status change to optedout by resetting the `PushIdManager` flags instead of calling `updatePushId` which would dispatch the event to Analytics. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
