### PR TITLE
Fix race conditions

### DIFF
--- a/AEPServices/Sources/ApplicationSystemInfoService.swift
+++ b/AEPServices/Sources/ApplicationSystemInfoService.swift
@@ -26,6 +26,9 @@ class ApplicationSystemInfoService: SystemInfoService {
     private let DEFAULT_LOCALE = "en-US"
 
     private let bundle: Bundle
+
+    private let queue = DispatchQueue(label: "com.adobe.applicationSystemInfoService.queue")
+
     private lazy var userAgent: String = {
         let model = UIDevice.current.model
         let osVersion = UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")
@@ -68,7 +71,10 @@ class ApplicationSystemInfoService: SystemInfoService {
     }
 
     func getDefaultUserAgent() -> String {
-        return userAgent
+        // Ensure the lazy variable is initialized correctly during concurrent API calls.
+        queue.sync {
+            return userAgent
+        }
     }
 
     func getActiveLocaleName() -> String {

--- a/AEPServices/Sources/cache/DiskCacheService.swift
+++ b/AEPServices/Sources/cache/DiskCacheService.swift
@@ -14,7 +14,7 @@ import Foundation
 
 /// Implements a cache which saves and retrieves data from the disk
 class DiskCacheService: Caching {
-    lazy var dataStore = NamedCollectionDataStore(name: "DiskCacheService")
+    var dataStore = NamedCollectionDataStore(name: "DiskCacheService")
     let cachePrefix = "com.adobe.mobile.diskcache/"
     let fileManager = FileManager.default
     private let LOG_PREFIX = "DiskCacheService"
@@ -35,7 +35,6 @@ class DiskCacheService: Caching {
         }
         
         let attributes: [String: Any] = [
-
             EXPIRY_DATE: entry.expiry.date.timeIntervalSince1970,
             METADATA: newMetadata
         ]

--- a/AEPServices/Sources/cache/DiskCacheService.swift
+++ b/AEPServices/Sources/cache/DiskCacheService.swift
@@ -14,9 +14,9 @@ import Foundation
 
 /// Implements a cache which saves and retrieves data from the disk
 class DiskCacheService: Caching {
-    var dataStore = NamedCollectionDataStore(name: "DiskCacheService")
-    let cachePrefix = "com.adobe.mobile.diskcache/"
-    let fileManager = FileManager.default
+    private let dataStore = NamedCollectionDataStore(name: "DiskCacheService")
+    private let cachePrefix = "com.adobe.mobile.diskcache/"
+    private let fileManager = FileManager.default
     private let LOG_PREFIX = "DiskCacheService"
     private let EXPIRY_DATE = "expirydate"
     private let METADATA = "metadata"

--- a/AEPServices/Sources/storage/NamedCollectionDataStore.swift
+++ b/AEPServices/Sources/storage/NamedCollectionDataStore.swift
@@ -14,11 +14,12 @@ import Foundation
 
 /// The named key value storage object to be used to store and retrieve values
 public class NamedCollectionDataStore {
-    private var storageService: NamedCollectionProcessing
+    private var storageService: NamedCollectionProcessing {
+        get { ServiceProvider.shared.namedKeyValueService }
+    }
     private var name: String
 
     public init(name: String) {
-        storageService = ServiceProvider.shared.namedKeyValueService
         self.name = name
     }
 


### PR DESCRIPTION

Fix race conditions due to lazy initialization.



<details>
<summary>ExtensionContainer</summary>

```
WARNING: ThreadSanitizer: data race (pid=36565)
  Write of size 8 at 0x00010af09390 by thread T10:
    #0 AEPCore.ExtensionContainer.sharedStateName.setter : Swift.String <null> (AEPCore:arm64+0x665b4)
    #1 closure #1 @Sendable () -> () in AEPCore.ExtensionContainer.init(_: Swift.String, _: AEPCore.Extension.Type, _: __C.OS_dispatch_queue, completion: (Swift.Optional<AEPCore.EventHubError>) -> ()) -> AEPCore.ExtensionContainer <null> (AEPCore:arm64+0x68df0)
    #2 partial apply forwarder for closure #1 @Sendable () -> () in AEPCore.ExtensionContainer.init(_: Swift.String, _: AEPCore.Extension.Type, _: __C.OS_dispatch_queue, completion: (Swift.Optional<AEPCore.EventHubError>) -> ()) -> AEPCore.ExtensionContainer <null> (AEPCore:arm64+0x68f30)
    #3 reabstraction thunk helper from @escaping @callee_guaranteed @Sendable () -> () to @escaping @callee_unowned @convention(block) @Sendable () -> () <null> (AEPCore:arm64+0xec28)
    #4 __tsan::invoke_and_release_block(void*) <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x77ee0)
    #5 _dispatch_client_callout <null> (libdispatch.dylib:arm64+0x5938)

  Previous read of size 8 at 0x00010af09390 by thread T8:
    #0 AEPCore.ExtensionContainer.sharedStateName.getter : Swift.String <null> (AEPCore:arm64+0x6650c)
    #1 closure #1 (Swift.String, AEPCore.ExtensionContainer) -> Swift.Bool in AEPCore.EventHub.(versionSharedState in _9BC38C3821775527AA936A3A1E9D703A)(extensionName: Swift.String, event: Swift.Optional<AEPCore.Event>, sharedStateType: AEPCore.SharedStateType) -> Swift.Optional<(AEPCore.SharedState, Swift.Int)> <null> (AEPCore:arm64+0x531c8)
    #2 partial apply forwarder for closure #1 (Swift.String, AEPCore.ExtensionContainer) -> Swift.Bool in AEPCore.EventHub.(versionSharedState in _9BC38C3821775527AA936A3A1E9D703A)(extensionName: Swift.String, event: Swift.Optional<AEPCore.Event>, sharedStateType: AEPCore.SharedStateType) -> Swift.Optional<(AEPCore.SharedState, Swift.Int)> <null> (AEPCore:arm64+0x541c4)
    #3 reabstraction thunk helper from @callee_guaranteed (@guaranteed Swift.String, @guaranteed AEPCore.ExtensionContainer) -> (@unowned Swift.Bool, @error @owned Swift.Error) to @escaping @callee_guaranteed (@in_guaranteed Swift.String, @in_guaranteed AEPCore.ExtensionContainer) -> (@unowned Swift.Bool, @error @owned Swift.Error) <null> (AEPCore:arm64+0x4a3e0)
    #4 reabstraction thunk helper from @callee_guaranteed (@guaranteed Swift.String, @guaranteed AEPCore.ExtensionContainer) -> (@unowned Swift.Bool, @error @owned Swift.Error) to @escaping @callee_guaranteed (@in_guaranteed Swift.String, @in_guaranteed AEPCore.ExtensionContainer) -> (@unowned Swift.Bool, @error @owned Swift.Error)partial apply forwarder with unmangled suffix ".98" <null> (AEPCore:arm64+0x54240)
    #5 reabstraction thunk helper <A, B where A: Swift.Hashable> from @callee_guaranteed (@in_guaranteed A, @in_guaranteed B) -> (@unowned Swift.Bool, @error @owned Swift.Error) to @escaping @callee_guaranteed (@in_guaranteed (key: A, value: B)) -> (@unowned Swift.Bool, @error @owned Swift.Error) <null> (AEPServices:arm64+0xa105c)
    #6 partial apply forwarder for reabstraction thunk helper <A, B where A: Swift.Hashable> from @callee_guaranteed (@in_guaranteed A, @in_guaranteed B) -> (@unowned Swift.Bool, @error @owned Swift.Error) to @escaping @callee_guaranteed (@in_guaranteed (key: A, value: B)) -> (@unowned Swift.Bool, @error @owned Swift.Error) <null> (AEPServices:arm64+0xa19d8)
    #7 (extension in Swift):Swift.Sequence.first(where: (A.Element) throws -> Swift.Bool) throws -> Swift.Optional<A.Element> <null> (libswiftCore.dylib:arm64+0x114a54)
    #8 partial apply forwarder for closure #1 () -> Swift.Optional<(key: A, value: B)> in AEPServices.ThreadSafeDictionary.first(where: ((key: A, value: B)) throws -> Swift.Bool) throws -> Swift.Optional<(key: A, value: B)> <null> (AEPServices:arm64+0xa0fac)
    #9 partial apply forwarder for reabstraction thunk helper <A> from @callee_guaranteed () -> (@out A, @error @owned Swift.Error) to @escaping @callee_guaranteed () -> (@out A, @error @owned Swift.Error) <null> (libswiftDispatch.dylib:arm64+0xaf44)
    #10 _dispatch_client_callout <null> (libdispatch.dylib:arm64+0x5938)
    #11 merged implicit closure #2 (() -> ()) -> () in implicit closure #1 (__C.OS_dispatch_queue) -> (() -> ()) -> () in (extension in Dispatch):__C.OS_dispatch_queue.asyncAndWait<A>(execute: () throws -> A) throws -> A <null> (libswiftDispatch.dylib:arm64+0x93e8)
    #12 AEPCore.EventHub.(versionSharedState in _9BC38C3821775527AA936A3A1E9D703A)(extensionName: Swift.String, event: Swift.Optional<AEPCore.Event>, sharedStateType: AEPCore.SharedStateType) -> Swift.Optional<(AEPCore.SharedState, Swift.Int)> <null> (AEPCore:arm64+0x4b500)
    #13 closure #1 @Sendable () -> () in AEPCore.EventHub.createSharedState(extensionName: Swift.String, data: Swift.Optional<Swift.Dictionary<Swift.String, Any>>, event: Swift.Optional<AEPCore.Event>, sharedStateType: AEPCore.SharedStateType) -> () <null> (AEPCore:arm64+0x4aacc)
    #14 partial apply forwarder for closure #1 @Sendable () -> () in AEPCore.EventHub.createSharedState(extensionName: Swift.String, data: Swift.Optional<Swift.Dictionary<Swift.String, Any>>, event: Swift.Optional<AEPCore.Event>, sharedStateType: AEPCore.SharedStateType) -> () <null> (AEPCore:arm64+0x5160c)
    #15 reabstraction thunk helper from @escaping @callee_guaranteed @Sendable () -> () to @escaping @callee_unowned @convention(block) @Sendable () -> () <null> (AEPCore:arm64+0xec28)
    #16 __tsan::invoke_and_release_block(void*) <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x77ee0)
    #17 _dispatch_client_callout <null> (libdispatch.dylib:arm64+0x5938)

  Location is heap block of size 96 at 0x00010af09360 allocated by thread T1:
    #0 __sanitizer_mz_malloc <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x4fe90)
    #1 _malloc_zone_malloc_instrumented_or_legacy <null> (libsystem_malloc.dylib:arm64+0x20cd0)
    #2 closure #1 @Sendable () -> () in AEPCore.EventHub.registerExtension(_: AEPCore.Extension.Type, completion: (Swift.Optional<AEPCore.EventHubError>) -> ()) -> () <null> (AEPCore:arm64+0x474b0)
    #3 partial apply forwarder for closure #1 @Sendable () -> () in AEPCore.EventHub.registerExtension(_: AEPCore.Extension.Type, completion: (Swift.Optional<AEPCore.EventHubError>) -> ()) -> () <null> (AEPCore:arm64+0x47bc4)
    #4 reabstraction thunk helper from @escaping @callee_guaranteed @Sendable () -> () to @escaping @callee_unowned @convention(block) @Sendable () -> () <null> (AEPCore:arm64+0xec28)
    #5 __tsan::invoke_and_release_block(void*) <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x77ee0)
    #6 _dispatch_client_callout <null> (libdispatch.dylib:arm64+0x5938)

  Thread T10 (tid=5300953, running) is a GCD worker thread

  Thread T8 (tid=5300952, running) is a GCD worker thread

  Thread T1 (tid=5300940, running) is a GCD worker thread
```
</details>

<details>
<summary>userAgent</summary>

```
WARNING: ThreadSanitizer: data race (pid=35516)
  Write of size 8 at 0x00010ae53d28 by thread T11:
    #0 AEPServices.ApplicationSystemInfoService.(userAgent in _60B492D01378A49183AB093178FD6533).getter : Swift.String <null> (AEPServices:arm64+0xad74)
    #1 AEPServices.ApplicationSystemInfoService.getDefaultUserAgent() -> Swift.String <null> (AEPServices:arm64+0xd68c)
    #2 protocol witness for AEPServices.SystemInfoService.getDefaultUserAgent() -> Swift.String in conformance AEPServices.ApplicationSystemInfoService : AEPServices.SystemInfoService in AEPServices <null> (AEPServices:arm64+0x117e0)
    #3 AEPServices.NetworkRequest.init(url: Foundation.URL, httpMethod: AEPServices.HttpMethod, connectPayloadData: Foundation.Data, httpHeaders: Swift.Dictionary<Swift.String, Swift.String>, connectTimeout: Swift.Double, readTimeout: Swift.Double) -> AEPServices.NetworkRequest <null> (AEPServices:arm64+0x764ec)
    #4 AEPServices.NetworkRequest.__allocating_init(url: Foundation.URL, httpMethod: AEPServices.HttpMethod, connectPayloadData: Foundation.Data, httpHeaders: Swift.Dictionary<Swift.String, Swift.String>, connectTimeout: Swift.Double, readTimeout: Swift.Double) -> AEPServices.NetworkRequest <null> (AEPServices:arm64+0x75ff0)
    #5 AEPServices.NetworkRequest.__allocating_init(url: Foundation.URL, httpMethod: AEPServices.HttpMethod, connectPayload: Swift.String, httpHeaders: Swift.Dictionary<Swift.String, Swift.String>, connectTimeout: Swift.Double, readTimeout: Swift.Double) -> AEPServices.NetworkRequest <null> (AEPServices:arm64+0x75ef4)
    #6 AEPCore.ConfigurationDownloader.loadConfigFromUrl(appId: Swift.String, dataStore: AEPServices.NamedCollectionDataStore, completion: (Swift.Optional<Swift.Dictionary<Swift.String, Any>>) -> ()) -> () <null> (AEPCore:arm64+0x163f8)
    #7 protocol witness for AEPCore.ConfigurationDownloadable.loadConfigFromUrl(appId: Swift.String, dataStore: AEPServices.NamedCollectionDataStore, completion: (Swift.Optional<Swift.Dictionary<Swift.String, Any>>) -> ()) -> () in conformance AEPCore.ConfigurationDownloader : AEPCore.ConfigurationDownloadable in AEPCore <null> (AEPCore:arm64+0x17e8c)
    #8 AEPCore.ConfigurationState.updateWith(appId: Swift.String, completion: (Swift.Optional<Swift.Dictionary<Swift.String, Any>>) -> ()) -> () <null> (AEPCore:arm64+0x1aa84)
    #9 AEPCore.Configuration.(processConfigureWith in _CE924D1D3DE59CCFAD68F426C90E3E41)(appId: Swift.String, event: AEPCore.Event, sharedStateResolver: (Swift.Optional<Swift.Dictionary<Swift.String, Any>>) -> ()) -> () <null> (AEPCore:arm64+0xd1e8)
    #10 AEPCore.Configuration.(receiveConfigurationRequest in _CE924D1D3DE59CCFAD68F426C90E3E41)(event: AEPCore.Event) -> () <null> (AEPCore:arm64+0xc9b0)
    #11 implicit closure #4 (AEPCore.Event) -> () in implicit closure #3 (AEPCore.Configuration) -> (AEPCore.Event) -> () in AEPCore.Configuration.onRegistered() -> () <null> (AEPCore:arm64+0xc480)
    #12 partial apply forwarder for implicit closure #4 (AEPCore.Event) -> () in implicit closure #3 (AEPCore.Configuration) -> (AEPCore.Event) -> () in AEPCore.Configuration.onRegistered() -> () <null> (AEPCore:arm64+0x11958)
    #13 reabstraction thunk helper from @escaping @callee_guaranteed (@guaranteed AEPCore.Event) -> () to @escaping @callee_unowned @convention(block) (@unowned AEPCore.Event) -> () <null> (AEPCore:arm64+0x49b54)
    #14 reabstraction thunk helper from @escaping @callee_unowned @convention(block) (@unowned AEPCore.Event) -> () to @escaping @callee_guaranteed (@guaranteed AEPCore.Event) -> () <null> (AEPCore:arm64+0x69778)
    #15 partial apply forwarder for reabstraction thunk helper from @escaping @callee_unowned @convention(block) (@unowned AEPCore.Event) -> () to @escaping @callee_guaranteed (@guaranteed AEPCore.Event) -> () <null> (AEPCore:arm64+0x6bc14)
    #16 AEPCore.ExtensionContainer.(eventProcessor in _B141A8AA9A656F8CCDC73CDE1C7E6E50)(AEPCore.Event) -> Swift.Bool <null> (AEPCore:arm64+0x68140)
    #17 implicit closure #2 (AEPCore.Event) -> Swift.Bool in implicit closure #1 (AEPCore.ExtensionContainer) -> (AEPCore.Event) -> Swift.Bool in AEPCore.ExtensionContainer.init(_: Swift.String, _: AEPCore.Extension.Type, _: __C.OS_dispatch_queue, completion: (Swift.Optional<AEPCore.EventHubError>) -> ()) -> AEPCore.ExtensionContainer <null> (AEPCore:arm64+0x67d28)
    #18 partial apply forwarder for implicit closure #2 (AEPCore.Event) -> Swift.Bool in implicit closure #1 (AEPCore.ExtensionContainer) -> (AEPCore.Event) -> Swift.Bool in AEPCore.ExtensionContainer.init(_: Swift.String, _: AEPCore.Extension.Type, _: __C.OS_dispatch_queue, completion: (Swift.Optional<AEPCore.EventHubError>) -> ()) -> AEPCore.ExtensionContainer <null> (AEPCore:arm64+0x6bd70)
    #19 reabstraction thunk helper from @escaping @callee_guaranteed (@guaranteed AEPCore.Event) -> (@unowned Swift.Bool) to @escaping @callee_guaranteed (@in_guaranteed AEPCore.Event) -> (@unowned Swift.Bool) <null> (AEPCore:arm64+0x6825c)
    #20 partial apply forwarder for reabstraction thunk helper from @escaping @callee_guaranteed (@guaranteed AEPCore.Event) -> (@unowned Swift.Bool) to @escaping @callee_guaranteed (@in_guaranteed AEPCore.Event) -> (@unowned Swift.Bool) <null> (AEPCore:arm64+0x68308)
    #21 AEPServices.OperationOrderer.(drain in _0F3002D2802B3BC91D6EEC974D4BCC05)() -> () <null> (AEPServices:arm64+0x7e6c8)
    #22 implicit closure #2 () -> () in implicit closure #1 (AEPServices.OperationOrderer<A>) -> () -> () in AEPServices.OperationOrderer.init(Swift.String) -> AEPServices.OperationOrderer<A> <null> (AEPServices:arm64+0x7cb30)
    #23 partial apply forwarder for implicit closure #2 () -> () in implicit closure #1 (AEPServices.OperationOrderer<A>) -> () -> () in AEPServices.OperationOrderer.init(Swift.String) -> AEPServices.OperationOrderer<A> <null> (AEPServices:arm64+0x7f0b4)
    #24 reabstraction thunk helper from @escaping @callee_guaranteed () -> () to @escaping @callee_unowned @convention(block) () -> () <null> (AEPServices:arm64+0x3ace8)
    #25 __tsan::dispatch_callback_wrap(void*) <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x77d50)
    #26 _dispatch_client_callout <null> (libdispatch.dylib:arm64+0x5938)

  Previous read of size 8 at 0x00010ae53d28 by thread T7:
    #0 AEPServices.ApplicationSystemInfoService.(userAgent in _60B492D01378A49183AB093178FD6533).getter : Swift.String <null> (AEPServices:arm64+0xacac)
    #1 AEPServices.ApplicationSystemInfoService.getDefaultUserAgent() -> Swift.String <null> (AEPServices:arm64+0xd68c)
    #2 protocol witness for AEPServices.SystemInfoService.getDefaultUserAgent() -> Swift.String in conformance AEPServices.ApplicationSystemInfoService : AEPServices.SystemInfoService in AEPServices <null> (AEPServices:arm64+0x117e0)
    #3 AEPServices.NetworkRequest.init(url: Foundation.URL, httpMethod: AEPServices.HttpMethod, connectPayloadData: Foundation.Data, httpHeaders: Swift.Dictionary<Swift.String, Swift.String>, connectTimeout: Swift.Double, readTimeout: Swift.Double) -> AEPServices.NetworkRequest <null> (AEPServices:arm64+0x764ec)
    #4 AEPServices.NetworkRequest.__allocating_init(url: Foundation.URL, httpMethod: AEPServices.HttpMethod, connectPayloadData: Foundation.Data, httpHeaders: Swift.Dictionary<Swift.String, Swift.String>, connectTimeout: Swift.Double, readTimeout: Swift.Double) -> AEPServices.NetworkRequest <null> (AEPServices:arm64+0x75ff0)
    #5 AEPServices.NetworkRequest.__allocating_init(url: Foundation.URL, httpMethod: AEPServices.HttpMethod, connectPayload: Swift.String, httpHeaders: Swift.Dictionary<Swift.String, Swift.String>, connectTimeout: Swift.Double, readTimeout: Swift.Double) -> AEPServices.NetworkRequest <null> (AEPServices:arm64+0x75ef4)
    #6 AEPIdentity.IdentityHitProcessor.processHit(entity: AEPServices.DataEntity, completion: (Swift.Bool) -> ()) -> () <null> (AEPIdentity:arm64+0x29d78)
    #7 protocol witness for AEPServices.HitProcessing.processHit(entity: AEPServices.DataEntity, completion: (Swift.Bool) -> ()) -> () in conformance AEPIdentity.IdentityHitProcessor : AEPServices.HitProcessing in AEPIdentity <null> (AEPIdentity:arm64+0x2c3a4)
    #8 closure #1 @Sendable () -> () in AEPServices.PersistentHitQueue.(processNextHit in _B8609AAEF0FC9D992E8CAC252036A882)() -> () <null> (AEPServices:arm64+0x80854)
    #9 partial apply forwarder for closure #1 @Sendable () -> () in AEPServices.PersistentHitQueue.(processNextHit in _B8609AAEF0FC9D992E8CAC252036A882)() -> () <null> (AEPServices:arm64+0x817a8)
    #10 reabstraction thunk helper from @escaping @callee_guaranteed @Sendable () -> () to @escaping @callee_unowned @convention(block) @Sendable () -> () <null> (AEPServices:arm64+0x2d124)
    #11 __tsan::invoke_and_release_block(void*) <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x77ee0)
    #12 _dispatch_client_callout <null> (libdispatch.dylib:arm64+0x5938)

  Location is heap block of size 56 at 0x00010ae53d00 allocated by main thread:
    #0 __sanitizer_mz_malloc <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x4fe90)
    #1 _malloc_zone_malloc_instrumented_or_legacy <null> (libsystem_malloc.dylib:arm64+0x20cd0)
    #2 AEPServices.ServiceProvider.() -> AEPServices.ServiceProvider(in _C1436E9173A676408550A7049CEF4764).init() -> AEPServices.ServiceProvider <null> (AEPServices:arm64+0x84308)
    #3 AEPServices.ServiceProvider.__allocating_init() -> AEPServices.ServiceProvider <null> (AEPServices:arm64+0x823d4)
    #4 one-time initialization function for shared <null> (AEPServices:arm64+0x8234c)
    #5 dispatch_once <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x78d30)
    #6 dispatch_once_f <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x78dcc)
    #7 AEPServices.ServiceProvider.shared.unsafeMutableAddressor : AEPServices.ServiceProvider <null> (AEPServices:arm64+0x82480)
    #8 static AEPServices.ServiceProvider.shared.getter : AEPServices.ServiceProvider <null> (AEPServices:arm64+0x824b4)
    #9 AEPCore.V4Migrator.(v4Defaults in _AD8F5075FFFB0AEDF94D735A3A0419C5).getter : __C.NSUserDefaults <null> (AEPCore:arm64+0xcc10c)
    #10 AEPCore.V4Migrator.(defaultsNeedsMigration in _AD8F5075FFFB0AEDF94D735A3A0419C5)() -> Swift.Bool <null> (AEPCore:arm64+0xcc720)
    #11 AEPCore.V4Migrator.migrate() -> () <null> (AEPCore:arm64+0xcc42c)
    #12 static AEPCore.MobileCore.registerExtensions(Swift.Array<__C.NSObject.Type>, Swift.Optional<() -> ()>) -> () <null> (AEPCore:arm64+0x99984)
    #13 AEPSampleApp.AppDelegate.application(_: __C.UIApplication, didFinishLaunchingWithOptions: Swift.Optional<Swift.Dictionary<__C.UIApplicationLaunchOptionsKey, Any>>) -> Swift.Bool <null> (AEPSampleApp:arm64+0x10009d154)
    #14 @objc AEPSampleApp.AppDelegate.application(_: __C.UIApplication, didFinishLaunchingWithOptions: Swift.Optional<Swift.Dictionary<__C.UIApplicationLaunchOptionsKey, Any>>) -> Swift.Bool <null> (AEPSampleApp:arm64+0x10009df68)
    #15 -[UIApplication _handleDelegateCallbacksWithOptions:isSuspended:restoreState:] <null> (UIKitCore:arm64+0xbb49cc)
    #16 <null> <null> (0x000104fc1558)

  Thread T11 (tid=5282693, running) is a GCD worker thread

  Thread T7 (tid=5282687, running) is a GCD worker thread

SUMMARY: ThreadSanitizer: data race (/Users/praveen/Library/Developer/CoreSimulator/Devices/5DCDA7B5-68B6-4442-9C23-059D7E360580/data/Containers/Bundle/Application/DF7929C9-DB83-42A8-BF4E-F11E10B4B59F/AEPSampleApp.app/Frameworks/AEPServices.framework/AEPServices:arm64+0xad74) in AEPServices.ApplicationSystemInfoService.(userAgent in _60B492D01378A49183AB093178FD6533).getter : Swift.String+0x120

```
</details>


<details>
<summary>DiskCacheService</summary>

```
==================
WARNING: ThreadSanitizer: data race (pid=36060)
  Write of size 8 at 0x00010e2142f0 by thread T6:
    #0 AEPServices.DiskCacheService.dataStore.getter : AEPServices.NamedCollectionDataStore <null> (AEPServices:arm64+0x252f8)
    #1 AEPServices.DiskCacheService.get(cacheName: Swift.String, key: Swift.String) -> Swift.Optional<AEPServices.CacheEntry> <null> (AEPServices:arm64+0x26d70)
    #2 protocol witness for AEPServices.Caching.get(cacheName: Swift.String, key: Swift.String) -> Swift.Optional<AEPServices.CacheEntry> in conformance AEPServices.DiskCacheService : AEPServices.Caching in AEPServices <null> (AEPServices:arm64+0x29c68)
    #3 AEPServices.Cache.get(key: Swift.String) -> Swift.Optional<AEPServices.CacheEntry> <null> (AEPServices:arm64+0x18ff8)
    #4 dispatch thunk of AEPServices.Cache.get(key: Swift.String) -> Swift.Optional<AEPServices.CacheEntry> <null> (AEPServices:arm64+0x19f10)
    #5 AEPCore.RulesDownloader.(getCachedRules in _FF50A3CA310452AA0A406007A2DFBD14)(rulesUrl: Swift.String) -> Swift.Optional<AEPCore.CachedRules> <null> (AEPCore:arm64+0xa5318)
    #6 AEPCore.RulesDownloader.loadRulesFromCache(rulesUrl: Foundation.URL) -> Swift.Optional<Foundation.Data> <null> (AEPCore:arm64+0xa5080)
    #7 AEPCore.LaunchRulesEngine.replaceRulesWithCache(from: Swift.String) -> Swift.Bool <null> (AEPCore:arm64+0x96490)
    #8 AEPCore.Configuration.onRegistered() -> () <null> (AEPCore:arm64+0xbc88)
    #9 @objc AEPCore.Configuration.onRegistered() -> () <null> (AEPCore:arm64+0xc4ec)
    #10 closure #1 @Sendable () -> () in AEPCore.ExtensionContainer.init(_: Swift.String, _: AEPCore.Extension.Type, _: __C.OS_dispatch_queue, completion: (Swift.Optional<AEPCore.EventHubError>) -> ()) -> AEPCore.ExtensionContainer <null> (AEPCore:arm64+0x68cf8)
    #11 partial apply forwarder for closure #1 @Sendable () -> () in AEPCore.ExtensionContainer.init(_: Swift.String, _: AEPCore.Extension.Type, _: __C.OS_dispatch_queue, completion: (Swift.Optional<AEPCore.EventHubError>) -> ()) -> AEPCore.ExtensionContainer <null> (AEPCore:arm64+0x68e00)
    #12 reabstraction thunk helper from @escaping @callee_guaranteed @Sendable () -> () to @escaping @callee_unowned @convention(block) @Sendable () -> () <null> (AEPCore:arm64+0xe2a4)
    #13 __tsan::invoke_and_release_block(void*) <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x77ee0)
    #14 _dispatch_client_callout <null> (libdispatch.dylib:arm64+0x5938)

  Previous read of size 8 at 0x00010e2142f0 by thread T8:
    #0 AEPServices.DiskCacheService.dataStore.getter : AEPServices.NamedCollectionDataStore <null> (AEPServices:arm64+0x25218)
    #1 AEPServices.DiskCacheService.get(cacheName: Swift.String, key: Swift.String) -> Swift.Optional<AEPServices.CacheEntry> <null> (AEPServices:arm64+0x26d70)
    #2 protocol witness for AEPServices.Caching.get(cacheName: Swift.String, key: Swift.String) -> Swift.Optional<AEPServices.CacheEntry> in conformance AEPServices.DiskCacheService : AEPServices.Caching in AEPServices <null> (AEPServices:arm64+0x29c68)
    #3 AEPServices.Cache.get(key: Swift.String) -> Swift.Optional<AEPServices.CacheEntry> <null> (AEPServices:arm64+0x18ff8)
    #4 dispatch thunk of AEPServices.Cache.get(key: Swift.String) -> Swift.Optional<AEPServices.CacheEntry> <null> (AEPServices:arm64+0x19f10)
    #5 AEPMessaging.MessagingRulesEngine.loadCachedPropositions(for: Swift.String) -> () <null> (AEPMessaging:arm64+0x44998)
    #6 AEPMessaging.Messaging.init(runtime: AEPCore.ExtensionRuntime) -> Swift.Optional<AEPMessaging.Messaging> <null> (AEPMessaging:arm64+0x1a490)
    #7 @objc AEPMessaging.Messaging.init(runtime: AEPCore.ExtensionRuntime) -> Swift.Optional<AEPMessaging.Messaging> <null> (AEPMessaging:arm64+0x1a57c)
    #8 closure #1 @Sendable () -> () in AEPCore.ExtensionContainer.init(_: Swift.String, _: AEPCore.Extension.Type, _: __C.OS_dispatch_queue, completion: (Swift.Optional<AEPCore.EventHubError>) -> ()) -> AEPCore.ExtensionContainer <null> (AEPCore:arm64+0x6844c)
    #9 partial apply forwarder for closure #1 @Sendable () -> () in AEPCore.ExtensionContainer.init(_: Swift.String, _: AEPCore.Extension.Type, _: __C.OS_dispatch_queue, completion: (Swift.Optional<AEPCore.EventHubError>) -> ()) -> AEPCore.ExtensionContainer <null> (AEPCore:arm64+0x68e00)
    #10 reabstraction thunk helper from @escaping @callee_guaranteed @Sendable () -> () to @escaping @callee_unowned @convention(block) @Sendable () -> () <null> (AEPCore:arm64+0xe2a4)
    #11 __tsan::invoke_and_release_block(void*) <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x77ee0)
    #12 _dispatch_client_callout <null> (libdispatch.dylib:arm64+0x5938)

  Location is heap block of size 112 at 0x00010e2142e0 allocated by main thread:
    #0 __sanitizer_mz_malloc <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x4fe90)
    #1 _malloc_zone_malloc_instrumented_or_legacy <null> (libsystem_malloc.dylib:arm64+0x20cd0)
    #2 AEPServices.ServiceProvider.() -> AEPServices.ServiceProvider(in _C1436E9173A676408550A7049CEF4764).init() -> AEPServices.ServiceProvider <null> (AEPServices:arm64+0x883e8)
    #3 AEPServices.ServiceProvider.__allocating_init() -> AEPServices.ServiceProvider <null> (AEPServices:arm64+0x862d0)
    #4 one-time initialization function for shared <null> (AEPServices:arm64+0x86248)
    #5 dispatch_once <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x78d30)
    #6 dispatch_once_f <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x78dcc)
    #7 AEPServices.ServiceProvider.shared.unsafeMutableAddressor : AEPServices.ServiceProvider <null> (AEPServices:arm64+0x8637c)
    #8 static AEPServices.ServiceProvider.shared.getter : AEPServices.ServiceProvider <null> (AEPServices:arm64+0x863b0)
    #9 AEPCore.V4Migrator.(v4Defaults in _AD8F5075FFFB0AEDF94D735A3A0419C5).getter : __C.NSUserDefaults <null> (AEPCore:arm64+0xcc10c)
    #10 AEPCore.V4Migrator.(defaultsNeedsMigration in _AD8F5075FFFB0AEDF94D735A3A0419C5)() -> Swift.Bool <null> (AEPCore:arm64+0xcc720)
    #11 AEPCore.V4Migrator.migrate() -> () <null> (AEPCore:arm64+0xcc42c)
    #12 static AEPCore.MobileCore.registerExtensions(Swift.Array<__C.NSObject.Type>, Swift.Optional<() -> ()>) -> () <null> (AEPCore:arm64+0x99984)
    #13 AEPSampleApp.AppDelegate.application(_: __C.UIApplication, didFinishLaunchingWithOptions: Swift.Optional<Swift.Dictionary<__C.UIApplicationLaunchOptionsKey, Any>>) -> Swift.Bool <null> (AEPSampleApp:arm64+0x10009d154)
    #14 @objc AEPSampleApp.AppDelegate.application(_: __C.UIApplication, didFinishLaunchingWithOptions: Swift.Optional<Swift.Dictionary<__C.UIApplicationLaunchOptionsKey, Any>>) -> Swift.Bool <null> (AEPSampleApp:arm64+0x10009df68)
    #15 -[UIApplication _handleDelegateCallbacksWithOptions:isSuspended:restoreState:] <null> (UIKitCore:arm64+0xbb49cc)
    #16 <null> <null> (0x0001057a1558)

  Thread T6 (tid=5290941, running) is a GCD worker thread

  Thread T8 (tid=5290944, running) is a GCD worker thread

SUMMARY: ThreadSanitizer: data race (/Users/praveen/Library/Developer/CoreSimulator/Devices/5DCDA7B5-68B6-4442-9C23-059D7E360580/data/Containers/Bundle/Application/47875CF3-5714-462C-A703-41F4F1D89A14/AEPSampleApp.app/Frameworks/AEPServices.framework/AEPServices:arm64+0x252f8) in AEPServices.DiskCacheService.dataStore.getter : AEPServices.NamedCollectionDataStore+0x13c
==================
```
</details>
