### PR TITLE
More stability fixes

### DIFF
--- a/AEPCore/Sources/configuration/ConfigurationDownloader.swift
+++ b/AEPCore/Sources/configuration/ConfigurationDownloader.swift
@@ -79,9 +79,7 @@ struct ConfigurationDownloader: ConfigurationDownloadable {
 
         let networkRequest = NetworkRequest(url: url, httpMethod: .get, httpHeaders: headers)
 
-        ServiceProvider.shared.networkService.connectAsync(networkRequest: networkRequest) { [weak self] httpConnection in
-            guard let self = self else { return }
-
+        ServiceProvider.shared.networkService.connectAsync(networkRequest: networkRequest) { httpConnection in
             // If we get a 304 back, we can use the config in cache and exit early
             if httpConnection.responseCode == 304 {
                 completion(AnyCodable.toAnyDictionary(dictionary: self.getCachedConfig(appId: appId, dataStore: dataStore)?.cacheable))

--- a/AEPCore/Sources/configuration/ConfigurationDownloader.swift
+++ b/AEPCore/Sources/configuration/ConfigurationDownloader.swift
@@ -79,7 +79,9 @@ struct ConfigurationDownloader: ConfigurationDownloadable {
 
         let networkRequest = NetworkRequest(url: url, httpMethod: .get, httpHeaders: headers)
 
-        ServiceProvider.shared.networkService.connectAsync(networkRequest: networkRequest) { httpConnection in
+        ServiceProvider.shared.networkService.connectAsync(networkRequest: networkRequest) { [weak self] httpConnection in
+            guard let self = self else { return }
+
             // If we get a 304 back, we can use the config in cache and exit early
             if httpConnection.responseCode == 304 {
                 completion(AnyCodable.toAnyDictionary(dictionary: self.getCachedConfig(appId: appId, dataStore: dataStore)?.cacheable))

--- a/AEPCore/Sources/configuration/ConfigurationState.swift
+++ b/AEPCore/Sources/configuration/ConfigurationState.swift
@@ -17,22 +17,20 @@ import Foundation
 class ConfigurationState {
     private static let CONFIGURATION_TTL = TimeInterval(15)
 
-    let dataStore: NamedCollectionDataStore
-    let appIdManager: LaunchIDManager
-    let configDownloader: ConfigurationDownloadable
+    private let queue = DispatchQueue(label: "com.adobe.configurationState")
+    private let dataStore: NamedCollectionDataStore
+    private let appIdManager: LaunchIDManager
+    private let configDownloader: ConfigurationDownloadable
 
     private var appIdDownloadDateMap: [String: Date] = [:]
     private let logTag = "ConfigurationState"
 
     // The configuration without a merge from programmaticConfig, needed for clearing the config
-    private(set) var unmergedConfiguration = [String: Any]()
-    private(set) var currentConfiguration = [String: Any]()
-    var environmentAwareConfiguration: [String: Any] {
-        return computeEnvironmentConfig()
-    }
+    private var unmergedConfiguration = [String: Any]()
+    private var currentConfiguration = [String: Any]()
 
     /// The persisted programmatic config or an empty config dictionary if none is found
-    private(set) var programmaticConfigInDataStore: [String: AnyCodable] {
+    private var programmaticConfigInDataStore: [String: AnyCodable] {
         get {
             if let storedConfig: [String: AnyCodable] = dataStore.getObject(key: ConfigurationConstants.DataStoreKeys.PERSISTED_OVERRIDDEN_CONFIG) {
                 return storedConfig
@@ -57,104 +55,81 @@ class ConfigurationState {
         appIdManager = LaunchIDManager(dataStore: dataStore)
     }
 
-    /// Loads the first configuration at launch
-    func loadInitialConfig() {
-        var config = [String: Any]()
-
-        // Load any existing application ID, either saved in persistence or read from the ADBMobileAppID property in the platform's System Info Service.
-        if let appId = appIdManager.loadAppId() {
-            config = configDownloader.loadConfigFromCache(appId: appId, dataStore: dataStore)
-                ?? configDownloader.loadDefaultConfigFromManifest()
-                ?? [:]
-        } else {
-            Log.trace(label: logTag, "App ID not found, attempting to load default config from manifest")
-            config = configDownloader.loadDefaultConfigFromManifest() ?? [:]
+    /// Computes and returns environment aware configuration based on `self.currentConfiguration`
+    /// - Returns: A configuration with the correct values for each key given the build environment, while also
+    ///   removing all keys prefix with `ConfigurationConstants.ENVIRONMENT_PREFIX_DELIMITER`
+    var environmentAwareConfiguration: [String: Any] {
+        queue.sync {
+            return computeEnvironmentConfig()
         }
-
-        updateWith(newConfig: config)
     }
 
-    /// Merges the current configuration to `newConfig` then applies programmatic configuration on top
+    /// Updates the current configuration to `newConfig` then applies programmatic configuration on top
     /// - Parameter newConfig: The new configuration
     func updateWith(newConfig: [String: Any]) {
-        unmergedConfiguration = newConfig
-        currentConfiguration.merge(newConfig) { _, updated in updated }
+        queue.sync {
+            self.replaceConfigurationWith(newConfig: newConfig)
+        }
 
-        // Apply any programmatic configuration updates
-        currentConfiguration.merge(AnyCodable.toAnyDictionary(dictionary: programmaticConfigInDataStore) ?? [:]) { _, updated in updated }
+    }
+
+    /// Updates the current configuration to `newConfig` then applies programmatic configuration on top, and records the download time for appId. 
+    /// - Parameters
+    ///     - newConfig: The new configuration
+    ///     - appId: The application identifier for which the configuration is being updated.
+    func updateWith(newConfig: [String: Any], appId: String) {
+        queue.sync {
+            self.appIdDownloadDateMap[appId] = Date()
+            self.replaceConfigurationWith(newConfig: newConfig)
+        }
     }
 
     /// Updates the programmatic config, then applies these changes to the current configuration
     /// - Parameter programmaticConfig: programmatic configuration to be applied
     func updateWith(programmaticConfig: [String: Any]) {
-        // Map any config keys to their correct environment key
-        let mappedEnvironmentKeyConfig = mapEnvironmentKeys(programmaticConfig: programmaticConfig)
+        queue.sync {
+            // Map any config keys to their correct environment key
+            let mappedEnvironmentKeyConfig = self.mapEnvironmentKeys(programmaticConfig: programmaticConfig)
 
-        // Any existing programmatic configuration updates are retrieved from persistence.
-        // New configuration updates are applied over the existing persisted programmatic configurations
-        // New programmatic configuration updates are saved to persistence.
-        programmaticConfigInDataStore.merge(AnyCodable.from(dictionary: mappedEnvironmentKeyConfig) ?? [:]) { _, updated in updated }
+            // Any existing programmatic configuration updates are retrieved from persistence.
+            // New configuration updates are applied over the existing persisted programmatic configurations
+            // New programmatic configuration updates are saved to persistence.
+            self.programmaticConfigInDataStore.merge(AnyCodable.from(dictionary: mappedEnvironmentKeyConfig) ?? [:]) { _, updated in updated }
 
-        // The current configuration is updated with these new programmatic configuration changes.
-        currentConfiguration.merge(AnyCodable.toAnyDictionary(dictionary: programmaticConfigInDataStore) ?? [:]) { _, updated in updated }
-    }
-
-    /// Attempts to download the configuration associated with `appId`. If downloading the remote config fails,
-    /// check for a cached config
-    /// - Parameter appId: appId associated with the remote config
-    /// - Parameter completion: A closure that is invoked with the downloaded config, nil if unable to download
-    ///   config with `appId`
-    func updateWith(appId: String, completion: @escaping ([String: Any]?) -> Void) {
-        // Save the AppID in persistence for loading configuration on future launches.
-        appIdManager.saveAppIdToPersistence(appId: appId)
-
-        // Try to download config from network, if fails try to load from cache
-        configDownloader.loadConfigFromUrl(appId: appId, dataStore: dataStore, completion: { [weak self] config in
-            guard let self = self else { return }
-            if let loadedConfig = config {
-                self.appIdDownloadDateMap[appId] = Date()
-                self.replaceConfigurationWith(newConfig: loadedConfig)
-            }
-
-            completion(config)
-        })
-    }
-
-    /// Attempts to load the configuration stored at `filePath`
-    /// - Parameter filePath: Path to a configuration file
-    /// - Returns: True if the configuration was loaded
-    func updateWith(filePath: String) -> Bool {
-        guard let bundledConfig = configDownloader.loadConfigFrom(filePath: filePath) else {
-            return false
+            // The current configuration is updated with these new programmatic configuration changes.
+            self.currentConfiguration.merge(AnyCodable.toAnyDictionary(dictionary: self.programmaticConfigInDataStore) ?? [:]) { _, updated in updated }
         }
-
-        replaceConfigurationWith(newConfig: bundledConfig)
-        return true
     }
 
     /// Clears the programmatic config from the data store and sets the current config to the initial config
     func clearConfigUpdates() {
-        // Clear the programmatic config
-        programmaticConfigInDataStore = [:]
+        queue.sync {
+            // Clear the programmatic config
+            self.programmaticConfigInDataStore = [:]
 
-        replaceConfigurationWith(newConfig: unmergedConfiguration)
+            self.replaceConfigurationWith(newConfig: self.unmergedConfiguration)
+        }
     }
 
     /// Determines if the configuration associated with `appId` has been downloaded and not expired.
     /// - Parameter appId: A valid appId
     /// - Returns: True if configuration has been downloaded for the provided `appId` and has not expired
     func hasUnexpiredConfig(appId: String) -> Bool {
-        let lasteDownloadedDate = appIdDownloadDateMap[appId]
-        if let expiredDate = lasteDownloadedDate?.addingTimeInterval(ConfigurationState.CONFIGURATION_TTL) {
-            return expiredDate > Date()
+        queue.sync {
+            let lasteDownloadedDate = appIdDownloadDateMap[appId]
+            if let expiredDate = lasteDownloadedDate?.addingTimeInterval(ConfigurationState.CONFIGURATION_TTL) {
+                return expiredDate > Date()
+            }
+            return false
         }
-        return false
     }
+
+    // MARK: - Private Methods
 
     /// Computes the environment aware configuration based on `self.currentConfiguration`
     /// - Returns: A configuration with the correct values for each key given the build environment, while also
     ///   removing all keys prefix with `ConfigurationConstants.ENVIRONMENT_PREFIX_DELIMITER`
-    func computeEnvironmentConfig() -> [String: Any] {
+    private func computeEnvironmentConfig() -> [String: Any] {
         // Remove all __env__ keys, only need to process config keys who do not have the environment prefix
         var environmentAwareConfig = currentConfiguration.filter { !$0.key.hasPrefix(ConfigurationConstants.ENVIRONMENT_PREFIX_DELIMITER) }
         guard let buildEnvironment = currentConfiguration[ConfigurationConstants.Keys.BUILD_ENVIRONMENT] as? String else {
@@ -176,7 +151,7 @@ class ConfigurationState {
     /// Maps config keys to their respective build environment keys if they exist
     /// - Parameter programmaticConfig: The programmatic config from the user
     /// - Returns: `programmaticConfig` with all keys mapped to their build environment equivalent
-    func mapEnvironmentKeys(programmaticConfig: [String: Any]) -> [String: Any] {
+    private func mapEnvironmentKeys(programmaticConfig: [String: Any]) -> [String: Any] {
         guard let buildEnvironment = currentConfiguration[ConfigurationConstants.Keys.BUILD_ENVIRONMENT] as? String else {
             Log.trace(label: logTag, "Build environment not found in current config, returning programmatic config.")
             return programmaticConfig
@@ -191,8 +166,6 @@ class ConfigurationState {
 
         return mappedConfig
     }
-
-    // MARK: - Private Methods
 
     /// Replaces `currentConfiguration` with `newConfig` and then applies the existing programmatic configuration on-top
     /// - Parameter newConfig: A configuration to replace the current configuration
@@ -213,5 +186,57 @@ class ConfigurationState {
         guard !environment.isEmpty else { return key }
         let delimiter = ConfigurationConstants.ENVIRONMENT_PREFIX_DELIMITER
         return "\(delimiter)\(environment)\(delimiter)\(key)"
+    }
+}
+
+/// Update configuration state from network, cache or filesystem.
+extension ConfigurationState {
+    /// Loads the first configuration at launch
+    public func loadInitialConfig() {
+        var config = [String: Any]()
+
+        // Load any existing application ID, either saved in persistence or read from the ADBMobileAppID property in the platform's System Info Service.
+        if let appId = appIdManager.loadAppId() {
+            config = configDownloader.loadConfigFromCache(appId: appId, dataStore: dataStore)
+                ?? configDownloader.loadDefaultConfigFromManifest()
+                ?? [:]
+        } else {
+            Log.trace(label: logTag, "App ID not found, attempting to load default config from manifest")
+            config = configDownloader.loadDefaultConfigFromManifest() ?? [:]
+        }
+
+        updateWith(newConfig: config)
+    }
+
+    /// Attempts to download the configuration associated with `appId`. If downloading the remote config fails,
+    /// check for a cached config
+    /// - Parameter appId: appId associated with the remote config
+    /// - Parameter completion: A closure that is invoked with the downloaded config, nil if unable to download
+    ///   config with `appId`
+    func updateWith(appId: String, completion: @escaping ([String: Any]?) -> Void) {
+        // Save the AppID in persistence for loading configuration on future launches.
+        appIdManager.saveAppIdToPersistence(appId: appId)
+
+        // Try to download config from network, if fails try to load from cache
+        configDownloader.loadConfigFromUrl(appId: appId, dataStore: dataStore, completion: { [weak self] config in
+            guard let self = self else { return }
+            if let loadedConfig = config {
+                self.updateWith(newConfig: loadedConfig, appId: appId)
+            }
+
+            completion(config)
+        })
+    }
+
+    /// Attempts to load the configuration stored at `filePath`
+    /// - Parameter filePath: Path to a configuration file
+    /// - Returns: True if the configuration was loaded
+    func updateWith(filePath: String) -> Bool {
+        guard let bundledConfig = configDownloader.loadConfigFrom(filePath: filePath) else {
+            return false
+        }
+
+        updateWith(newConfig: bundledConfig)
+        return true
     }
 }

--- a/AEPCore/Sources/configuration/ConfigurationState.swift
+++ b/AEPCore/Sources/configuration/ConfigurationState.swift
@@ -68,7 +68,7 @@ class ConfigurationState {
     /// - Parameter newConfig: The new configuration
     func updateWith(newConfig: [String: Any]) {
         queue.sync {
-            self.replaceConfigurationWith(newConfig: newConfig)
+            replaceConfigurationWith(newConfig: newConfig)
         }
 
     }
@@ -79,8 +79,8 @@ class ConfigurationState {
     ///     - appId: The application identifier for which the configuration is being updated.
     func updateWith(newConfig: [String: Any], appId: String) {
         queue.sync {
-            self.appIdDownloadDateMap[appId] = Date()
-            self.replaceConfigurationWith(newConfig: newConfig)
+            appIdDownloadDateMap[appId] = Date()
+            replaceConfigurationWith(newConfig: newConfig)
         }
     }
 
@@ -94,10 +94,10 @@ class ConfigurationState {
             // Any existing programmatic configuration updates are retrieved from persistence.
             // New configuration updates are applied over the existing persisted programmatic configurations
             // New programmatic configuration updates are saved to persistence.
-            self.programmaticConfigInDataStore.merge(AnyCodable.from(dictionary: mappedEnvironmentKeyConfig) ?? [:]) { _, updated in updated }
+            programmaticConfigInDataStore.merge(AnyCodable.from(dictionary: mappedEnvironmentKeyConfig) ?? [:]) { _, updated in updated }
 
             // The current configuration is updated with these new programmatic configuration changes.
-            self.currentConfiguration.merge(AnyCodable.toAnyDictionary(dictionary: self.programmaticConfigInDataStore) ?? [:]) { _, updated in updated }
+            currentConfiguration.merge(AnyCodable.toAnyDictionary(dictionary: programmaticConfigInDataStore) ?? [:]) { _, updated in updated }
         }
     }
 
@@ -105,9 +105,9 @@ class ConfigurationState {
     func clearConfigUpdates() {
         queue.sync {
             // Clear the programmatic config
-            self.programmaticConfigInDataStore = [:]
+            programmaticConfigInDataStore = [:]
 
-            self.replaceConfigurationWith(newConfig: self.unmergedConfiguration)
+            replaceConfigurationWith(newConfig: self.unmergedConfiguration)
         }
     }
 

--- a/AEPCore/Sources/rules/LaunchRulesEngine+Downloader.swift
+++ b/AEPCore/Sources/rules/LaunchRulesEngine+Downloader.swift
@@ -24,7 +24,9 @@ public extension LaunchRulesEngine {
             return
         }
         let rulesDownloader = RulesDownloader(fileUnzipper: FileUnzipper())
-        rulesDownloader.loadRulesFromUrl(rulesUrl: url) { result in
+        rulesDownloader.loadRulesFromUrl(rulesUrl: url) { [weak self] result in
+            guard let self = self else { return }
+
             switch result {
             case .success(let data):
                 guard let rules = JSONRulesParser.parse(data) else {

--- a/AEPCore/Sources/rules/RulesDownloader.swift
+++ b/AEPCore/Sources/rules/RulesDownloader.swift
@@ -55,7 +55,9 @@ struct RulesDownloader: RulesLoader {
         }
 
         let networkRequest = NetworkRequest(url: rulesUrl, httpMethod: .get, httpHeaders: headers)
-        ServiceProvider.shared.networkService.connectAsync(networkRequest: networkRequest) { httpConnection in
+        ServiceProvider.shared.networkService.connectAsync(networkRequest: networkRequest) { [weak self] httpConnection in
+            guard let self = self else { return }
+
             if httpConnection.responseCode == 304 {
                 completion(.failure(.notModified))
                 return

--- a/AEPCore/Sources/rules/RulesDownloader.swift
+++ b/AEPCore/Sources/rules/RulesDownloader.swift
@@ -55,9 +55,7 @@ struct RulesDownloader: RulesLoader {
         }
 
         let networkRequest = NetworkRequest(url: rulesUrl, httpMethod: .get, httpHeaders: headers)
-        ServiceProvider.shared.networkService.connectAsync(networkRequest: networkRequest) { [weak self] httpConnection in
-            guard let self = self else { return }
-
+        ServiceProvider.shared.networkService.connectAsync(networkRequest: networkRequest) { httpConnection in            
             if httpConnection.responseCode == 304 {
                 completion(.failure(.notModified))
                 return

--- a/AEPCore/Tests/ConfigurationTests/ConfigurationStateTests.swift
+++ b/AEPCore/Tests/ConfigurationTests/ConfigurationStateTests.swift
@@ -11,11 +11,12 @@
  */
 
 @testable import AEPCore
+@testable import AEPCoreMocks
 @testable import AEPServicesMocks
 import AEPServices
 import XCTest
 
-class ConfigurationStateTests: XCTestCase {
+class ConfigurationStateTests: XCTestCase, AnyCodableAsserts {
     var configState: ConfigurationState!
     let dataStore = NamedCollectionDataStore(name: "ConfigurationStateTests")
     var configDownloader: MockConfigurationDownloader!
@@ -37,18 +38,18 @@ class ConfigurationStateTests: XCTestCase {
         configDownloader.configFromCache = config
     }
 
-    private func putProgrammaticConfigInPersistence(config: [String: AnyCodable]) {
-        dataStore.setObject(key: ConfigurationConstants.DataStoreKeys.PERSISTED_OVERRIDDEN_CONFIG, value: config)
+    private func putProgrammaticConfigInPersistence(config: [String: Any]) {
+        if let value = AnyCodable.from(dictionary: config) {
+            dataStore.setObject(key: ConfigurationConstants.DataStoreKeys.PERSISTED_OVERRIDDEN_CONFIG, value: value)
+        }
+    }
+
+    private func getProgrammaticConfigFromPersistence() -> [String: AnyCodable]? {
+        return dataStore.getObject(key: ConfigurationConstants.DataStoreKeys.PERSISTED_OVERRIDDEN_CONFIG)
     }
 
     private func putConfigInManifest(config: [String: Any]) {
         configDownloader.configFromManifest = config
-    }
-
-    private func assertContainsConfig(config: [String: Any]) {
-        for (key, _) in config {
-            XCTAssertTrue(configState.currentConfiguration.contains(where: { $0.key == key }))
-        }
     }
 
     // MARK: loadInitialConfig() tests
@@ -56,9 +57,16 @@ class ConfigurationStateTests: XCTestCase {
     /// Tests when appId present, cached config present, bundled config present, programmatic config present
     func testAppIdAndCachedConfigAndBundledConfigAndProgrammaticConfig() {
         // setup
-        let cachedConfig = ["experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg", "target.clientCode": "yourclientcode"]
-        let programmaticConfig: [String: AnyCodable] = ["testKey": AnyCodable("testVal")]
-        let bundledConfig: [String: Any] = ["target.timeout": 5, "bundled.config.key": "bundled.config.value"]
+        let cachedConfig = [
+            "experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg",
+            "target.clientCode": "yourclientcode"
+        ]
+        let programmaticConfig = ["testKey": "testVal"]
+        let bundledConfig: [String: Any] = [
+            "target.timeout": 5, 
+            "bundled.config.key":
+                "bundled.config.value"
+        ]
 
         putAppIdInPersistence(appId: "some-test-app-id")
         putCachedConfigInPersistence(config: cachedConfig)
@@ -69,16 +77,26 @@ class ConfigurationStateTests: XCTestCase {
         configState.loadInitialConfig()
 
         // verify
-        XCTAssertEqual(cachedConfig.count + programmaticConfig.count, configState.currentConfiguration.count)
-        assertContainsConfig(config: programmaticConfig)
+        let expected = [
+            "experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg",
+            "target.clientCode": "yourclientcode",
+            "testKey": "testVal"
+        ]
+        assertEqual(expected: expected, actual: configState.environmentAwareConfiguration)
         XCTAssertFalse(configDownloader.calledLoadDefaultConfig) // bundled config should not even be looked at in this case
     }
 
     /// Tests when appId present, cached config present, bundled config present, programmatic config not present
     func testAppIdAndCachedConfigAndBundledConfig() {
         // setup
-        let cachedConfig = ["experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg", "target.clientCode": "yourclientcode"]
-        let bundledConfig: [String: Any] = ["target.timeout": 5, "bundled.config.key": "bundled.config.value"]
+        let cachedConfig = [
+            "experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg",
+            "target.clientCode": "yourclientcode"
+        ]
+        let bundledConfig: [String : Any] = [
+            "target.timeout": 5,
+            "bundled.config.key": "bundled.config.value"
+        ]
 
         putAppIdInPersistence(appId: "some-test-app-id")
         putCachedConfigInPersistence(config: cachedConfig)
@@ -88,15 +106,18 @@ class ConfigurationStateTests: XCTestCase {
         configState.loadInitialConfig()
 
         // verify
-        XCTAssertEqual(cachedConfig.count, configState.currentConfiguration.count)
+        assertEqual(expected: cachedConfig, actual: configState.environmentAwareConfiguration)
         XCTAssertFalse(configDownloader.calledLoadDefaultConfig) // bundled config should not even be looked at in this case
     }
 
     /// Tests when appId present, cached config present, no bundled config, programmatic config present
     func testAppIdAndCachedAndProgrammatic() {
         // setup
-        let cachedConfig = ["experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg", "target.clientCode": "yourclientcode"]
-        let programmaticConfig: [String: AnyCodable] = ["testKey": AnyCodable("testVal")]
+        let cachedConfig = [
+            "experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg",
+            "target.clientCode": "yourclientcode"
+        ]
+        let programmaticConfig = ["testKey": "testVal"]
 
         putAppIdInPersistence(appId: "some-test-app-id")
         putCachedConfigInPersistence(config: cachedConfig)
@@ -106,14 +127,21 @@ class ConfigurationStateTests: XCTestCase {
         configState.loadInitialConfig()
 
         // verify
-        XCTAssertEqual(cachedConfig.count + programmaticConfig.count, configState.currentConfiguration.count)
-        assertContainsConfig(config: programmaticConfig)
+        let expected = [
+            "experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg",
+            "target.clientCode": "yourclientcode",
+            "testKey": "testVal"
+        ]
+        assertEqual(expected: expected, actual: configState.environmentAwareConfiguration)
     }
 
     /// Tests when appId present, cached config present, no bundled config, no programmatic config
     func testAppIdAndCachedConfig() {
         // setup
-        let cachedConfig = ["experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg", "target.clientCode": "yourclientcode"]
+        let cachedConfig = [
+            "experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg",
+            "target.clientCode": "yourclientcode"
+        ]
 
         putAppIdInPersistence(appId: "some-test-app-id")
         putCachedConfigInPersistence(config: cachedConfig)
@@ -122,14 +150,17 @@ class ConfigurationStateTests: XCTestCase {
         configState.loadInitialConfig()
 
         // verify
-        XCTAssertEqual(cachedConfig.count, configState.currentConfiguration.count)
+        assertEqual(expected: cachedConfig, actual: configState.environmentAwareConfiguration)
     }
 
     /// Tests when appId present, no cached config, bundled config present, programmatic config present
     func testAppIdAndBundledConfigAndProgrammatic() {
         // setup
-        let programmaticConfig: [String: AnyCodable] = ["testKey": AnyCodable("testVal")]
-        let bundledConfig: [String: Any] = ["target.timeout": 5, "bundled.config.key": "bundled.config.value"]
+        let programmaticConfig = ["testKey": "testVal"]
+        let bundledConfig: [String: Any] = [
+            "target.timeout": 5,
+            "bundled.config.key": "bundled.config.value"
+        ]
 
         putAppIdInPersistence(appId: "some-test-app-id")
         putProgrammaticConfigInPersistence(config: programmaticConfig)
@@ -139,16 +170,22 @@ class ConfigurationStateTests: XCTestCase {
         configState.loadInitialConfig()
 
         // verify
-        XCTAssertEqual(bundledConfig.count + programmaticConfig.count, configState.currentConfiguration.count)
-        assertContainsConfig(config: programmaticConfig)
+        let expected: [String: Any] = [
+            "bundled.config.key": "bundled.config.value",
+            "target.timeout": 5,
+            "testKey": "testVal"
+        ]
+        assertEqual(expected: expected, actual: configState.environmentAwareConfiguration)
         XCTAssertTrue(configDownloader.calledLoadDefaultConfig)
-        XCTAssertNotNil(configState.currentConfiguration["bundled.config.key"])
     }
 
     /// Tests when appId present, no cached config, bundled config present, no programmatic
     func testAppIdAndBundledConfig() {
         // setup
-        let bundledConfig: [String: Any] = ["target.timeout": 5, "bundled.config.key": "bundled.config.value"]
+        let bundledConfig: [String: Any] = [
+            "target.timeout": 5,
+            "bundled.config.key": "bundled.config.value"
+        ]
 
         putAppIdInPersistence(appId: "some-test-app-id")
         putConfigInManifest(config: bundledConfig)
@@ -157,14 +194,14 @@ class ConfigurationStateTests: XCTestCase {
         configState.loadInitialConfig()
 
         // verify
-        XCTAssertEqual(bundledConfig.count, configState.currentConfiguration.count)
+        assertEqual(expected: bundledConfig, actual: configState.environmentAwareConfiguration)
         XCTAssertTrue(configDownloader.calledLoadDefaultConfig)
     }
 
     /// Tests when appId present, no cached config, no bundled config, programmatic config present
     func testAppIdAndProgrammatic() {
         // setup
-        let programmaticConfig: [String: AnyCodable] = ["testKey": AnyCodable("testVal")]
+        let programmaticConfig = ["testKey": "testVal"]
 
         putAppIdInPersistence(appId: "some-test-app-id")
         putProgrammaticConfigInPersistence(config: programmaticConfig)
@@ -173,8 +210,7 @@ class ConfigurationStateTests: XCTestCase {
         configState.loadInitialConfig()
 
         // verify
-        XCTAssertEqual(programmaticConfig.count, configState.currentConfiguration.count)
-        assertContainsConfig(config: programmaticConfig)
+        assertEqual(expected: programmaticConfig, actual: configState.environmentAwareConfiguration)
     }
 
     /// Tests when appId present, no cached config, no bundled config, no programmatic config
@@ -186,15 +222,23 @@ class ConfigurationStateTests: XCTestCase {
         configState.loadInitialConfig()
 
         // verify
-        XCTAssertTrue(configState.currentConfiguration.isEmpty)
+        XCTAssertTrue(configState.environmentAwareConfiguration.isEmpty)
     }
 
     /// Tests when no appId, cached config present, bundled config present, programmatic config present
     func testCachedConfigAndBundledConfigAndProgrammaticConfig() {
         // setup
-        let cachedConfig = ["experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg", "target.clientCode": "yourclientcode"]
-        let programmaticConfig: [String: AnyCodable] = ["testKey": AnyCodable("testVal")]
-        let bundledConfig: [String: Any] = ["target.timeout": 5, "bundled.config.key": "bundled.config.value"]
+        let cachedConfig = [
+            "experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg",
+            "target.clientCode": "yourclientcode"
+        ]
+        let programmaticConfig: [String: Any] = [
+            "testKey": "testVal"
+        ]
+        let bundledConfig: [String: Any] = [
+            "target.timeout": 5,
+            "bundled.config.key": "bundled.config.value"
+        ]
 
         putCachedConfigInPersistence(config: cachedConfig)
         putConfigInManifest(config: bundledConfig)
@@ -204,17 +248,26 @@ class ConfigurationStateTests: XCTestCase {
         configState.loadInitialConfig()
 
         // verify
-        XCTAssertEqual(bundledConfig.count + programmaticConfig.count, configState.currentConfiguration.count)
-        assertContainsConfig(config: programmaticConfig)
-        assertContainsConfig(config: bundledConfig)
+        let expected: [String : Any] = [
+            "target.timeout": 5,
+            "bundled.config.key": "bundled.config.value",
+            "testKey": "testVal"
+        ]
+        assertEqual(expected: expected, actual: configState.environmentAwareConfiguration)
         XCTAssertTrue(configDownloader.calledLoadDefaultConfig)
     }
 
     /// Tests when no appId present, cached config present, bundled config present, no programmatic config
     func testCachedConfigAndBundledConfig() {
         // setup
-        let cachedConfig = ["experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg", "target.clientCode": "yourclientcode"]
-        let bundledConfig: [String: Any] = ["target.timeout": 5, "bundled.config.key": "bundled.config.value"]
+        let cachedConfig = [
+            "experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg",
+            "target.clientCode": "yourclientcode"
+        ]
+        let bundledConfig: [String: Any] = [
+            "target.timeout": 5,
+            "bundled.config.key": "bundled.config.value"
+        ]
 
         putCachedConfigInPersistence(config: cachedConfig)
         putConfigInManifest(config: bundledConfig)
@@ -223,16 +276,18 @@ class ConfigurationStateTests: XCTestCase {
         configState.loadInitialConfig()
 
         // verify
-        XCTAssertEqual(bundledConfig.count, configState.currentConfiguration.count)
+        assertEqual(expected: bundledConfig, actual: configState.environmentAwareConfiguration)
         XCTAssertTrue(configDownloader.calledLoadDefaultConfig)
-        assertContainsConfig(config: bundledConfig)
     }
 
     /// Tests when no appId, cached config present, no bundled config, programmatic config present
     func testCachedConfigAndProgrammatic() {
         // setup
-        let cachedConfig = ["experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg", "target.clientCode": "yourclientcode"]
-        let programmaticConfig: [String: AnyCodable] = ["testKey": AnyCodable("testVal")]
+        let cachedConfig = [
+            "experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg",
+            "target.clientCode": "yourclientcode"
+        ]
+        let programmaticConfig = ["testKey": "testVal"]
 
         putCachedConfigInPersistence(config: cachedConfig)
         putProgrammaticConfigInPersistence(config: programmaticConfig)
@@ -241,14 +296,17 @@ class ConfigurationStateTests: XCTestCase {
         configState.loadInitialConfig()
 
         // verify
-        XCTAssertEqual(programmaticConfig.count, configState.currentConfiguration.count)
-        assertContainsConfig(config: programmaticConfig)
+        assertEqual(expected: programmaticConfig, actual: configState.environmentAwareConfiguration)
+        XCTAssertTrue(configDownloader.calledLoadDefaultConfig)
     }
 
     /// Tests when no appId, cached config present, no bundled config, no programmatic config
     func testCachedConfig() {
         // setup
-        let cachedConfig = ["experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg", "target.clientCode": "yourclientcode"]
+        let cachedConfig = [
+            "experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg",
+            "target.clientCode": "yourclientcode"
+        ]
 
         putCachedConfigInPersistence(config: cachedConfig)
 
@@ -256,14 +314,17 @@ class ConfigurationStateTests: XCTestCase {
         configState.loadInitialConfig()
 
         // verify
-        XCTAssertTrue(configState.currentConfiguration.isEmpty)
+        XCTAssertTrue(configState.environmentAwareConfiguration.isEmpty)
     }
 
     /// Tests when no appId, no cached config, bundled config present, programmatic config present
     func testBundledConfigAndProgrammaticConfig() {
         // setup
-        let programmaticConfig: [String: AnyCodable] = ["testKey": AnyCodable("testVal")]
-        let bundledConfig: [String: Any] = ["target.timeout": 5, "bundled.config.key": "bundled.config.value"]
+        let programmaticConfig = ["testKey": "testVal"]
+        let bundledConfig: [String: Any] = [
+            "target.timeout": 5,
+            "bundled.config.key": "bundled.config.value"
+        ]
 
         putConfigInManifest(config: bundledConfig)
         putProgrammaticConfigInPersistence(config: programmaticConfig)
@@ -272,16 +333,22 @@ class ConfigurationStateTests: XCTestCase {
         configState.loadInitialConfig()
 
         // verify
-        XCTAssertEqual(bundledConfig.count + programmaticConfig.count, configState.currentConfiguration.count)
-        assertContainsConfig(config: bundledConfig)
-        assertContainsConfig(config: programmaticConfig)
+        let expected: [String: Any] = [
+            "target.timeout": 5,
+            "bundled.config.key": "bundled.config.value",
+            "testKey": "testVal"
+        ]
+        assertEqual(expected: expected, actual: configState.environmentAwareConfiguration)
         XCTAssertTrue(configDownloader.calledLoadDefaultConfig)
     }
 
     /// Tests when no appId, no cached config, bundled config present, no programmatic config
     func testBundledConfig() {
         // setup
-        let bundledConfig: [String: Any] = ["target.timeout": 5, "bundled.config.key": "bundled.config.value"]
+        let bundledConfig: [String: Any] = [
+            "target.timeout": 5,
+            "bundled.config.key": "bundled.config.value"
+        ]
 
         putConfigInManifest(config: bundledConfig)
 
@@ -289,15 +356,14 @@ class ConfigurationStateTests: XCTestCase {
         configState.loadInitialConfig()
 
         // verify
-        XCTAssertEqual(bundledConfig.count, configState.currentConfiguration.count)
-        assertContainsConfig(config: bundledConfig)
+        assertEqual(expected: bundledConfig, actual: configState.environmentAwareConfiguration)
         XCTAssertTrue(configDownloader.calledLoadDefaultConfig)
     }
 
     /// Tests when no appId, no cached config, no bundled config, programmatic config present
     func testProgrammaticConfig() {
         // setup
-        let programmaticConfig: [String: AnyCodable] = ["testKey": AnyCodable("testVal")]
+        let programmaticConfig = ["testKey": "testVal"]
 
         putProgrammaticConfigInPersistence(config: programmaticConfig)
 
@@ -305,8 +371,8 @@ class ConfigurationStateTests: XCTestCase {
         configState.loadInitialConfig()
 
         // verify
-        XCTAssertEqual(programmaticConfig.count, configState.currentConfiguration.count)
-        assertContainsConfig(config: programmaticConfig)
+        assertEqual(expected: programmaticConfig, actual: configState.environmentAwareConfiguration)
+        XCTAssertTrue(configDownloader.calledLoadDefaultConfig)
     }
 
     /// Tests when No appId, no cached config, no bundled config, no programmatic config
@@ -315,7 +381,7 @@ class ConfigurationStateTests: XCTestCase {
         configState.loadInitialConfig()
 
         // verify
-        XCTAssertTrue(configState.currentConfiguration.isEmpty)
+        XCTAssertTrue(configState.environmentAwareConfiguration.isEmpty)
     }
 
     // MARK: updateConfigWith(newConfig) tests
@@ -329,14 +395,13 @@ class ConfigurationStateTests: XCTestCase {
         configState.updateWith(newConfig: expectedConfig)
 
         // verify
-        XCTAssertEqual(1, configState.currentConfiguration.count)
-        XCTAssertEqual("testVal", configState.currentConfiguration["testKey"] as! String)
+        assertEqual(expected: expectedConfig, actual: configState.environmentAwareConfiguration)
     }
 
-    /// Tests that calling updateConfigWith(newConfig:) properly sets and updates key/values
-    func testUpdateConfigNewConfigOverwriteAndMerge() {
+    /// Tests that calling updateConfigWith(newConfig:) properly sets and replaces key/values
+    func testUpdateConfigNewConfigOverwrite() {
         // setup
-        let expectedConfig = ["testKey": "testVal"]
+        let expectedConfig = ["testKey": "testVal", "testKey2": "testVal2"]
         let expectedConfig1 = ["testKey": "overwrittenVal", "newKey": "newVal"]
 
         // test
@@ -344,26 +409,26 @@ class ConfigurationStateTests: XCTestCase {
         configState.updateWith(newConfig: expectedConfig1)
 
         // verify
-        XCTAssertEqual(2, configState.currentConfiguration.count)
-        XCTAssertEqual("overwrittenVal", configState.currentConfiguration["testKey"] as! String)
-        XCTAssertEqual("newVal", configState.currentConfiguration["newKey"] as! String)
+        assertEqual(expected: expectedConfig1, actual: configState.environmentAwareConfiguration)
     }
 
     /// Test that programmatic config and updateConfigWith merge the existing configs together
     func testUpdateConfigNewConfigPersistedConfigPresent() {
         // setup
-        let programmaticConfig: [String: AnyCodable] = ["testKey": AnyCodable("testVal")]
+        let programmaticConfig = ["programmaticKey": "programmaticVal"]
         putProgrammaticConfigInPersistence(config: programmaticConfig)
-        let expectedConfig = ["programmaticKey": "programmaticVal"]
+
+        let config = ["testKey": "testVal"]
 
         // test
-        configState.updateWith(newConfig: expectedConfig)
+        configState.updateWith(newConfig: config)
 
         // verify
-        XCTAssertEqual(2, configState.currentConfiguration.count)
-        XCTAssertEqual("programmaticVal", configState.currentConfiguration["programmaticKey"] as! String)
-        XCTAssertEqual("testVal", configState.currentConfiguration["testKey"] as! String)
-        assertContainsConfig(config: programmaticConfig)
+        let expected = [
+            "programmaticKey": "programmaticVal",
+            "testKey": "testVal"
+        ]
+        assertEqual(expected: expected, actual: configState.environmentAwareConfiguration)
     }
 
     // MARK: updateProgrammaticConfig tests
@@ -377,11 +442,8 @@ class ConfigurationStateTests: XCTestCase {
         configState.updateWith(programmaticConfig: expectedConfig)
 
         // verify
-        XCTAssertEqual(1, configState.currentConfiguration.count)
-        XCTAssertEqual("testVal", configState.currentConfiguration["testKey"] as! String)
-        XCTAssertEqual(1, configState.programmaticConfigInDataStore.count)
-        XCTAssertEqual("testVal", configState.programmaticConfigInDataStore["testKey"]?.value as? String)
-        XCTAssertEqual(dataStore.getObject(key: ConfigurationConstants.DataStoreKeys.PERSISTED_OVERRIDDEN_CONFIG), configState.programmaticConfigInDataStore)
+        assertEqual(expected: expectedConfig, actual: configState.environmentAwareConfiguration)
+        assertEqual(expected: expectedConfig, actual: getProgrammaticConfigFromPersistence())
     }
 
     /// Tests that updating programmatic config updates the correct build environment key
@@ -397,9 +459,78 @@ class ConfigurationStateTests: XCTestCase {
         configState.updateWith(programmaticConfig: ["analytics.rsids": "updated-dev-rsid"])
 
         // verify
-        XCTAssertEqual("updated-dev-rsid", configState.currentConfiguration["__dev__analytics.rsids"] as? String)
-        XCTAssertEqual("rsid1,rsid2", configState.currentConfiguration["analytics.rsids"] as? String)
-        XCTAssertEqual("updated-dev-rsid", configState.environmentAwareConfiguration["analytics.rsids"] as? String)
+        let expected = [
+            "build.environment": "dev",
+            "analytics.rsids": "updated-dev-rsid",
+            "analytics.server": "old-server.com"
+        ]
+        assertEqual(expected: expected, actual: configState.environmentAwareConfiguration)
+
+        let expectedProgrammatic = [
+            "__dev__analytics.rsids": "updated-dev-rsid"
+        ]
+        assertEqual(expected: expectedProgrammatic, actual: getProgrammaticConfigFromPersistence())
+    }
+
+    /// Tests that when there is not matching environment specific key that the key is mapped correctly
+    func testUpdateProgrammaticConfigNoMatchingEnvironmentKey() {
+        // setup
+        let existingConfig = [
+            "build.environment": "dev",
+            "analytics.rsids": "rsid1,rsid2",
+            "__dev__analytics.rsids": "devrsid1,devrsid2"
+        ]
+
+        configState.updateWith(newConfig: existingConfig)
+
+        // test
+        // __dev__ should not be prepended to analytics.server as there is no __dev__analytics.sever key in the existing config
+        configState.updateWith(programmaticConfig: ["analytics.server": "server.com"])
+
+
+        // verify
+        let expected = [
+            "build.environment": "dev",
+            "analytics.rsids": "devrsid1,devrsid2",
+            "analytics.server": "server.com"
+        ]
+        assertEqual(expected: expected, actual: configState.environmentAwareConfiguration)
+
+        let expectedProgrammatic = [
+            "analytics.server": "server.com"
+        ]
+        assertEqual(expected: expectedProgrammatic, actual: getProgrammaticConfigFromPersistence())
+    }
+
+    /// Tests that when keys that have environment specific keys and keys that do not are mapped correctly
+    func testUpdateProgrammaticConfigDevEnvKeyExistsAndDoesNotExist() {
+        // setup
+        let existingConfig = [
+            "build.environment": "dev",
+            "analytics.rsids": "rsid1,rsid2",
+            "__dev__analytics.rsids": "devrsid1,devrsid2",
+            "analytics.server": "old-server.com"
+        ]
+
+        configState.updateWith(newConfig: existingConfig)
+
+        // test
+        // __dev__ should be prepended to rsids but not analytics.server
+        configState.updateWith(programmaticConfig: ["__dev__analytics.rsids": "updated,rsids", "analytics.server": "server.com"])
+
+        // verify
+        let expected = [
+            "build.environment": "dev",
+            "analytics.rsids": "updated,rsids",
+            "analytics.server": "server.com"
+        ]
+        assertEqual(expected: expected, actual: configState.environmentAwareConfiguration)
+
+        let expectedProgrammatic = [
+            "__dev__analytics.rsids": "updated,rsids",
+            "analytics.server": "server.com"
+        ]
+        assertEqual(expected: expectedProgrammatic, actual: getProgrammaticConfigFromPersistence())
     }
 
     // MARK: updateConfigWith(appId) tests
@@ -410,14 +541,26 @@ class ConfigurationStateTests: XCTestCase {
         let expectation = XCTestExpectation(description: "ConfigurationDownloader closure should be invoked")
         expectation.assertForOverFulfill = true
 
-        let cachedConfig = ["experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg", "target.clientCode": "yourclientcode"]
+        let cachedConfig = [
+            "build.environment": "dev",
+            "analytics.rsids": "rsid1,rsid2",
+            "__dev__analytics.rsids": "devrsid1,devrsid2",
+            "experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg",
+        ]
         configDownloader.configFromUrl = cachedConfig
 
         let appId = "valid-app-id"
 
+
+        let expectedConfig = [
+            "build.environment": "dev",
+            "analytics.rsids": "devrsid1,devrsid2",
+            "experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg",
+        ]
         // test & verify
         configState.updateWith(appId: appId) { config in
-            XCTAssertEqual(cachedConfig.count, config?.count)
+            self.assertEqual(expected: cachedConfig, actual: config)
+            self.assertEqual(expected: expectedConfig, actual: self.configState.environmentAwareConfiguration)
             XCTAssertTrue(self.configState.hasUnexpiredConfig(appId: appId))
             expectation.fulfill()
         }
@@ -431,17 +574,18 @@ class ConfigurationStateTests: XCTestCase {
         // setup
         let expectation = XCTestExpectation(description: "ConfigurationDownloader closure should be invoked")
         expectation.assertForOverFulfill = true
-        let appId = "app-id-not-on-server"
+        let appId = "app-id-download-failure"
 
         // test
         configState.updateWith(appId: appId) { config in
             XCTAssertNil(config)
             XCTAssertFalse(self.configState.hasUnexpiredConfig(appId: appId))
+            XCTAssertTrue(self.configState.environmentAwareConfiguration.isEmpty)
             expectation.fulfill()
         }
 
         // verify
-        wait(for: [expectation], timeout: 1)
+        wait(for: [expectation], timeout: 1)        
     }
 
     /// Tests that we can configure with multiple app ids
@@ -451,16 +595,25 @@ class ConfigurationStateTests: XCTestCase {
         expectation.expectedFulfillmentCount = 2
         expectation.assertForOverFulfill = true
 
-        let cachedConfig = ["experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg", "target.clientCode": "yourclientcode"]
-        configDownloader.configFromUrl = cachedConfig
+        let firstAppIdConfig = [
+            "config1.key": "config1.value"
+        ]
+
+        let secondAppIdConfig = [
+            "config2.key": "config2.value"
+        ]
+        configDownloader.configFromUrl = firstAppIdConfig
 
         // test
         configState.updateWith(appId: "valid-app-id") { config in
-            XCTAssertEqual(cachedConfig.count, config?.count)
+            self.assertEqual(expected: firstAppIdConfig, actual: config)
+            self.assertEqual(expected: firstAppIdConfig, actual: self.configState.environmentAwareConfiguration)
             expectation.fulfill()
 
+            self.configDownloader.configFromUrl = secondAppIdConfig
             self.configState.updateWith(appId: "newAppId") { newConfig in
-                XCTAssertEqual(cachedConfig.count, newConfig?.count)
+                self.assertEqual(expected: secondAppIdConfig, actual: newConfig)
+                self.assertEqual(expected: secondAppIdConfig, actual: self.configState.environmentAwareConfiguration)
                 expectation.fulfill()
             }
         }
@@ -469,25 +622,29 @@ class ConfigurationStateTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
-    /// Tests that a valid config is preserved even when an invalid app id is passed
+    /// Tests that a valid config is preserved for the session even when new app-id download failure happens
     func testUpdateConfigWithValidThenInvalidId() {
         // setup
         let expectation = XCTestExpectation(description: "ConfigurationDownloader closure should be invoked")
         expectation.expectedFulfillmentCount = 2
         expectation.assertForOverFulfill = true
 
-        let cachedConfig = ["experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg", "target.clientCode": "yourclientcode"]
-        configDownloader.configFromUrl = cachedConfig
+        let firstAppIdConfig = [
+            "experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg",
+            "target.clientCode": "yourclientcode"
+        ]
+        configDownloader.configFromUrl = firstAppIdConfig
 
         // test
         configState.updateWith(appId: "valid-app-id") { config in
-            XCTAssertEqual(cachedConfig.count, config?.count)
+            self.assertEqual(expected: firstAppIdConfig, actual: config)
+            self.assertEqual(expected: firstAppIdConfig, actual: self.configState.environmentAwareConfiguration)
             self.configDownloader.configFromUrl = nil
             expectation.fulfill()
 
             self.configState.updateWith(appId: "invalid-app-id") { newConfig in
                 XCTAssertNil(newConfig)
-                XCTAssertEqual(cachedConfig.count, self.configState.currentConfiguration.count)
+                self.assertEqual(expected: firstAppIdConfig, actual: self.configState.environmentAwareConfiguration)
                 expectation.fulfill()
             }
         }
@@ -510,243 +667,226 @@ class ConfigurationStateTests: XCTestCase {
 
     /// Tests when the configuration downloader returns a valid config we properly update the current configuration
     func testUpdateConfigWithPathSimple() {
-        let cachedConfig = ["experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg", "target.clientCode": "yourclientcode"]
+        let cachedConfig = [
+            "experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg",
+            "target.clientCode": "yourclientcode"
+        ]
         configDownloader.configFromPath = cachedConfig // simulate file found
         XCTAssertTrue(configState.updateWith(filePath: "validPath"))
-        XCTAssertEqual(cachedConfig.count, configState.currentConfiguration.count)
+        assertEqual(expected: cachedConfig, actual: configState.environmentAwareConfiguration)
     }
 
     /// Tests when we have loaded a config from a file path, then we pass in an invalid path that the previous valid configuration is preserved
     func testUpdateConfigWithValidPathThenInvalid() {
-        let cachedConfig = ["experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg", "target.clientCode": "yourclientcode"]
+        let cachedConfig = [
+            "experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg",
+            "target.clientCode": "yourclientcode"
+        ]
         configDownloader.configFromPath = cachedConfig // simulate file found
         XCTAssertTrue(configState.updateWith(filePath: "validPath"))
-        XCTAssertEqual(cachedConfig.count, configState.currentConfiguration.count)
+        assertEqual(expected: cachedConfig, actual: configState.environmentAwareConfiguration)
 
         configDownloader.configFromPath = nil // simulate file not found
         XCTAssertFalse(configState.updateWith(filePath: "Invalid/Path/ADBMobile.json"))
-        XCTAssertEqual(cachedConfig.count, configState.currentConfiguration.count)
+        assertEqual(expected: cachedConfig, actual: configState.environmentAwareConfiguration)
     }
 
     /// Tests that the correct config values are shared when the build environment value is empty and all __env__ keys are removed
     func testEnvironmentConfigEmptyEnvironment() {
         // setup
-        let existingConfig: [String: Any] = ["build.environment": "",
-                                             "analytics.rsids": "rsid1,rsid2",
-                                             "__stage__analytics.rsids": "stagersid1,stagersid2",
-                                             "__dev__analytics.rsids": "devrsid1,devrsid2",
-                                             "analytics.server": "mycompany.sc.omtrdc.net"]
+        let existingConfig = [
+            "build.environment": "",
+            "analytics.rsids": "rsid1,rsid2",
+            "__stage__analytics.rsids": "stagersid1,stagersid2",
+            "__dev__analytics.rsids": "devrsid1,devrsid2",
+            "analytics.server": "mycompany.sc.omtrdc.net"
+        ]
         configState.updateWith(newConfig: existingConfig)
 
-        let expectedConfig = ["build.environment": "",
-                              "analytics.rsids": "rsid1,rsid2",
-                              "analytics.server": "mycompany.sc.omtrdc.net"]
-
-        // test
-        let envAwareConfig = configState.computeEnvironmentConfig()
-
+        let expectedConfig = [
+            "build.environment": "",
+            "analytics.rsids": "rsid1,rsid2",
+            "analytics.server": "mycompany.sc.omtrdc.net"
+        ]
         // verify
-        XCTAssertEqual(expectedConfig, envAwareConfig as? [String: String])
+        assertEqual(expected: expectedConfig, actual: configState.environmentAwareConfiguration)
     }
 
     /// Tests that the correct config values are shared when the build environment value is prod
     func testEnvironmentConfigProd() {
         // setup
-        let existingConfig: [String: Any] = ["build.environment": "prod",
-                                             "analytics.rsids": "rsid1,rsid2",
-                                             "__stage__analytics.rsids": "stagersid1,stagersid2",
-                                             "__dev__analytics.rsids": "devrsid1,devrsid2",
-                                             "analytics.server": "mycompany.sc.omtrdc.net"]
+        let existingConfig: [String: Any] = [
+            "build.environment": "prod",
+            "analytics.rsids": "rsid1,rsid2",
+            "__stage__analytics.rsids": "stagersid1,stagersid2",
+            "__dev__analytics.rsids": "devrsid1,devrsid2",
+            "analytics.server": "mycompany.sc.omtrdc.net"
+        ]
 
         configState.updateWith(newConfig: existingConfig)
 
-        let expectedConfig = ["build.environment": "prod",
-                              "analytics.rsids": "rsid1,rsid2",
-                              "analytics.server": "mycompany.sc.omtrdc.net"]
-
-        // test
-        let envAwareConfig = configState.computeEnvironmentConfig()
+        let expectedConfig = [
+            "build.environment": "prod",
+            "analytics.rsids": "rsid1,rsid2",
+            "analytics.server": "mycompany.sc.omtrdc.net"
+        ]
 
         // verify
-        XCTAssertEqual(expectedConfig, envAwareConfig as? [String: String])
+        assertEqual(expected: expectedConfig, actual: configState.environmentAwareConfiguration)
     }
 
     /// Tests that the correct config values are shared when the build environment value is staging
     func testEnvironmentConfigStaging() {
         // setup
-        let existingConfig: [String: Any] = ["build.environment": "stage",
-                                             "analytics.rsids": "rsid1,rsid2",
-                                             "__stage__analytics.rsids": "stagersid1,stagersid2",
-                                             "__dev__analytics.rsids": "devrsid1,devrsid2",
-                                             "analytics.server": "mycompany.sc.omtrdc.net"]
+        let existingConfig: [String: Any] = [
+            "build.environment": "stage",
+            "analytics.rsids": "rsid1,rsid2",
+            "__stage__analytics.rsids": "stagersid1,stagersid2",
+            "__dev__analytics.rsids": "devrsid1,devrsid2",
+            "analytics.server": "mycompany.sc.omtrdc.net"
+        ]
 
         configState.updateWith(newConfig: existingConfig)
 
-        let expectedConfig = ["build.environment": "stage",
-                              "analytics.rsids": "stagersid1,stagersid2",
-                              "analytics.server": "mycompany.sc.omtrdc.net"]
-
-        // test
-        let envAwareConfig = configState.computeEnvironmentConfig()
+        let expectedConfig = [
+            "build.environment": "stage",
+            "analytics.rsids": "stagersid1,stagersid2",
+            "analytics.server": "mycompany.sc.omtrdc.net"
+        ]
 
         // verify
-        XCTAssertEqual(expectedConfig, envAwareConfig as? [String: String])
+        assertEqual(expected: expectedConfig, actual: configState.environmentAwareConfiguration)
     }
 
     /// Tests that the correct config values are shared when the build environment value is dev
     func testEnvironmentConfigDev() {
         // setup
-        let existingConfig: [String: Any] = ["build.environment": "dev",
-                                             "analytics.rsids": "rsid1,rsid2",
-                                             "__stage__analytics.rsids": "stagersid1,stagersid2",
-                                             "__dev__analytics.rsids": "devrsid1,devrsid2",
-                                             "analytics.server": "mycompany.sc.omtrdc.net"]
+        let existingConfig: [String: Any] = [
+            "build.environment": "dev",
+            "analytics.rsids": "rsid1,rsid2",
+            "__stage__analytics.rsids": "stagersid1,stagersid2",
+            "__dev__analytics.rsids": "devrsid1,devrsid2",
+            "analytics.server": "mycompany.sc.omtrdc.net"
+        ]
 
         configState.updateWith(newConfig: existingConfig)
 
-        let expectedConfig = ["build.environment": "dev",
-                              "analytics.rsids": "devrsid1,devrsid2",
-                              "analytics.server": "mycompany.sc.omtrdc.net"]
-
-        // test
-        let envAwareConfig = configState.computeEnvironmentConfig()
+        let expectedConfig = [
+            "build.environment": "dev",
+            "analytics.rsids": "devrsid1,devrsid2",
+            "analytics.server": "mycompany.sc.omtrdc.net"
+        ]
 
         // verify
-        XCTAssertEqual(expectedConfig, envAwareConfig as? [String: String])
+        assertEqual(expected: expectedConfig, actual: configState.environmentAwareConfiguration)
     }
 
     /// Tests that when there are no environment specific keys, all existing keys are not modified.
-    func testMapEnvironmentKeysNoEnvKeys() {
+    func testEnvironmentConfigNoEnvKeys() {
         // setup
-        let newConfig: [String: Any] = ["build.environment": "dev",
-                                        "analytics.rsids": "rsid1,rsid2"]
+        let newConfig: [String: Any] = [
+            "build.environment": "dev", 
+            "analytics.rsids": "rsid1,rsid2"
+        ]
 
         // test
-        let mappedConfig = configState.mapEnvironmentKeys(programmaticConfig: newConfig)
+        configState.updateWith(newConfig: newConfig)
 
         // verify
-        XCTAssertEqual(newConfig as? [String: String], mappedConfig as? [String: String])
+        assertEqual(expected: newConfig, actual: configState.environmentAwareConfiguration)
     }
 
-    /// Tests that when a config key that has a build specific key is mapped to the specific key
-    func testMapEnvironmentKeysDevEnvKeyExist() {
+    /// Tests that environment specific keys are removed when there is no build.environment
+    func testEnvironmentConfigNoBuildEnvironment() {
         // setup
-        let existingConfig: [String: Any] = ["build.environment": "dev",
-                                             "analytics.rsids": "rsid1,rsid2",
-                                             "__dev__analytics.rsids": "devrsid1,devrsid2"]
-
-        configState.updateWith(newConfig: existingConfig)
-
-        // __dev__ should be prepended to the analytics.rsids key as we are in dev env
-        let expected: [String: Any] = ["__dev__analytics.rsids": "updated,rsids"]
+        let newConfig: [String: Any] = [
+            "__dev__analytics.rsids": "rsid1,rsid2",
+            "testKey": "testVal"
+        ]
 
         // test
-        let mappedConfig = configState.mapEnvironmentKeys(programmaticConfig: ["analytics.rsids": "updated,rsids"])
+        configState.updateWith(newConfig: newConfig)
 
         // verify
-        XCTAssertEqual(expected as? [String: String], mappedConfig as? [String: String])
-    }
-
-    /// Tests that when there is not matching environment specific key that the key is mapped correctly
-    func testMapEnvironmentKeysDevEnvKeyDoesNotExist() {
-        // setup
-        let existingConfig: [String: Any] = ["build.environment": "dev",
-                                             "analytics.rsids": "rsid1,rsid2",
-                                             "__dev__analytics.rsids": "devrsid1,devrsid2"]
-
-        configState.updateWith(newConfig: existingConfig)
-
-        // __dev__ should not be prepended to analytics.server as there is no __dev__analytics.sever key in the existing config
-        let expected: [String: Any] = ["analytics.server": "server.com"]
-
-        // test
-        let mappedConfig = configState.mapEnvironmentKeys(programmaticConfig: ["analytics.server": "server.com"])
-
-        // verify
-        XCTAssertEqual(expected as? [String: String], mappedConfig as? [String: String])
-    }
-
-    /// Tests that when keys that have environment specific keys and keys that do not are mapped correctly
-    func testMapEnvironmentKeysDevEnvKeyExistsAndDoesNotExist() {
-        // setup
-        let existingConfig: [String: Any] = ["build.environment": "dev",
-                                             "analytics.rsids": "rsid1,rsid2",
-                                             "__dev__analytics.rsids": "devrsid1,devrsid2",
-                                             "analytics.server": "old-server.com"]
-
-        configState.updateWith(newConfig: existingConfig)
-
-        // __dev__ should be prepended to rsids but not analytics.server
-        let expected: [String: Any] = ["__dev__analytics.rsids": "updated,rsids", "analytics.server": "server.com"]
-
-        // test
-        let mappedConfig = configState.mapEnvironmentKeys(programmaticConfig: ["analytics.rsids": "updated,rsids", "analytics.server": "server.com"])
-
-        // verify
-        XCTAssertEqual(expected as? [String: String], mappedConfig as? [String: String])
+        let expectedConfig = [
+            "testKey": "testVal"
+        ]
+        assertEqual(expected: expectedConfig, actual: configState.environmentAwareConfiguration)
     }
 
     // MARK: - Revert Config API Tests
     func testClearConfig() {
         // setup
-        let expectedConfig = ["testKey": "testVal"]
         let testAppid = "testAppid"
-        let cachedConfig: [String: Any] = ["build.environment": "dev",
-                                           "analytics.rsids": "rsid1,rsid2",
-                                           "__dev__analytics.rsids": "devrsid1,devrsid2",
-                                           "analytics.server": "old-server.com"]
+        let cachedConfig: [String: Any] = [
+            "build.environment": "dev",
+            "analytics.rsids": "rsid1,rsid2",
+            "__dev__analytics.rsids": "devrsid1,devrsid2",
+            "analytics.server": "old-server.com"
+        ]
         putAppIdInPersistence(appId: testAppid)
         putCachedConfigInPersistence(config: cachedConfig)
 
         configState.loadInitialConfig()
 
         // test
+        let expectedConfig = ["testKey": "testVal"]
         configState.updateWith(programmaticConfig: expectedConfig)
 
         // verify
-        XCTAssertEqual(5, configState.currentConfiguration.count)
-        XCTAssertEqual("testVal", configState.currentConfiguration["testKey"] as! String)
-        XCTAssertEqual(1, configState.programmaticConfigInDataStore.count)
-        XCTAssertEqual("testVal", configState.programmaticConfigInDataStore["testKey"]?.value as? String)
-        XCTAssertEqual(dataStore.getObject(key: ConfigurationConstants.DataStoreKeys.PERSISTED_OVERRIDDEN_CONFIG), configState.programmaticConfigInDataStore)
+        let configAfterProgrammaticUpdate = [
+            "build.environment": "dev",
+            "analytics.rsids": "devrsid1,devrsid2",
+            "analytics.server": "old-server.com",
+            "testKey": "testVal"
+        ]
+        assertEqual(expected:configAfterProgrammaticUpdate , actual: configState.environmentAwareConfiguration)
+        assertEqual(expected:expectedConfig , actual: getProgrammaticConfigFromPersistence())
 
         configState.clearConfigUpdates()
 
-        XCTAssertEqual(4, configState.currentConfiguration.count)
-        XCTAssertNil(configState.currentConfiguration["testKey"] as? String)
-        XCTAssertEqual(0, configState.programmaticConfigInDataStore.count)
-        XCTAssertNil(configState.programmaticConfigInDataStore["testKey"]?.value as? String)
-        XCTAssertEqual(0, (dataStore.getObject(key: ConfigurationConstants.DataStoreKeys.PERSISTED_OVERRIDDEN_CONFIG) as [String:AnyCodable]?)?.count)
+        let configAfterClear = [
+            "build.environment": "dev",
+            "analytics.rsids": "devrsid1,devrsid2",
+            "analytics.server": "old-server.com"
+        ]
+        assertEqual(expected:configAfterClear , actual: configState.environmentAwareConfiguration)
+        assertEqual(expected:[:] , actual: getProgrammaticConfigFromPersistence())
     }
 
     // Tests that updating then reverting then updating the config doesn't have remnants from first update
     func testUpdateClearUpdate() {
         // setup
-        let firstUpdate = ["shouldNotExist": "afterRevert"]
         let testAppid = "testAppid"
-        let cachedConfig: [String: Any] = ["build.environment": "dev",
-                                           "analytics.rsids": "rsid1,rsid2",
-                                           "__dev__analytics.rsids": "devrsid1,devrsid2",
-                                           "analytics.server": "old-server.com"]
-        let expectedConfig2: [String: String] = ["analytics.server": "new-server.com", "newKey": "newValue"]
+        let cachedConfig = [
+            "build.environment": "dev",
+            "analytics.rsids": "rsid1,rsid2",
+            "__dev__analytics.rsids": "devrsid1,devrsid2",
+            "analytics.server": "old-server.com"
+        ]
         putAppIdInPersistence(appId: testAppid)
         putCachedConfigInPersistence(config: cachedConfig)
 
         configState.loadInitialConfig()
 
         // test
+        let firstUpdate = ["shouldNotExist": "afterRevert"]
         configState.updateWith(programmaticConfig: firstUpdate)
+        assertEqual(expected:firstUpdate , actual: getProgrammaticConfigFromPersistence())
 
         configState.clearConfigUpdates()
 
-        configState.updateWith(programmaticConfig:  expectedConfig2)
+        let secondUpdate: [String: String] = ["analytics.server": "new-server.com", "newKey": "newValue"]
+        configState.updateWith(programmaticConfig:  secondUpdate)
 
-        XCTAssertEqual(5, configState.currentConfiguration.count)
-        XCTAssertNil(configState.currentConfiguration["shouldNotExist"] as? String)
-        XCTAssertEqual(2, configState.programmaticConfigInDataStore.count)
-        XCTAssertNil(configState.programmaticConfigInDataStore["testKey"]?.value as? String)
-        let progammaticMapped: [String: String] = configState.programmaticConfigInDataStore.mapValues{$0.stringValue!}
-        XCTAssertEqual(expectedConfig2, progammaticMapped)
+        let expectedConfig = [
+            "build.environment": "dev",
+            "analytics.rsids": "devrsid1,devrsid2",
+            "analytics.server": "new-server.com",
+            "newKey": "newValue"
+        ]
+        assertEqual(expected:expectedConfig , actual: configState.environmentAwareConfiguration)
+        assertEqual(expected:secondUpdate , actual: getProgrammaticConfigFromPersistence())
     }
 
     // Test reverting without an update makes no change
@@ -763,57 +903,77 @@ class ConfigurationStateTests: XCTestCase {
 
         configState.clearConfigUpdates()
 
-        let mappedCurrentConfig: [String: String] = configState.currentConfiguration.mapValues {$0 as! String}
-        XCTAssertEqual(mappedCurrentConfig, cachedConfig)
+        let expectedConfig = [
+            "build.environment": "dev",
+            "analytics.rsids": "devrsid1,devrsid2",
+            "analytics.server": "old-server.com"
+        ]
+        assertEqual(expected:expectedConfig , actual: configState.environmentAwareConfiguration)
+        assertEqual(expected:[:] , actual: getProgrammaticConfigFromPersistence())
     }
 
     func testConfigureWithFilePathThenUpdateThenClear() {
-        let cachedConfig: [String: String] = ["experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg",
-                                              "target.clientCode": "yourclientcode",
-                                              "analytics.server": "old-server.com"]
+        let cachedConfig: [String: String] = [
+            "experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg",
+            "target.clientCode": "yourclientcode",
+            "analytics.server": "old-server.com"
+        ]
         configDownloader.configFromPath = cachedConfig // simulate file found
 
         XCTAssertTrue(configState.updateWith(filePath: "validPath"))
-        XCTAssertEqual(cachedConfig, configState.currentConfiguration.mapValues{$0 as! String})
+
+
+        assertEqual(expected: cachedConfig, actual: configState.environmentAwareConfiguration)
+
 
         configState.updateWith(programmaticConfig: ["analytics.server": "new-server.com", "newKey": "newValue"])
 
-        XCTAssertEqual(4, configState.currentConfiguration.count)
-        XCTAssertEqual("new-server.com", configState.currentConfiguration["analytics.server"] as? String)
-        XCTAssertEqual("newValue", configState.currentConfiguration["newKey"] as? String)
+        let expectedConfig = [
+            "experienceCloud.org": "3CE342C75100435B0A490D4C@AdobeOrg",
+            "target.clientCode": "yourclientcode",
+            "analytics.server": "new-server.com",
+            "newKey": "newValue"
+        ]
+        assertEqual(expected: expectedConfig, actual: configState.environmentAwareConfiguration)
 
         configState.clearConfigUpdates()
 
-        XCTAssertTrue(configState.updateWith(filePath: "validPath"))
-        XCTAssertEqual(cachedConfig, configState.currentConfiguration.mapValues{$0 as! String})
+        assertEqual(expected: cachedConfig, actual: configState.environmentAwareConfiguration)
+        assertEqual(expected:[:] , actual: getProgrammaticConfigFromPersistence())
     }
 
     // Tests that updating then reverting then updating the config doesn't have remnants from first update
     func testConfigureWithFilePathThenUpdateThenClearThenUpdate() {
         // setup
-        let firstUpdate = ["shouldNotExist": "afterRevert"]
-        let cachedConfig: [String: Any] = ["build.environment": "dev",
-                                           "analytics.rsids": "rsid1,rsid2",
-                                           "__dev__analytics.rsids": "devrsid1,devrsid2",
-                                           "analytics.server": "old-server.com"]
-        let expectedConfig2: [String: String] = ["analytics.server": "new-server.com", "newKey": "newValue"]
-
+        let cachedConfig: [String: Any] = [
+            "build.environment": "dev",
+            "analytics.rsids": "rsid1,rsid2",
+            "__dev__analytics.rsids": "devrsid1,devrsid2",
+            "analytics.server": "old-server.com"
+        ]
         configDownloader.configFromPath = cachedConfig
+
         XCTAssertTrue(configState.updateWith(filePath: "validPath"))
 
         // test
+        let firstUpdate = ["shouldNotExist": "afterRevert"]
         configState.updateWith(programmaticConfig: firstUpdate)
 
         configState.clearConfigUpdates()
 
-        configState.updateWith(programmaticConfig:  expectedConfig2)
+        let secondUpdate = ["analytics.server": "new-server.com", "newKey": "newValue"]
+        configState.updateWith(programmaticConfig:  secondUpdate)
 
-        XCTAssertEqual(5, configState.currentConfiguration.count)
-        XCTAssertNil(configState.currentConfiguration["shouldNotExist"] as? String)
-        XCTAssertEqual(2, configState.programmaticConfigInDataStore.count)
-        XCTAssertNil(configState.programmaticConfigInDataStore["testKey"]?.value as? String)
-        let progammaticMapped: [String: String] = configState.programmaticConfigInDataStore.mapValues{$0.stringValue!}
-        XCTAssertEqual(expectedConfig2, progammaticMapped)
+
+        let expectedConfig = [
+            "build.environment": "dev",
+            "analytics.rsids": "devrsid1,devrsid2",
+            "analytics.server": "new-server.com",
+            "newKey": "newValue"
+
+        ]
+        assertEqual(expected: expectedConfig, actual: configState.environmentAwareConfiguration)
+        assertEqual(expected:secondUpdate , actual: getProgrammaticConfigFromPersistence())
     }
 
 

--- a/AEPIdentity/Sources/IdentityHitProcessor.swift
+++ b/AEPIdentity/Sources/IdentityHitProcessor.swift
@@ -42,7 +42,8 @@ class IdentityHitProcessor: HitProcessing {
         let headers = [NetworkServiceConstants.Headers.CONTENT_TYPE: NetworkServiceConstants.HeaderValues.CONTENT_TYPE_URL_ENCODED]
         let networkRequest = NetworkRequest(url: identityHit.url, httpMethod: .get, connectPayload: "", httpHeaders: headers, connectTimeout: IdentityConstants.Default.TIMEOUT, readTimeout: IdentityConstants.Default.TIMEOUT)
 
-        networkService.connectAsync(networkRequest: networkRequest) { connection in
+        networkService.connectAsync(networkRequest: networkRequest) { [weak self] connection in
+            guard let self = self else { return }
             self.handleNetworkResponse(hit: identityHit, connection: connection, completion: completion)
         }
     }

--- a/AEPSignal/Sources/SignalHitProcessor.swift
+++ b/AEPSignal/Sources/SignalHitProcessor.swift
@@ -48,7 +48,8 @@ class SignalHitProcessor: HitProcessing {
 
         let request = NetworkRequest(url: signalHit.url, httpMethod: httpMethod, connectPayload: signalHit.postBody ?? "", httpHeaders: headers, connectTimeout: timeout, readTimeout: timeout)
 
-        networkService.connectAsync(networkRequest: request) { connection in
+        networkService.connectAsync(networkRequest: request) { [weak self] connection in
+            guard let self = self else { return }
             self.handleNetworkResponse(hit: signalHit, connection: connection, completion: completion)
         }
     }


### PR DESCRIPTION
- Prevent concurrent access exceptions in ConfigurationState.
- Update `ConfigurationState` tests to use the validation method from test utils.
- Pass weak references to network response handler. 