### PR TITLE
Use instanced EventHub with ExtensionContainer

### DIFF
--- a/AEPCore/Sources/eventhub/EventHub.swift
+++ b/AEPCore/Sources/eventhub/EventHub.swift
@@ -136,7 +136,7 @@ final class EventHub {
             // Init the extension on a dedicated queue
             let extensionTypeName = "com.adobe.eventhub.extension.\(type.typeName)"
             let extensionQueue = DispatchQueue(label: extensionTypeName)
-            let extensionContainer = ExtensionContainer(extensionTypeName, type, extensionQueue, completion: completion)
+            let extensionContainer = ExtensionContainer(self, extensionTypeName, type, extensionQueue, completion: completion)
             self.registeredExtensions[type.typeName] = extensionContainer
             Log.debug(label: self.LOG_TAG, "\(type.typeName) successfully registered.")
         }

--- a/AEPCore/Sources/eventhub/ExtensionContainer.swift
+++ b/AEPCore/Sources/eventhub/ExtensionContainer.swift
@@ -19,6 +19,9 @@ import Foundation
 class ExtensionContainer {
     private static let LOG_TAG = "ExtensionContainer"
 
+    /// A weak reference to the EventHub instance responsible for processing events sent to/from this ExtensionContainer.
+    private weak var eventHub: EventHub?
+
     /// The extension held in this container
     private var _exten: Extension?
     var exten: Extension? {
@@ -58,7 +61,8 @@ class ExtensionContainer {
         set { containerQueue.async { self._lastProcessedEvent = newValue } }
     }
 
-    init(_ name: String, _ type: Extension.Type, _ queue: DispatchQueue, completion: @escaping (EventHubError?) -> Void) {
+    init(_ eventHub: EventHub, _ name: String, _ type: Extension.Type, _ queue: DispatchQueue, completion: @escaping (EventHubError?) -> Void) {
+        self.eventHub = eventHub
         extensionQueue = queue
         containerQueue = DispatchQueue(label: "\(name).containerQueue")
         eventOrderer = OperationOrderer<Event>("\(name).operationOrderer")
@@ -100,8 +104,8 @@ class ExtensionContainer {
 
 extension ExtensionContainer: ExtensionRuntime {
     func unregisterExtension() {
-        guard let exten = exten else { return }
-        EventHub.shared.unregisterExtension(type(of: exten), completion: {_ in })
+        guard let exten = exten, let eventHub = eventHub else { return }
+        eventHub.unregisterExtension(type(of: exten), completion: {_ in })
     }
 
     public func registerListener(type: String, source: String, listener: @escaping EventListener) {
@@ -110,47 +114,58 @@ extension ExtensionContainer: ExtensionRuntime {
     }
 
     func registerResponseListener(triggerEvent: Event, timeout: TimeInterval, listener: @escaping EventResponseListener) {
-        EventHub.shared.registerResponseListener(triggerEvent: triggerEvent, timeout: timeout, listener: listener)
+        guard let eventHub = eventHub else { return }
+        eventHub.registerResponseListener(triggerEvent: triggerEvent, timeout: timeout, listener: listener)
     }
 
     func dispatch(event: Event) {
-        EventHub.shared.dispatch(event: event)
+        guard let eventHub = eventHub else { return }
+        eventHub.dispatch(event: event)
     }
 
     func createSharedState(data: [String: Any], event: Event?) {
-        EventHub.shared.createSharedState(extensionName: sharedStateName, data: data, event: event)
+        guard let eventHub = eventHub else { return }
+        eventHub.createSharedState(extensionName: sharedStateName, data: data, event: event)
     }
 
     func createPendingSharedState(event: Event?) -> SharedStateResolver {
-        return EventHub.shared.createPendingSharedState(extensionName: sharedStateName, event: event)
+        guard let eventHub = eventHub else { return { _ in } }
+        return eventHub.createPendingSharedState(extensionName: sharedStateName, event: event)
     }
 
     func getSharedState(extensionName: String, event: Event?, barrier: Bool = true) -> SharedStateResult? {
-        return EventHub.shared.getSharedState(extensionName: extensionName, event: event, barrier: barrier)
+        guard let eventHub = eventHub else { return nil }
+        return eventHub.getSharedState(extensionName: extensionName, event: event, barrier: barrier)
     }
 
     func getSharedState(extensionName: String, event: Event?, barrier: Bool = true, resolution: SharedStateResolution = .any) -> SharedStateResult? {
-        return EventHub.shared.getSharedState(extensionName: extensionName, event: event, barrier: barrier, resolution: resolution)
+        guard let eventHub = eventHub else { return nil }
+        return eventHub.getSharedState(extensionName: extensionName, event: event, barrier: barrier, resolution: resolution)
     }
 
     func createXDMSharedState(data: [String: Any], event: Event?) {
-        EventHub.shared.createSharedState(extensionName: sharedStateName, data: data, event: event, sharedStateType: .xdm)
+        guard let eventHub = eventHub else { return }
+        return eventHub.createSharedState(extensionName: sharedStateName, data: data, event: event, sharedStateType: .xdm)
     }
 
     func createPendingXDMSharedState(event: Event?) -> SharedStateResolver {
-        return EventHub.shared.createPendingSharedState(extensionName: sharedStateName, event: event, sharedStateType: .xdm)
+        guard let eventHub = eventHub else { return { _ in } }
+        return eventHub.createPendingSharedState(extensionName: sharedStateName, event: event, sharedStateType: .xdm)
     }
 
     func getXDMSharedState(extensionName: String, event: Event?, barrier: Bool = false) -> SharedStateResult? {
-        return EventHub.shared.getSharedState(extensionName: extensionName, event: event, barrier: barrier, sharedStateType: .xdm)
+        guard let eventHub = eventHub else { return nil }
+        return eventHub.getSharedState(extensionName: extensionName, event: event, barrier: barrier, sharedStateType: .xdm)
     }
 
     func getXDMSharedState(extensionName: String, event: Event?, barrier: Bool = true, resolution: SharedStateResolution = .any) -> SharedStateResult? {
-        return EventHub.shared.getSharedState(extensionName: extensionName, event: event, barrier: barrier, resolution: resolution, sharedStateType: .xdm)
+        guard let eventHub = eventHub else { return nil }
+        return eventHub.getSharedState(extensionName: extensionName, event: event, barrier: barrier, resolution: resolution, sharedStateType: .xdm)
     }
 
     func getHistoricalEvents(_ requests: [EventHistoryRequest], enforceOrder: Bool, handler: @escaping ([EventHistoryResult]) -> Void) {
-        EventHub.shared.getHistoricalEvents(requests, enforceOrder: enforceOrder, handler: handler)
+        guard let eventHub = eventHub else { return }
+        eventHub.getHistoricalEvents(requests, enforceOrder: enforceOrder, handler: handler)
     }
 
     func startEvents() {


### PR DESCRIPTION

## Description

This PR updated the ExtenionContainer class to use an instance of EventHub instead of a shared global reference.

This is to avoid a relatively common test scenario where EventHub is started and shutdown rapidly between test cases, and extension containers have pending events that will get sent to the new EventHub instance; this can affect test case state, shared states, processing times, etc.

See: https://github.com/adobe/aepsdk-core-ios/issues/1064

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
