### PR TITLE
[MOB-21073] Revert removal of log level in log string

### DIFF
--- a/AEPServices/Sources/log/LoggingService.swift
+++ b/AEPServices/Sources/log/LoggingService.swift
@@ -50,6 +50,6 @@ class LoggingService: Logging {
     // MARK: Logging
 
     func log(level: LogLevel, label: String, message: String) {
-        os_log("%@", log: osLog(label), type: osLogType(level), message)
+        os_log("%@", log: osLog("AEP SDK \(level.toString()) - <\(label)>"), type: osLogType(level), message)
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is a partial fix. Specifically this will fix logs not showing in the Assurance Log plugin for pre iOS 17 devices. This is also being reverted because structured logging is only supported on iOS 17+ which means that any debug logs provided on other iOS versions would be missing the log level. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
