### PR TITLE
Apply latest AEPTestUtil updates (5.1.0)

### DIFF
--- a/AEPServices/Mocks/PublicTestUtils/MockNetworkService.swift
+++ b/AEPServices/Mocks/PublicTestUtils/MockNetworkService.swift
@@ -14,7 +14,7 @@
 import Foundation
 import XCTest
 
-/// `Networking` conforming network service utility used for tests that require mocked network requests and mocked responses
+/// `Networking` conforming network service utility used for tests that require mocked network requests and mocked responses.
 public class MockNetworkService: Networking {
     private let helper: NetworkRequestHelper = NetworkRequestHelper()
     private var responseDelay: UInt32
@@ -126,20 +126,25 @@ public class MockNetworkService: Networking {
     }
 
     /// Asserts that the correct number of network requests were seen for all previously set network request expectations.
+    ///
     /// - Parameters:
+    ///   - ignoreUnexpectedRequests: A Boolean value indicating whether unexpected requests should be ignored. Defaults to `true`.
+    ///   - timeout: The time interval to wait for network requests before timing out. Defaults to ``TestConstants/Defaults/WAIT_NETWORK_REQUEST_TIMEOUT``.
     ///   - file: The file from which the method is called, used for localized assertion failures.
     ///   - line: The line from which the method is called, used for localized assertion failures.
     /// - SeeAlso:
     ///     - ``setExpectationForNetworkRequest(url:httpMethod:expectedCount:file:line:)``
-    public func assertAllNetworkRequestExpectations(ignoreUnexpectedRequests: Bool = true, file: StaticString = #file, line: UInt = #line) {
-        helper.assertAllNetworkRequestExpectations(ignoreUnexpectedRequests: ignoreUnexpectedRequests, file: file, line: line)
+    public func assertAllNetworkRequestExpectations(ignoreUnexpectedRequests: Bool = true, timeout: TimeInterval = TestConstants.Defaults.WAIT_NETWORK_REQUEST_TIMEOUT, file: StaticString = #file, line: UInt = #line) {
+        helper.assertAllNetworkRequestExpectations(ignoreUnexpectedRequests: ignoreUnexpectedRequests, timeout: timeout, file: file, line: line)
     }
 
     /// Immediately returns all sent network requests (if any) **without awaiting**.
     ///
     /// Note: To await network responses for a given request, make sure to set an expectation
     /// using ``setExpectationForNetworkRequest(url:httpMethod:expectedCount:file:line:)``
-    /// then await the expectation using ``assertAllNetworkRequestExpectations(ignoreUnexpectedRequests:file:line:)``.
+    /// then await the expectation using ``assertAllNetworkRequestExpectations(ignoreUnexpectedRequests:timeout:file:line:)``.
+    ///
+    /// - Returns: An array of `NetworkRequest` objects representing all sent network requests.
     public func getNetworkRequests() -> [NetworkRequest] {
         return helper.orderedNetworkRequests
     }
@@ -151,40 +156,36 @@ public class MockNetworkService: Networking {
     /// - Parameters:
     ///   - url: The URL `String` of the `NetworkRequest` to get.
     ///   - httpMethod: The HTTP method of the `NetworkRequest` to get.
-    ///   - expectationTimeout: The duration (in seconds) to wait for **expected network requests** before failing, with a default of
-    ///    ``TestConstants/Defaults/WAIT_NETWORK_REQUEST_TIMEOUT``. Otherwise waits for ``TestConstants/Defaults/WAIT_TIMEOUT``
-    ///     without failing.
+    ///   - timeout: The time interval to wait for network requests before timing out. Defaults to ``TestConstants/Defaults/WAIT_NETWORK_REQUEST_TIMEOUT``.
     ///   - file: The file from which the method is called, used for localized assertion failures.
     ///   - line: The line from which the method is called, used for localized assertion failures.
     /// - Returns: An array of `NetworkRequest`s that match the provided `url` and `httpMethod`. Returns an empty array if no matching requests were dispatched.
     ///
     /// - SeeAlso:
     ///     - ``setExpectationForNetworkRequest(url:httpMethod:expectedCount:file:line:)``
-    public func getNetworkRequestsWith(url: String, httpMethod: HttpMethod, expectationTimeout: TimeInterval = TestConstants.Defaults.WAIT_NETWORK_REQUEST_TIMEOUT, file: StaticString = #file, line: UInt = #line) -> [NetworkRequest] {
+    public func getNetworkRequestsWith(url: String, httpMethod: HttpMethod, timeout: TimeInterval = TestConstants.Defaults.WAIT_NETWORK_REQUEST_TIMEOUT, file: StaticString = #file, line: UInt = #line) -> [NetworkRequest] {
         guard let url = URL(string: url) else {
             return []
         }
-        return getNetworkRequestsWith(url: url, httpMethod: httpMethod, expectationTimeout: expectationTimeout, file: file, line: line)
+        return getNetworkRequestsWith(url: url, httpMethod: httpMethod, timeout: timeout, file: file, line: line)
     }
 
     /// Returns the network request(s) sent through the Core NetworkService, or empty if none was found.
     ///
-    /// Use this method after calling `setExpectationForNetworkRequest(url:httpMethod:expectedCount:file:line:)` to wait for expected requests.
+    /// Use this method after calling ``setExpectationForNetworkRequest(url:httpMethod:expectedCount:file:line:)`` to wait for expected requests.
     ///
     /// - Parameters:
     ///   - url: The URL `String` of the `NetworkRequest` to get.
     ///   - httpMethod: The HTTP method of the `NetworkRequest` to get.
-    ///   - expectationTimeout: The duration (in seconds) to wait for **expected network requests** before failing, with a default of
-    ///    ``TestConstants/Defaults/WAIT_NETWORK_REQUEST_TIMEOUT``. Otherwise waits for ``TestConstants/Defaults/WAIT_TIMEOUT``
-    ///     without failing.
+    ///   - timeout: The time interval to wait for network requests before timing out. Defaults to ``TestConstants/Defaults/WAIT_NETWORK_REQUEST_TIMEOUT``.
     ///   - file: The file from which the method is called, used for localized assertion failures.
     ///   - line: The line from which the method is called, used for localized assertion failures.
     /// - Returns: An array of `NetworkRequest`s that match the provided `url` and `httpMethod`. Returns an empty array if no matching requests were dispatched.
     ///
     /// - SeeAlso:
     ///     - ``setExpectationForNetworkRequest(url:httpMethod:expectedCount:file:line:)``
-    public func getNetworkRequestsWith(url: URL, httpMethod: HttpMethod, expectationTimeout: TimeInterval = TestConstants.Defaults.WAIT_NETWORK_REQUEST_TIMEOUT, file: StaticString = #file, line: UInt = #line) -> [NetworkRequest] {
-        return helper.getNetworkRequestsWith(url: url, httpMethod: httpMethod, expectationTimeout: expectationTimeout, file: file, line: line)
+    public func getNetworkRequestsWith(url: URL, httpMethod: HttpMethod, timeout: TimeInterval = TestConstants.Defaults.WAIT_NETWORK_REQUEST_TIMEOUT, file: StaticString = #file, line: UInt = #line) -> [NetworkRequest] {
+        return helper.getNetworkRequestsWith(url: url, httpMethod: httpMethod, timeout: timeout, file: file, line: line)
     }
 
     // MARK: - Private helpers

--- a/AEPServices/Mocks/PublicTestUtils/NamedCollectionDataStore+TestHelper.swift
+++ b/AEPServices/Mocks/PublicTestUtils/NamedCollectionDataStore+TestHelper.swift
@@ -14,8 +14,8 @@ import AEPServices
 
 public extension NamedCollectionDataStore {
     /// Clears all known locations for Adobe Mobile SDK local device data persistence:
-    /// 1. `UserDefaults` - tvOS (in use for all versions) and iOS (in use for Core version lower than v4.2.0) (see: ``UserDefaults/clearAll()``)
-    /// 2. `FileManager` - hits databases for each extension (see: ``FileManager/clearCache``)
+    /// 1. `UserDefaults` - tvOS (in use for all versions) and iOS (in use for Core version lower than v4.2.0)
+    /// 2. `FileManager` - hits databases for each extension
     /// 3. File system directory - iOS (in use for Core version v4.2.0 and beyond)
     static func clear() {
         UserDefaults.clearAll()

--- a/AEPServices/Mocks/PublicTestUtils/NetworkRequestHelper.swift
+++ b/AEPServices/Mocks/PublicTestUtils/NetworkRequestHelper.swift
@@ -84,9 +84,11 @@ class NetworkRequestHelper {
     /// - Returns: A `DispatchTimeoutResult` with the result of the wait operation, or `nil` if the `NetworkRequest` does not match any expected request.
     private func awaitFor(networkRequest: NetworkRequest, timeout: TimeInterval) -> DispatchTimeoutResult? {
         let testableNetworkRequest = TestableNetworkRequest(from: networkRequest)
-        return queue.sync {
-            return self.expectedNetworkRequests[testableNetworkRequest]?.await(timeout: timeout)
+        var countdownLatch: CountDownLatch?
+        queue.sync {
+            countdownLatch = self.expectedNetworkRequests[testableNetworkRequest]
         }
+        return countdownLatch?.await(timeout: timeout)
     }
 
     ///  Returns all sent network requests that match the provided network request using the

--- a/AEPServices/Mocks/PublicTestUtils/RealNetworkService.swift
+++ b/AEPServices/Mocks/PublicTestUtils/RealNetworkService.swift
@@ -14,7 +14,7 @@
 import Foundation
 import XCTest
 
-/// Overriding NetworkService used for tests that require real outgoing network requests
+/// Overriding `NetworkService` used for tests that require real outgoing network requests.
 public class RealNetworkService: NetworkService {
     private let helper: NetworkRequestHelper = NetworkRequestHelper()
     /// Flag that indicates if the ``connectAsync(networkRequest:completionHandler:)`` method was called.
@@ -43,11 +43,11 @@ public class RealNetworkService: NetworkService {
     ///
     /// Note: To await network responses for a given request, make sure to set an expectation
     /// using ``setExpectation(for:expectedCount:file:line:)`` then await the expectation using
-    /// ``assertAllNetworkRequestExpectations(ignoreUnexpectedRequests:file:line:)``.
+    /// ``assertAllNetworkRequestExpectations(ignoreUnexpectedRequests:timeout:file:line:)``.
     ///
     /// - Parameter networkRequest: The `NetworkRequest` for which the response should be returned.
     /// - Returns: The array of `HttpConnection` responses for the given request or `nil` if not found.
-    /// - seeAlso: ``assertAllNetworkRequestExpectations(ignoreUnexpectedRequests:file:line:)``
+    /// - seeAlso: ``assertAllNetworkRequestExpectations(ignoreUnexpectedRequests:timeout:file:line:)``
     public func getResponses(for networkRequest: NetworkRequest) -> [HttpConnection]? {
         return helper.getResponses(for: networkRequest)
     }
@@ -55,64 +55,64 @@ public class RealNetworkService: NetworkService {
     // MARK: - Passthrough for shared helper APIs
     /// Asserts that the correct number of network requests were seen for all previously set network request expectations.
     /// - Parameters:
+    ///   - ignoreUnexpectedRequests: A Boolean value indicating whether unexpected requests should be ignored. Defaults to `true`.
+    ///   - timeout: The time interval to wait for network requests before timing out. Defaults to ``TestConstants/Defaults/WAIT_NETWORK_REQUEST_TIMEOUT``.
     ///   - file: The file from which the method is called, used for localized assertion failures.
     ///   - line: The line from which the method is called, used for localized assertion failures.
     /// - SeeAlso: ``setExpectation(for:expectedCount:file:line:)``
-    public func assertAllNetworkRequestExpectations(ignoreUnexpectedRequests: Bool = true, file: StaticString = #file, line: UInt = #line) {
-        helper.assertAllNetworkRequestExpectations(ignoreUnexpectedRequests: ignoreUnexpectedRequests, file: file, line: line)
+    public func assertAllNetworkRequestExpectations(ignoreUnexpectedRequests: Bool = true, timeout: TimeInterval = TestConstants.Defaults.WAIT_NETWORK_REQUEST_TIMEOUT, file: StaticString = #file, line: UInt = #line) {
+        helper.assertAllNetworkRequestExpectations(ignoreUnexpectedRequests: ignoreUnexpectedRequests, timeout: timeout, file: file, line: line)
     }
 
     /// Immediately returns all sent network requests (if any) **without awaiting**.
     ///
     /// Note: To await network responses for a given request, make sure to set an expectation
-    /// using ``setExpectation(for:expectedCount:file:line:)`` then await the expectation using
-    /// ``assertAllNetworkRequestExpectations(ignoreUnexpectedRequests:file:line:)``.
+    /// using ``setExpectation(for:expectedCount:file:line:)``
+    /// then await the expectation using ``assertAllNetworkRequestExpectations(ignoreUnexpectedRequests:timeout:file:line:)``.
+    ///
+    /// - Returns: An array of `NetworkRequest` objects representing all sent network requests.
     public func getNetworkRequests() -> [NetworkRequest] {
         return helper.orderedNetworkRequests
     }
 
     /// Returns the network request(s) sent through the Core NetworkService, or empty if none was found.
     ///
-    /// Use this method after calling ``setExpectationForNetworkRequest(url:httpMethod:expectedCount:file:line:)`` to wait for expected requests.
+    /// Use this method after calling ``setExpectation(for:expectedCount:file:line:)`` to wait for expected requests.
     ///
     /// - Parameters:
     ///   - url: The URL `String` of the `NetworkRequest` to get.
     ///   - httpMethod: The HTTP method of the `NetworkRequest` to get.
-    ///   - expectationTimeout: The duration (in seconds) to wait for **expected network requests** before failing, with a default of
-    ///    ``TestConstants/Defaults/WAIT_NETWORK_REQUEST_TIMEOUT``. Otherwise waits for ``TestConstants/Defaults/WAIT_TIMEOUT``
-    ///     without failing.
+    ///   - timeout: The time interval to wait for network requests before timing out. Defaults to ``TestConstants/Defaults/WAIT_NETWORK_REQUEST_TIMEOUT``.
     ///   - file: The file from which the method is called, used for localized assertion failures.
     ///   - line: The line from which the method is called, used for localized assertion failures.
     /// - Returns: An array of `NetworkRequest`s that match the provided `url` and `httpMethod`. Returns an empty array if no matching requests were dispatched.
     ///
     /// - SeeAlso:
-    ///     - ``setExpectationForNetworkRequest(url:httpMethod:expectedCount:file:line:)``
-    public func getNetworkRequestsWith(url: String, httpMethod: HttpMethod, expectationTimeout: TimeInterval = TestConstants.Defaults.WAIT_NETWORK_REQUEST_TIMEOUT, file: StaticString = #file, line: UInt = #line) -> [NetworkRequest] {
+    ///     - ``setExpectation(for:expectedCount:file:line:)``
+    public func getNetworkRequestsWith(url: String, httpMethod: HttpMethod, timeout: TimeInterval = TestConstants.Defaults.WAIT_NETWORK_REQUEST_TIMEOUT, file: StaticString = #file, line: UInt = #line) -> [NetworkRequest] {
         guard let url = URL(string: url) else {
             return []
         }
-        return getNetworkRequestsWith(url: url, httpMethod: httpMethod, expectationTimeout: expectationTimeout, file: file, line: line)
+        return getNetworkRequestsWith(url: url, httpMethod: httpMethod, timeout: timeout, file: file, line: line)
     }
 
     /// Returns the network request(s) sent through the Core NetworkService, or empty if none was found.
     ///
-    /// Use this method after calling ``setExpectationForNetworkRequest(url:httpMethod:expectedCount:file:line:)`` to wait for expected
+    /// Use this method after calling ``setExpectation(for:expectedCount:file:line:)`` to wait for expected
     /// requests.
     ///
     /// - Parameters:
     ///   - url: The URL `String` of the `NetworkRequest` to get.
     ///   - httpMethod: The HTTP method of the `NetworkRequest` to get.
-    ///   - expectationTimeout: The duration (in seconds) to wait for **expected network requests** before failing, with a default of
-    ///    ``TestConstants/Defaults/WAIT_NETWORK_REQUEST_TIMEOUT``. Otherwise waits for ``TestConstants/Defaults/WAIT_TIMEOUT``
-    ///     without failing.
+    ///   - timeout: The time interval to wait for network requests before timing out. Defaults to ``TestConstants/Defaults/WAIT_NETWORK_REQUEST_TIMEOUT``.
     ///   - file: The file from which the method is called, used for localized assertion failures.
     ///   - line: The line from which the method is called, used for localized assertion failures.
     /// - Returns: An array of `NetworkRequest`s that match the provided `url` and `httpMethod`. Returns an empty array if no matching requests were dispatched.
     ///
     /// - SeeAlso:
-    ///     - ``setExpectationForNetworkRequest(url:httpMethod:expectedCount:file:line:)``
-    public func getNetworkRequestsWith(url: URL, httpMethod: HttpMethod, expectationTimeout: TimeInterval = TestConstants.Defaults.WAIT_NETWORK_REQUEST_TIMEOUT, file: StaticString = #file, line: UInt = #line) -> [NetworkRequest] {
-        return helper.getNetworkRequestsWith(url: url, httpMethod: httpMethod, expectationTimeout: expectationTimeout, file: file, line: line)
+    ///     - ``setExpectation(for:expectedCount:file:line:)``
+    public func getNetworkRequestsWith(url: URL, httpMethod: HttpMethod, timeout: TimeInterval = TestConstants.Defaults.WAIT_NETWORK_REQUEST_TIMEOUT, file: StaticString = #file, line: UInt = #line) -> [NetworkRequest] {
+        return helper.getNetworkRequestsWith(url: url, httpMethod: httpMethod, timeout: timeout, file: file, line: line)
     }
 
     /// Resets all stored network request elements and expectations.

--- a/AEPServices/Tests/utility/PersistentHitQueueTests.swift
+++ b/AEPServices/Tests/utility/PersistentHitQueueTests.swift
@@ -234,8 +234,7 @@ class ControllableHitProcessor: HitProcessing {
 
     func processHit(entity: DataEntity, completion: @escaping (Bool) -> Void) {
         processedHits.append(entity)
-        var hitResult = _hitResult
-        completion(hitResult)
+        completion(_hitResult)
     }
 }
 

--- a/AEPServices/Tests/utility/PersistentHitQueueTests.swift
+++ b/AEPServices/Tests/utility/PersistentHitQueueTests.swift
@@ -234,7 +234,7 @@ class ControllableHitProcessor: HitProcessing {
 
     func processHit(entity: DataEntity, completion: @escaping (Bool) -> Void) {
         processedHits.append(entity)
-        completion(_hitResult)
+        completion(hitResult)
     }
 }
 

--- a/AEPServices/Tests/utility/PersistentHitQueueTests.swift
+++ b/AEPServices/Tests/utility/PersistentHitQueueTests.swift
@@ -234,9 +234,8 @@ class ControllableHitProcessor: HitProcessing {
 
     func processHit(entity: DataEntity, completion: @escaping (Bool) -> Void) {
         processedHits.append(entity)
-        queue.sync {
-            completion(_hitResult)
-        }
+        var hitResult = _hitResult
+        completion(hitResult)
     }
 }
 

--- a/AEPTestUtils.podspec
+++ b/AEPTestUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "AEPTestUtils"
-    s.version          = "5.0.3"
+    s.version          = "5.2.0"
     s.summary          = "Adobe Experience Platform test utilities for Adobe Experience Platform Mobile SDK. Written and maintained by Adobe."
   
     s.description      = <<-DESC


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR brings over the latest updates from AEPTestUtils (up to 5.1.0) and also updates `NetworkRequestHelper` class to use `ThreadSafeDictionary` and `ThreadSafeArray` instead of a queue at the class level.
* The `ThreadSafe` changes have been tested with Edge extension functional and integration tests locally

There is a breaking change where the parameter name `expectationTimeout` has been renamed to `timeout` across `NetworkRequestHelper`, `MockNetworkService`, and `RealNetworkService`


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
