### PR TITLE
Retry hit processor requests failing with recoverable URL errors

### DIFF
--- a/AEPIdentity/Sources/IdentityHitProcessor.swift
+++ b/AEPIdentity/Sources/IdentityHitProcessor.swift
@@ -65,7 +65,7 @@ class IdentityHitProcessor: HitProcessing {
             // retry this hit later
             Log.debug(label: "\(LOG_TAG):\(#function)", "Retrying Identity hit, request with url \(hit.url.absoluteString) failed with error \(connection.error?.localizedDescription ?? "") and recoverable status code \(connection.responseCode ?? -1)")
             completion(false)
-        } else if let error = connection.error as? URLError, NetworkServiceConstants.RECOVERABLE_URL_ERROR_CODES.contains(error.code) {
+        } else if let error = connection.error as? URLError, error.isRecoverable {
             // retry this hit later as the request failed with a recoverable transport error
             Log.debug(label: "\(LOG_TAG):\(#function)", "Retrying Identity hit, request with url \(urlString) failed with error \(connection.error?.localizedDescription ?? "") and recoverable status code \(connection.responseCode ?? -1)")
             completion(false)

--- a/AEPIdentity/Sources/IdentityHitProcessor.swift
+++ b/AEPIdentity/Sources/IdentityHitProcessor.swift
@@ -65,6 +65,10 @@ class IdentityHitProcessor: HitProcessing {
             // retry this hit later
             Log.debug(label: "\(LOG_TAG):\(#function)", "Retrying Identity hit, request with url \(hit.url.absoluteString) failed with error \(connection.error?.localizedDescription ?? "") and recoverable status code \(connection.responseCode ?? -1)")
             completion(false)
+        } else if let error = connection.error as? URLError, NetworkServiceConstants.RECOVERABLE_URL_ERROR_CODES.contains(error.code) {
+            // retry this hit later as the request failed with a recoverable transport error
+            Log.debug(label: "\(LOG_TAG):\(#function)", "Retrying Identity hit, request with url \(urlString) failed with error \(connection.error?.localizedDescription ?? "") and recoverable status code \(connection.responseCode ?? -1)")
+            completion(false)
         } else {
             // unrecoverable error. delete the hit from the database and continue
             Log.warning(label: "\(LOG_TAG):\(#function)", "Dropping Identity hit, request with url \(urlString) failed with error \(connection.error?.localizedDescription ?? "") and unrecoverable status code \(connection.responseCode ?? -1)")

--- a/AEPIdentity/Tests/IdentityHitProcessorTests.swift
+++ b/AEPIdentity/Tests/IdentityHitProcessorTests.swift
@@ -73,34 +73,40 @@ class IdentityHitProcessorTests: XCTestCase {
         XCTAssertEqual(mockNetworkService?.getNetworkRequests().first?.url, expectedUrl) // network request should be made with the url in the hit
     }
 
-    /// Tests that when the network request fails but has a recoverable error that we will retry the hit and do not invoke the response handler for that hit
-    func testProcessHitRecoverableNetworkError() {
+    /// a response code in the list of `NetworkServiceConstants.RECOVERABLE_ERROR_CODES` should not result in
+    /// the `DataEntity` being removed from the queue
+    func testProcessHitRecoverableHTTPError() {
         // setup
-        let expectation = XCTestExpectation(description: "Callback should be invoked with true signaling this hit should be retried")
         let expectedUrl = URL(string: "adobe.com")!
         let expectedEvent = Event(name: "Hit Event", type: EventType.identity, source: EventSource.requestIdentity, data: nil)
         let hit = IdentityHit(url: expectedUrl, event: expectedEvent)
-        let testConnection = HttpConnection(data: nil, response: HTTPURLResponse(url: expectedUrl, statusCode: NetworkServiceConstants.RECOVERABLE_ERROR_CODES.first!, httpVersion: nil, headerFields: nil), error: nil)
         
-        mockNetworkService?.setMockResponse(url: expectedUrl, httpMethod: .get, responseConnection: testConnection)
+        NetworkServiceConstants.RECOVERABLE_ERROR_CODES.forEach { error in
+            let expectation = XCTestExpectation(description: "Callback should be invoked with true signaling this hit should not be retried")
+            mockNetworkService?.reset()
+            
+            let testConnection = HttpConnection(data: nil, response: HTTPURLResponse(url: expectedUrl, statusCode: error , httpVersion: nil, headerFields: nil), error: nil)
+            
+            mockNetworkService?.setMockResponse(url: expectedUrl, httpMethod: .get, responseConnection: testConnection)
 
-        let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try! JSONEncoder().encode(hit))
+            let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try! JSONEncoder().encode(hit))
 
-        // test
-        hitProcessor.processHit(entity: entity) { success in
-            XCTAssertFalse(success)
-            expectation.fulfill()
+            // test
+            hitProcessor.processHit(entity: entity) { success in
+                XCTAssertFalse(success)
+                expectation.fulfill()
+            }
+
+            // verify
+            wait(for: [expectation], timeout: 1)
+            XCTAssertTrue(responseCallbackArgs.isEmpty) // response handler should have not been invoked
+            XCTAssertTrue(mockNetworkService?.connectAsyncCalled ?? false) // network request should have been made
+            XCTAssertEqual(mockNetworkService?.getNetworkRequests().first?.url, expectedUrl) // network request should be made with the url in the hit
         }
-
-        // verify
-        wait(for: [expectation], timeout: 1)
-        XCTAssertTrue(responseCallbackArgs.isEmpty) // response handler should have not been invoked
-        XCTAssertTrue(mockNetworkService?.connectAsyncCalled ?? false) // network request should have been made
-        XCTAssertEqual(mockNetworkService?.getNetworkRequests().first?.url, expectedUrl) // network request should be made with the url in the hit
     }
 
-    /// Tests that when the network request fails and does not have a recoverable response code that we invoke the response handler and do not retry the hit
-    func testProcessHitUnrecoverableNetworkError() {
+    /// a response code that is not 2xx or in the recoverable list should result in removing the hit from the queue
+    func testProcessHitUnrecoverableHTTPError() {
         // setup
         let expectation = XCTestExpectation(description: "Callback should be invoked with true signaling this hit should not be retried")
         let expectedUrl = URL(string: "adobe.com")!
@@ -123,5 +129,71 @@ class IdentityHitProcessorTests: XCTestCase {
         XCTAssertFalse(responseCallbackArgs.isEmpty) // response handler should have been invoked
         XCTAssertTrue(mockNetworkService?.connectAsyncCalled ?? false) // network request should have been made
         XCTAssertEqual(mockNetworkService?.getNetworkRequests().first?.url, expectedUrl) // network request should be made with the url in the hit
+    }
+    
+    // an error in the list of `NetworkServiceConstants.RECOVERABLE_URL_ERROR_CODES` should not result in
+    /// the `DataEntity` being removed from the queue
+    func testProcessHitRecoverableURLError() throws {
+        // setup
+        let expectedUrl = URL(string: "adobe.com")!
+        let expectedEvent = Event(name: "Hit Event", type: EventType.identity, source: EventSource.requestIdentity, data: nil)
+        let hit = IdentityHit(url: expectedUrl, event: expectedEvent)
+        
+        NetworkServiceConstants.RECOVERABLE_URL_ERROR_CODES.forEach { error in
+            let expectation = XCTestExpectation(description: "Callback should be invoked with true signaling this hit should not be retried")
+            mockNetworkService?.reset()
+            
+            let testConnection = HttpConnection(data: nil, response: nil, error: URLError(error))
+            
+            mockNetworkService?.setMockResponse(url: expectedUrl, httpMethod: .get, responseConnection: testConnection)
+
+            let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try! JSONEncoder().encode(hit))
+
+            // test
+            hitProcessor.processHit(entity: entity) { success in
+                XCTAssertFalse(success)
+                expectation.fulfill()
+            }
+
+            // verify
+            wait(for: [expectation], timeout: 1)
+            XCTAssertTrue(responseCallbackArgs.isEmpty) // response handler should have not been invoked
+            XCTAssertTrue(mockNetworkService?.connectAsyncCalled ?? false) // network request should have been made
+            XCTAssertEqual(mockNetworkService?.getNetworkRequests().first?.url, expectedUrl) // network request should be made with the url in the hit
+        }
+    }
+    
+    // an error not in the list of `NetworkServiceConstants.RECOVERABLE_URL_ERROR_CODES` should result in
+    /// the `DataEntity` being removed from the queue
+    func testProcessHitUnrecoverableError() throws {
+        // setup
+        let expectedUrl = URL(string: "adobe.com")!
+        let expectedEvent = Event(name: "Hit Event", type: EventType.identity, source: EventSource.requestIdentity, data: nil)
+        let hit = IdentityHit(url: expectedUrl, event: expectedEvent)
+        
+        // Errors not in recoverable error list
+        let unrecoverableErrors:[Error] = [AEPError.networkError, URLError(URLError.badURL)]
+        unrecoverableErrors.forEach { error in
+            let expectation = XCTestExpectation(description: "Callback should be invoked with true signaling this hit should not be retried")
+            mockNetworkService?.reset()
+            
+            let testConnection = HttpConnection(data: nil, response: nil, error: error)
+            
+            mockNetworkService?.setMockResponse(url: expectedUrl, httpMethod: .get, responseConnection: testConnection)
+            
+            let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try! JSONEncoder().encode(hit))
+            
+            // test
+            hitProcessor.processHit(entity: entity) { success in
+                XCTAssertTrue(success)
+                expectation.fulfill()
+            }
+            
+            // verify
+            wait(for: [expectation], timeout: 1)
+            XCTAssertFalse(responseCallbackArgs.isEmpty) // response handler should have been invoked
+            XCTAssertTrue(mockNetworkService?.connectAsyncCalled ?? false) // network request should have been made
+            XCTAssertEqual(mockNetworkService?.getNetworkRequests().first?.url, expectedUrl) // network request should be made with the url in the hit
+        }
     }
 }

--- a/AEPIdentity/Tests/IdentityHitProcessorTests.swift
+++ b/AEPIdentity/Tests/IdentityHitProcessorTests.swift
@@ -82,7 +82,7 @@ class IdentityHitProcessorTests: XCTestCase {
         let hit = IdentityHit(url: expectedUrl, event: expectedEvent)
         
         NetworkServiceConstants.RECOVERABLE_ERROR_CODES.forEach { error in
-            let expectation = XCTestExpectation(description: "Callback should be invoked with true signaling this hit should not be retried")
+            let expectation = XCTestExpectation(description: "Callback should be invoked with false signaling this hit should be retried")
             mockNetworkService?.reset()
             
             let testConnection = HttpConnection(data: nil, response: HTTPURLResponse(url: expectedUrl, statusCode: error , httpVersion: nil, headerFields: nil), error: nil)
@@ -140,7 +140,7 @@ class IdentityHitProcessorTests: XCTestCase {
         let hit = IdentityHit(url: expectedUrl, event: expectedEvent)
         
         NetworkServiceConstants.RECOVERABLE_URL_ERROR_CODES.forEach { error in
-            let expectation = XCTestExpectation(description: "Callback should be invoked with true signaling this hit should not be retried")
+            let expectation = XCTestExpectation(description: "Callback should be invoked with false signaling this hit should be retried")
             mockNetworkService?.reset()
             
             let testConnection = HttpConnection(data: nil, response: nil, error: URLError(error))

--- a/AEPSignal/Sources/SignalHitProcessor.swift
+++ b/AEPSignal/Sources/SignalHitProcessor.swift
@@ -70,6 +70,10 @@ class SignalHitProcessor: HitProcessing {
             // retry this hit later
             Log.debug(label: LOG_TAG, "Signal request failed with recoverable error \(connection.error?.localizedDescription ?? "") and status code \(connection.responseCode ?? -1). Will retry sending the request later: \(hit.url.absoluteString)")
             completion(false)
+        } else if let error = connection.error as? URLError, NetworkServiceConstants.RECOVERABLE_URL_ERROR_CODES.contains(error.code) {
+            // retry this hit later as the request failed with a recoverable transport error
+            Log.debug(label: LOG_TAG, "Signal request failed with unrecoverable error \(connection.error?.localizedDescription ?? "") and status code \(connection.responseCode ?? -1). It will be dropped from the queue: \(urlString)")
+            completion(false)
         } else {
             // unrecoverable error. delete the hit from the database and continue
             Log.warning(label: LOG_TAG, "Signal request failed with unrecoverable error \(connection.error?.localizedDescription ?? "") and status code \(connection.responseCode ?? -1). It will be dropped from the queue: \(urlString)")

--- a/AEPSignal/Sources/SignalHitProcessor.swift
+++ b/AEPSignal/Sources/SignalHitProcessor.swift
@@ -70,7 +70,7 @@ class SignalHitProcessor: HitProcessing {
             // retry this hit later
             Log.debug(label: LOG_TAG, "Signal request failed with recoverable error \(connection.error?.localizedDescription ?? "") and status code \(connection.responseCode ?? -1). Will retry sending the request later: \(hit.url.absoluteString)")
             completion(false)
-        } else if let error = connection.error as? URLError, NetworkServiceConstants.RECOVERABLE_URL_ERROR_CODES.contains(error.code) {
+        } else if let error = connection.error as? URLError, error.isRecoverable {
             // retry this hit later as the request failed with a recoverable transport error
             Log.debug(label: LOG_TAG, "Signal request failed with unrecoverable error \(connection.error?.localizedDescription ?? "") and status code \(connection.responseCode ?? -1). It will be dropped from the queue: \(urlString)")
             completion(false)


### PR DESCRIPTION
Currently, the hit processor drops a hit even when the network request fails due to a recoverable error. Fix the processing logic to retry when the network failure occurs due to one of the `NetworkServiceConstants.RECOVERABLE_URL_ERROR_CODES`.