### PR TITLE
Fix flaky Identity tests

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -331,6 +331,7 @@
 		3FF829492507F8AA00483C74 /* rules_lifecycle.json in Resources */ = {isa = PBXBuildFile; fileRef = 3FF829482507F8AA00483C74 /* rules_lifecycle.json */; };
 		3FF829692509937100483C74 /* SignalIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF829682509937100483C74 /* SignalIntegrationTests.swift */; };
 		3FF8296D2509942300483C74 /* rules_signal.json in Resources */ = {isa = PBXBuildFile; fileRef = 3FF8296B2509942300483C74 /* rules_signal.json */; };
+		4C7B340F2C59B2B7009FA7A2 /* ThreadSafeDictionary+TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7B340E2C59B2B7009FA7A2 /* ThreadSafeDictionary+TestHelper.swift */; };
 		4CF0285D2C2CCBD3008ADE05 /* AnyCodable+Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CF028162C2CCA0F008ADE05 /* AnyCodable+Array.swift */; };
 		4CF0285E2C2CCBD3008ADE05 /* CountDownLatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CF0281D2C2CCA0F008ADE05 /* CountDownLatch.swift */; };
 		4CF0285F2C2CCBD3008ADE05 /* EventSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CF028182C2CCA0F008ADE05 /* EventSpec.swift */; };
@@ -1069,6 +1070,7 @@
 		3FF8296B2509942300483C74 /* rules_signal.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_signal.json; sourceTree = "<group>"; };
 		4107BA7054E313DACA0D4EF4 /* Pods-AEPCoreTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPCoreTests.release.xcconfig"; path = "Target Support Files/Pods-AEPCoreTests/Pods-AEPCoreTests.release.xcconfig"; sourceTree = "<group>"; };
 		41E5D22C6D72CCCF26904EDE /* Pods-AEPSignalTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPSignalTests.debug.xcconfig"; path = "Target Support Files/Pods-AEPSignalTests/Pods-AEPSignalTests.debug.xcconfig"; sourceTree = "<group>"; };
+		4C7B340E2C59B2B7009FA7A2 /* ThreadSafeDictionary+TestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ThreadSafeDictionary+TestHelper.swift"; sourceTree = "<group>"; };
 		4CF028162C2CCA0F008ADE05 /* AnyCodable+Array.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AnyCodable+Array.swift"; sourceTree = "<group>"; };
 		4CF028172C2CCA0F008ADE05 /* RealNetworkService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealNetworkService.swift; sourceTree = "<group>"; };
 		4CF028182C2CCA0F008ADE05 /* EventSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventSpec.swift; sourceTree = "<group>"; };
@@ -2165,6 +2167,7 @@
 				4CF0281E2C2CCA0F008ADE05 /* URL+TestHelper.swift */,
 				4CF0281F2C2CCA0F008ADE05 /* UserDefaults+TestHelper.swift */,
 				4CF028252C2CCA0F008ADE05 /* XCTestCase+AnyCodableAsserts.swift */,
+				4C7B340E2C59B2B7009FA7A2 /* ThreadSafeDictionary+TestHelper.swift */,
 			);
 			path = PublicTestUtils;
 			sourceTree = "<group>";
@@ -3529,6 +3532,7 @@
 				4CF0285D2C2CCBD3008ADE05 /* AnyCodable+Array.swift in Sources */,
 				4CF0285E2C2CCBD3008ADE05 /* CountDownLatch.swift in Sources */,
 				4CF0285F2C2CCBD3008ADE05 /* EventSpec.swift in Sources */,
+				4C7B340F2C59B2B7009FA7A2 /* ThreadSafeDictionary+TestHelper.swift in Sources */,
 				4CF028602C2CCBD3008ADE05 /* FileManager+TestHelper.swift in Sources */,
 				4CF028612C2CCBD3008ADE05 /* HttpConnection+DeepCopy.swift in Sources */,
 				4CF028622C2CCBD3008ADE05 /* MockDataQueue.swift in Sources */,

--- a/AEPIntegrationTests/IdentityIntegrationTests.swift
+++ b/AEPIntegrationTests/IdentityIntegrationTests.swift
@@ -53,6 +53,10 @@ class IdentityIntegrationTests: TestBase {
 
         wait(for: [unregisterExpectation], timeout: 3)
 
+        // NOTE: There may be some test cases where there are carryover events due to the race condition interactions
+        // between the shutdown process of extension containers and the singleton nature of the EventHub.
+        // If it needs to be addressed, the architecture should be updated to allow for definitive stopping
+        // of event dispatching in extension containers in the shutdown process.
         EventHub.shared.shutdown()
         ServiceProvider.shared.reset()
         EventHub.reset()
@@ -243,8 +247,7 @@ class IdentityIntegrationTests: TestBase {
             XCTAssertNil(error)
             getECIDExpectation.fulfill()
         }
-        // getExperienceCloudId returns within 0.5 sec when config is bundled with the app. 
-        // Increasing timeout to 1 sec to avoid race conditions
+
         wait(for: [getECIDExpectation], timeout: 1.5)
     }
 

--- a/AEPServices/Mocks/PublicTestUtils/MockDataStore.swift
+++ b/AEPServices/Mocks/PublicTestUtils/MockDataStore.swift
@@ -13,8 +13,12 @@ import AEPServices
 import Foundation
 
 public class MockDataStore: NamedCollectionProcessing {
+    public var dict = ThreadSafeDictionary<String, Any>()
     private var appGroup: String?
 
+    public init() {}
+
+    // MARK: AppGroup methods
     public func getAppGroup() -> String? {
         return appGroup
     }
@@ -23,10 +27,7 @@ public class MockDataStore: NamedCollectionProcessing {
         self.appGroup = appGroup
     }
 
-    public var dict = [String: Any?]()
-
-    public init() {}
-
+    // MARK: DataStore dictionary methods
     public func set(collectionName _: String, key: String, value: Any?) {
         dict[key] = value
     }
@@ -36,6 +37,6 @@ public class MockDataStore: NamedCollectionProcessing {
     }
 
     public func remove(collectionName _: String, key: String) {
-        dict.removeValue(forKey: key)
+        _ = dict.removeValue(forKey: key)
     }
 }

--- a/AEPServices/Mocks/PublicTestUtils/ThreadSafeDictionary+TestHelper.swift
+++ b/AEPServices/Mocks/PublicTestUtils/ThreadSafeDictionary+TestHelper.swift
@@ -1,0 +1,19 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+*/
+
+import AEPServices
+
+public extension ThreadSafeDictionary {
+    var isEmpty: Bool {
+        count == 0
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR aims to address some of the flakiness issues with Identity tests in two main files:
1. `IdentityIntegrationTests.swift` and 
2. `IdentityStateTests.swift`

With the fixes being:
#### `IdentityIntegrationTests.swift`
1. Add a small delay to the setup process after MobileCore is started, to give bootup process events time to complete before starting the test cases
2. Add event based expectations for test case setup events before starting the timer for the actual APIs under test

#### `IdentityStateTests.swift`
1. Fix data race issues in MockDataStore by
    1. Converting the data struct `dict` from regular `Dictionary` to `ThreadSafeDictionary`
    2. Adding `extension` to `ThreadSafeDictionary` to support direct usage of `isEmpty` on the `dict` in `MockDataStore`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
