### PR TITLE
Add Logger protocol and instance and non-instance implementations.

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -474,6 +474,9 @@
 		BF4A70BE26CCD30800612434 /* rules_dispatch_consequence.zip in Resources */ = {isa = PBXBuildFile; fileRef = BF4A70BD26CCD30800612434 /* rules_dispatch_consequence.zip */; };
 		BF4BDFBE2C87D5AB00485ABC /* SDKInstanceIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4BDFBD2C87D5AB00485ABC /* SDKInstanceIdentifier.swift */; };
 		BF4BDFC02C87DD8600485ABC /* SDKInstanceIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4BDFBF2C87DD8600485ABC /* SDKInstanceIdentifierTests.swift */; };
+		BF4BDFC22C8F609500485ABC /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4BDFC12C8F609500485ABC /* Logger.swift */; };
+		BF4BDFC42C8F615400485ABC /* LoggerImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4BDFC32C8F615400485ABC /* LoggerImpl.swift */; };
+		BF4BDFC62C8F623D00485ABC /* SDKInstanceLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4BDFC52C8F623D00485ABC /* SDKInstanceLogger.swift */; };
 		C0FC8CAF8ADDBE9FBAE4C374 /* Pods_AEPLifecycleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D83561969E15C045AEBC014 /* Pods_AEPLifecycleTests.framework */; };
 		D42C989C26CAE6DA002E3184 /* LifecycleV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42C989B26CAE6DA002E3184 /* LifecycleV2.swift */; };
 		D42C989E26CAE790002E3184 /* LifecycleV2Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42C989D26CAE790002E3184 /* LifecycleV2Constants.swift */; };
@@ -1210,6 +1213,9 @@
 		BF4A70BD26CCD30800612434 /* rules_dispatch_consequence.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = rules_dispatch_consequence.zip; sourceTree = "<group>"; };
 		BF4BDFBD2C87D5AB00485ABC /* SDKInstanceIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKInstanceIdentifier.swift; sourceTree = "<group>"; };
 		BF4BDFBF2C87DD8600485ABC /* SDKInstanceIdentifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKInstanceIdentifierTests.swift; sourceTree = "<group>"; };
+		BF4BDFC12C8F609500485ABC /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		BF4BDFC32C8F615400485ABC /* LoggerImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerImpl.swift; sourceTree = "<group>"; };
+		BF4BDFC52C8F623D00485ABC /* SDKInstanceLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKInstanceLogger.swift; sourceTree = "<group>"; };
 		CBB1F735C1AAEA1CD448B2C0 /* Pods-AEPLifecycleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPLifecycleTests.debug.xcconfig"; path = "Target Support Files/Pods-AEPLifecycleTests/Pods-AEPLifecycleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		D42C989B26CAE6DA002E3184 /* LifecycleV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleV2.swift; sourceTree = "<group>"; };
 		D42C989D26CAE790002E3184 /* LifecycleV2Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleV2Constants.swift; sourceTree = "<group>"; };
@@ -1718,9 +1724,11 @@
 			isa = PBXGroup;
 			children = (
 				3F0397A824BE5FF30019F095 /* Log.swift */,
-				3F0397A924BE5FF30019F095 /* LogLevel.swift */,
+				BF4BDFC12C8F609500485ABC /* Logger.swift */,
+				BF4BDFC32C8F615400485ABC /* LoggerImpl.swift */,
 				3F0397A724BE5FF30019F095 /* Logging.swift */,
 				3F0397AD24BE5FF30019F095 /* LoggingService.swift */,
+				3F0397A924BE5FF30019F095 /* LogLevel.swift */,
 			);
 			path = log;
 			sourceTree = "<group>";
@@ -2046,6 +2054,7 @@
 				3FB66AA824CA004400502CAF /* ExtensionContainer.swift */,
 				3FB66AAD24CA004400502CAF /* ExtensionRuntime.swift */,
 				BF4BDFBD2C87D5AB00485ABC /* SDKInstanceIdentifier.swift */,
+				BF4BDFC52C8F623D00485ABC /* SDKInstanceLogger.swift */,
 				3FB66AAB24CA004400502CAF /* SharedState.swift */,
 				217E220424D1FD7900B70B3E /* SharedStateResult.swift */,
 				21A6737225434AE600A7E906 /* SharedStateType.swift */,
@@ -3261,6 +3270,7 @@
 				24D2A3D524DB5B370079DCCF /* HitQueuing+PrivacyStatus.swift in Sources */,
 				3FB66AD924CA004400502CAF /* LaunchRule.swift in Sources */,
 				BB0E397224FD56100050C181 /* RulesEngineNativeLogging.swift in Sources */,
+				BF4BDFC62C8F623D00485ABC /* SDKInstanceLogger.swift in Sources */,
 				21F79ABB24E70CDC003204C3 /* IDParsing.swift in Sources */,
 				3FB66AE524CA004400502CAF /* CachedConfiguration.swift in Sources */,
 				3FB66AC924CA004400502CAF /* MobileCore+Configuration.swift in Sources */,
@@ -3455,12 +3465,14 @@
 				92EEA6062589343700DBA3EE /* MessageMonitor.swift in Sources */,
 				3F0397DC24BE5FF30019F095 /* UserDefaultsNamedCollection.swift in Sources */,
 				92F06D0425BA33F4004C1700 /* Showable.swift in Sources */,
+				BF4BDFC42C8F615400485ABC /* LoggerImpl.swift in Sources */,
 				3F0397D524BE5FF30019F095 /* DataQueue.swift in Sources */,
 				BB00E26D24D9BF6C00C578C1 /* URLUtility.swift in Sources */,
 				3F0397DE24BE5FF30019F095 /* SystemInfoService.swift in Sources */,
 				3F0397F624BE60910019F095 /* FileUnzipper.swift in Sources */,
 				3F0397D424BE5FF30019F095 /* SQLiteWrapper.swift in Sources */,
 				3F0397D024BE5FF30019F095 /* HttpMethod.swift in Sources */,
+				BF4BDFC22C8F609500485ABC /* Logger.swift in Sources */,
 				3F0397CB24BE5FF30019F095 /* LogLevel.swift in Sources */,
 				BB00E26B24D8C9A600C578C1 /* Date+Format.swift in Sources */,
 				3F0397FA24BE60910019F095 /* FileUnzipperConstants.swift in Sources */,

--- a/AEPCore/Sources/eventhub/SDKInstanceLogger.swift
+++ b/AEPCore/Sources/eventhub/SDKInstanceLogger.swift
@@ -1,0 +1,70 @@
+//
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+*/
+
+import AEPServices
+
+/// Tenant aware logging service.
+class SDKInstanceLogger: Logger {
+    private static var instanceLoggers: [SDKInstanceIdentifier: SDKInstanceLogger] = [:]
+    
+    private let instance: SDKInstanceIdentifier
+    
+    private init(instance: SDKInstanceIdentifier) {
+        self.instance = instance
+    }
+    
+    /// Get a `SDKInstanceLogger` for the given `SDKInstanceIdentifier`.
+    /// - Parameter instance: the SDK instance identifier.
+    /// - Returns: a `Logger` for the given `instance`.
+    static func getForInstance(_ instance: SDKInstanceIdentifier) -> SDKInstanceLogger {
+        if let logger = instanceLoggers[instance] {
+            return logger
+        } else {
+            let logger = SDKInstanceLogger(instance: instance)
+            instanceLoggers[instance] = logger
+            return logger
+        }
+    }
+
+    /// Used to print more verbose information.
+    /// - Parameters:
+    ///   - label: the name of the label to localize message
+    ///   - message: the string to be logged
+    func trace(label: String, _ message: String) {
+        Log.trace(label: label.instanceAwareName(for: instance), message)
+    }
+
+    /// Information provided to the debug method should contain high-level details about the data being processed
+    /// - Parameters:
+    ///   - label: the name of the label to localize message
+    ///   - message: the string to be logged
+    func debug(label: String, _ message: String) {
+        Log.debug(label: label.instanceAwareName(for: instance), message)
+    }
+
+    /// Information provided to the warning method indicates that a request has been made to the SDK, but the SDK will be unable to perform the requested task
+    /// - Parameters:
+    ///   - label: the name of the label to localize message
+    ///   - message: the string to be logged
+    func warning(label: String, _ message: String) {
+        Log.warning(label: label.instanceAwareName(for: instance), message)
+    }
+
+    /// Information provided to the error method indicates that there has been an unrecoverable error
+    /// - Parameters:
+    ///   - label: the name of the label to localize message
+    ///   - message: the string to be logged
+    func error(label: String, _ message: String) {
+        Log.error(label: label.instanceAwareName(for: instance), message)
+    }
+}

--- a/AEPServices/Sources/log/Logger.swift
+++ b/AEPServices/Sources/log/Logger.swift
@@ -1,0 +1,40 @@
+//
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+*/
+
+@objc
+public protocol Logger {
+    
+    /// Used to print more verbose information.
+    /// - Parameters:
+    ///   - label: the name of the label to localize message
+    ///   - message: the string to be logged
+    func trace(label: String, _ message: String)
+
+    /// Information provided to the debug method should contain high-level details about the data being processed
+    /// - Parameters:
+    ///   - label: the name of the label to localize message
+    ///   - message: the string to be logged
+    func debug(label: String, _ message: String)
+
+    /// Information provided to the warning method indicates that a request has been made to the SDK, but the SDK will be unable to perform the requested task
+    /// - Parameters:
+    ///   - label: the name of the label to localize message
+    ///   - message: the string to be logged
+    func warning(label: String, _ message: String)
+
+    /// Information provided to the error method indicates that there has been an unrecoverable error
+    /// - Parameters:
+    ///   - label: the name of the label to localize message
+    ///   - message: the string to be logged
+    func error(label: String, _ message: String)
+}

--- a/AEPServices/Sources/log/LoggerImpl.swift
+++ b/AEPServices/Sources/log/LoggerImpl.swift
@@ -1,0 +1,49 @@
+//
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+*/
+
+import Foundation
+
+/// Basic `Logger` implementation which uses the `Log` class to log messages.
+class LoggerImpl: Logger {
+    /// Used to print more verbose information.
+    /// - Parameters:
+    ///   - label: the name of the label to localize message
+    ///   - message: the string to be logged
+    public func trace(label: String, _ message: String) {
+        Log.trace(label: label, message)
+    }
+
+    /// Information provided to the debug method should contain high-level details about the data being processed
+    /// - Parameters:
+    ///   - label: the name of the label to localize message
+    ///   - message: the string to be logged
+    public func debug(label: String, _ message: String) {
+        Log.debug(label: label, message)
+    }
+
+    /// Information provided to the warning method indicates that a request has been made to the SDK, but the SDK will be unable to perform the requested task
+    /// - Parameters:
+    ///   - label: the name of the label to localize message
+    ///   - message: the string to be logged
+    public func warning(label: String, _ message: String) {
+        Log.warning(label: label, message)
+    }
+
+    /// Information provided to the error method indicates that there has been an unrecoverable error
+    /// - Parameters:
+    ///   - label: the name of the label to localize message
+    ///   - message: the string to be logged
+    public func error(label: String, _ message: String) {
+        Log.error(label: label, message)
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds:

-  `Logger` protocol in AEPServices which defines methods for logging.
- `SDKInstanceLogger` implementation of `Logger` in AEPCore, initialized with an `SDKInstanceIdentifier`. Each log function uses `.instanceAwareName()` to include the SDK instance identifier in the log label. 
- `LoggerImpl` in AEPServices which is a base implementation of `Logger` used in instances where a Logger is needed without an SDKInstanceIdentifier.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
