### PR TITLE
Correct user default migration key for Identity analytics push sync

### DIFF
--- a/AEPCore/Sources/migration/UserDefaultMigrationConstants.swift
+++ b/AEPCore/Sources/migration/UserDefaultMigrationConstants.swift
@@ -69,7 +69,7 @@ enum UserDefaultMigratorConstants {
         enum DataStoreKeys: String, CaseIterable {
             case IDENTITY_PROPERTIES = "identity.properties"
             case PUSH_ENABLED = "push.enabled"
-            case ANALYTICS_PUSH_ENABLED = "analytics.push.enabled"
+            case ANALYTICS_PUSH_SYNC = "analytics.push.sync"
         }
     }
     

--- a/AEPCore/Tests/MigrationTests/UserDefaultMigratorTests.swift
+++ b/AEPCore/Tests/MigrationTests/UserDefaultMigratorTests.swift
@@ -82,8 +82,8 @@ class UserDefaultMigratorTests: XCTestCase {
     }
     
     func testIdentityMigration() {
-        let identityStoreName = UserDefaultMigratorConstants.Identity.DATASTORE_NAME
-        typealias identityKeys = UserDefaultMigratorConstants.Identity.DataStoreKeys
+        let identityStoreName = IdentityConstants.DATASTORE_NAME
+        typealias identityKeys = IdentityConstants.DataStoreKeys
         var properties = IdentityProperties()
         properties.ecid = ECID()
         properties.advertisingIdentifier = "test-ad-id"
@@ -93,9 +93,9 @@ class UserDefaultMigratorTests: XCTestCase {
         properties.customerIds = [CustomIdentity(origin: "test-origin", type: "test-type", identifier: "test-identifier", authenticationState: .authenticated)]
         properties.lastSync = Date()
         
-        let identityPropertyKey = keyWithPrefix(datastoreName: identityStoreName, key: identityKeys.IDENTITY_PROPERTIES.rawValue)
-        let identityPushEnabledKey = keyWithPrefix(datastoreName: identityStoreName, key: identityKeys.PUSH_ENABLED.rawValue)
-        let identityAnalyticsPushEnabledKey = keyWithPrefix(datastoreName: identityStoreName, key: identityKeys.ANALYTICS_PUSH_ENABLED.rawValue)
+        let identityPropertyKey = keyWithPrefix(datastoreName: identityStoreName, key: identityKeys.IDENTITY_PROPERTIES)
+        let identityPushEnabledKey = keyWithPrefix(datastoreName: identityStoreName, key: identityKeys.PUSH_ENABLED)
+        let identityAnalyticsPushEnabledKey = keyWithPrefix(datastoreName: identityStoreName, key: identityKeys.ANALYTICS_PUSH_SYNC)
         let encoder = JSONEncoder()
         if let encodedValue = try? encoder.encode(properties) {
             defaults.set(encodedValue, forKey: identityPropertyKey)
@@ -106,7 +106,7 @@ class UserDefaultMigratorTests: XCTestCase {
         UserDefaultsMigrator().migrate()
         
         var setProperties: IdentityProperties?
-        if let savedString = mockDataStore.dict[identityKeys.IDENTITY_PROPERTIES.rawValue] as? String, let savedData = savedString.data(using: .utf8) {
+        if let savedString = mockDataStore.dict[identityKeys.IDENTITY_PROPERTIES] as? String, let savedData = savedString.data(using: .utf8) {
             setProperties =  try? JSONDecoder().decode(IdentityProperties.self, from: savedData)
         }
         XCTAssertEqual(setProperties?.ecid, properties.ecid)
@@ -116,8 +116,8 @@ class UserDefaultMigratorTests: XCTestCase {
         XCTAssertEqual(setProperties?.locationHint, properties.locationHint)
         XCTAssertEqual(setProperties?.customerIds, properties.customerIds)
         XCTAssertEqual(setProperties?.lastSync, properties.lastSync)
-        XCTAssertTrue(mockDataStore.dict[identityKeys.PUSH_ENABLED.rawValue] as! Bool)
-        XCTAssertFalse(mockDataStore.dict[identityKeys.ANALYTICS_PUSH_ENABLED.rawValue] as! Bool)
+        XCTAssertTrue(mockDataStore.dict[identityKeys.PUSH_ENABLED] as? Bool ?? false)
+        XCTAssertFalse(mockDataStore.dict[identityKeys.ANALYTICS_PUSH_SYNC] as? Bool ?? true)
         XCTAssertNil(defaults.object(forKey: identityPropertyKey))
         XCTAssertNil(defaults.object(forKey: identityPushEnabledKey))
         XCTAssertNil(defaults.object(forKey: identityAnalyticsPushEnabledKey))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The UserDefaults migration key was incorrect for Identity "analytics.push.sync". This PR corrects the datastore key name and updates the Identity migration tests to validate against the Identity datastore keys.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
