### PR TITLE
[MOB-21055] Make sharedStateName var synchronous

### DIFF
--- a/AEPCore/Sources/eventhub/ExtensionContainer.swift
+++ b/AEPCore/Sources/eventhub/ExtensionContainer.swift
@@ -28,7 +28,7 @@ class ExtensionContainer {
     /// The XDM `SharedState` associated with the extension
     var xdmSharedState: SharedState?
 
-    var sharedStateName: String = "invalidSharedStateName"
+    private var _sharedStateName: String = "invalidSharedStateName"
 
     /// The extension's dispatch queue
     let extensionQueue: DispatchQueue
@@ -44,6 +44,19 @@ class ExtensionContainer {
 
     private var _lastProcessedEvent: Event?
 
+    var sharedStateName: String {
+        get {
+            containerQueue.sync {
+                return _sharedStateName
+            }
+        }
+        set {
+            containerQueue.sync {
+                _sharedStateName = newValue
+            }
+        }
+    }
+    
     /// The last `Event` that was processed by this extension, nil if no events have been processed
     var lastProcessedEvent: Event? {
         get {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The sharedStateName is accessed from the ExtensionContainers init, and from the registerEventListener function leading to potential races. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
