### PR TITLE
[MOB-20702] Weak self fix

### DIFF
--- a/AEPServices/Sources/storage/FileSystemNamedCollection.swift
+++ b/AEPServices/Sources/storage/FileSystemNamedCollection.swift
@@ -21,7 +21,8 @@ class FileSystemNamedCollection: NamedCollectionProcessing {
     private var appGroup: String?
 
     func setAppGroup(_ appGroup: String?) {
-        queue.async {
+        queue.async { [weak self] in
+            guard let self = self else { return }
             self.appGroup = appGroup
             if let appGroup = appGroup {
                 self.appGroupUrl = self.fileManager.containerURL(forSecurityApplicationGroupIdentifier: appGroup)
@@ -36,8 +37,8 @@ class FileSystemNamedCollection: NamedCollectionProcessing {
     }
 
     func set(collectionName: String, key: String, value: Any?) {
-        queue.async {
-            guard let fileUrl = self.fileUrl(for: collectionName) else {
+        queue.async { [weak self] in
+            guard let self = self, let fileUrl = self.fileUrl(for: collectionName) else {
                 return
             }
             var dict = self.getDictFor(collectionName: collectionName) ?? [:]
@@ -69,8 +70,8 @@ class FileSystemNamedCollection: NamedCollectionProcessing {
     }
 
     func remove(collectionName: String, key: String) {
-        queue.async {
-            guard let fileUrl = self.fileUrl(for: collectionName) else {
+        queue.async { [weak self] in
+            guard let self = self, let fileUrl = self.fileUrl(for: collectionName) else {
                 return
             }
             if var dict = self.getDictFor(collectionName: collectionName) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Potentially fixes a crash that can happen in FileSystemNamedCollection due to a strongly held reference to self in an async block. Haven't been able to reproduce.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
