### PR TITLE
Update EventHub with Multi-Instance Support

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -422,6 +422,8 @@
 		92F06BFC25B8F1FE004C1700 /* MessageMonitoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F06BFB25B8F1FE004C1700 /* MessageMonitoring.swift */; };
 		92F06D0425BA33F4004C1700 /* Showable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F06D0325BA33F3004C1700 /* Showable.swift */; };
 		AC1089C926DD87C0004ABAC4 /* XDMLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1089C826DD87C0004ABAC4 /* XDMLanguage.swift */; };
+		AC3835C22C98FD47000CE68E /* MockLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC3835C12C98FD41000CE68E /* MockLogger.swift */; };
+		AC5C517D2C8FA7770021C1E9 /* EventHubProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC5C517C2C8FA76E0021C1E9 /* EventHubProvider.swift */; };
 		ACC7A9762A0EA51F001A04FB /* EventHistoryIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC7A9752A0EA51F001A04FB /* EventHistoryIntegrationTests.swift */; };
 		ACC7A97B2A12AF9D001A04FB /* rules_attach.json in Resources */ = {isa = PBXBuildFile; fileRef = ACC7A9792A12AF9D001A04FB /* rules_attach.json */; };
 		ACC7A97C2A12AF9D001A04FB /* rules_attach.zip in Resources */ = {isa = PBXBuildFile; fileRef = ACC7A97A2A12AF9D001A04FB /* rules_attach.zip */; };
@@ -1158,7 +1160,9 @@
 		A5F5A65742E1DBDC25CF9F98 /* Pods-AEPIdentityTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPIdentityTests.debug.xcconfig"; path = "Target Support Files/Pods-AEPIdentityTests/Pods-AEPIdentityTests.debug.xcconfig"; sourceTree = "<group>"; };
 		AA4461A0B65C5DFE219540A5 /* Pods-TestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestApp.release.xcconfig"; path = "Target Support Files/Pods-TestApp/Pods-TestApp.release.xcconfig"; sourceTree = "<group>"; };
 		AC1089C826DD87C0004ABAC4 /* XDMLanguage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XDMLanguage.swift; sourceTree = "<group>"; };
+		AC3835C12C98FD41000CE68E /* MockLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLogger.swift; sourceTree = "<group>"; };
 		AC4D8D4526D9AC0200A86435 /* EventTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventTests.swift; sourceTree = "<group>"; };
+		AC5C517C2C8FA76E0021C1E9 /* EventHubProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHubProvider.swift; sourceTree = "<group>"; };
 		AC838996795DECE800B0A11B /* Pods-AEPIdentityTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPIdentityTests.release.xcconfig"; path = "Target Support Files/Pods-AEPIdentityTests/Pods-AEPIdentityTests.release.xcconfig"; sourceTree = "<group>"; };
 		ACC7A9752A0EA51F001A04FB /* EventHistoryIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHistoryIntegrationTests.swift; sourceTree = "<group>"; };
 		ACC7A9792A12AF9D001A04FB /* rules_attach.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_attach.json; sourceTree = "<group>"; };
@@ -2052,6 +2056,7 @@
 				3FB66AB224CA004400502CAF /* Extension.swift */,
 				3FB66AA824CA004400502CAF /* ExtensionContainer.swift */,
 				3FB66AAD24CA004400502CAF /* ExtensionRuntime.swift */,
+				AC5C517C2C8FA76E0021C1E9 /* EventHubProvider.swift */,
 				BF4BDFBD2C87D5AB00485ABC /* SDKInstanceIdentifier.swift */,
 				BF4BDFC52C8F623D00485ABC /* SDKInstanceLogger.swift */,
 				BF4BDFD02C93994000485ABC /* ExtensionServiceProvider.swift */,
@@ -2170,6 +2175,7 @@
 				4CF028212C2CCA0F008ADE05 /* MockDataQueue.swift */,
 				4CF028272C2CCA10008ADE05 /* MockDataStore.swift */,
 				4CF028202C2CCA0F008ADE05 /* MockHitProcessor.swift */,
+				AC3835C12C98FD41000CE68E /* MockLogger.swift */,
 				4CF028192C2CCA0F008ADE05 /* MockNetworkService.swift */,
 				4CF0281A2C2CCA0F008ADE05 /* NamedCollectionDataStore+TestHelper.swift */,
 				4CF0281B2C2CCA0F008ADE05 /* NetworkRequest+DeepCopy.swift */,
@@ -3271,6 +3277,7 @@
 				3FB66AD924CA004400502CAF /* LaunchRule.swift in Sources */,
 				BB0E397224FD56100050C181 /* RulesEngineNativeLogging.swift in Sources */,
 				BF4BDFC62C8F623D00485ABC /* SDKInstanceLogger.swift in Sources */,
+				AC5C517D2C8FA7770021C1E9 /* EventHubProvider.swift in Sources */,
 				21F79ABB24E70CDC003204C3 /* IDParsing.swift in Sources */,
 				3FB66AE524CA004400502CAF /* CachedConfiguration.swift in Sources */,
 				3FB66AC924CA004400502CAF /* MobileCore+Configuration.swift in Sources */,
@@ -3577,6 +3584,7 @@
 				4CF028752C2CCBD3008ADE05 /* MockMessagingDelegate.swift in Sources */,
 				4CF028762C2CCBD3008ADE05 /* MockSystemInfoService.swift in Sources */,
 				4CF028772C2CCBD3008ADE05 /* MockTask.swift in Sources */,
+				AC3835C22C98FD47000CE68E /* MockLogger.swift in Sources */,
 				4CF028782C2CCBD3008ADE05 /* MockUnzipper.swift in Sources */,
 				4CF028792C2CCBD3008ADE05 /* MockURLService.swift in Sources */,
 				4CF0287A2C2CCBD3008ADE05 /* MockURLSession.swift in Sources */,

--- a/AEPCore/Mocks/PublicTestUtils/EventHub+TestHelper.swift
+++ b/AEPCore/Mocks/PublicTestUtils/EventHub+TestHelper.swift
@@ -15,6 +15,6 @@ import Foundation
 
 extension EventHub {
     public static func reset() {
-        shared = EventHub()
+        shared = EventHub(identifier: .default)
     }
 }

--- a/AEPCore/Mocks/PublicTestUtils/MockEventHistoryDatabase.swift
+++ b/AEPCore/Mocks/PublicTestUtils/MockEventHistoryDatabase.swift
@@ -12,9 +12,9 @@
 
 import Foundation
 @testable import AEPCore
+import AEPServicesMocks
 
 class MockEventHistoryDatabase: EventHistoryDatabase {
-
     var paramHash: UInt32?
     var paramTimestamp: Date?
     var paramFrom: Date?
@@ -24,11 +24,11 @@ class MockEventHistoryDatabase: EventHistoryDatabase {
     var returnDelete: Int = 0
 
     init?() {
-        super.init(dispatchQueue: DispatchQueue(label: "mockEventHistoryDatabase"))
+        super.init(dbName: "MockEventHistoryDatabase", dbQueue: DispatchQueue(label: "MockEventHistoryDatabase"), logger: MockLogger())
     }
 
     override func insert(hash: UInt32, timestamp: Date, handler: ((Bool) -> Void)? = nil) {
-        dispatchQueue.async {
+        dbQueue.async {
             self.paramHash = hash
             self.paramTimestamp = timestamp
             handler?(self.returnInsert)
@@ -36,7 +36,7 @@ class MockEventHistoryDatabase: EventHistoryDatabase {
     }
 
     override func select(hash: UInt32, from: Date? = nil, to: Date? = nil, handler: @escaping (EventHistoryResult) -> Void) {
-        dispatchQueue.async {
+        dbQueue.async {
             self.paramHash = hash
             self.paramFrom = from
             self.paramTo = to
@@ -45,7 +45,7 @@ class MockEventHistoryDatabase: EventHistoryDatabase {
     }
 
     override func delete(hash: UInt32, from: Date? = nil, to: Date? = nil, handler: ((Int) -> Void)? = nil) {
-        dispatchQueue.async {
+        dbQueue.async {
             self.paramHash = hash
             self.paramFrom = from
             self.paramTo = to

--- a/AEPCore/Mocks/PublicTestUtils/TestableExtensionRuntime.swift
+++ b/AEPCore/Mocks/PublicTestUtils/TestableExtensionRuntime.swift
@@ -12,6 +12,7 @@
 
 @testable import AEPCore
 import Foundation
+import AEPServicesMocks
 
 /// Testable implementation for `ExtensionRuntime`
 ///
@@ -180,6 +181,11 @@ public class TestableExtensionRuntime: ExtensionRuntime {
         receivedEnforceOrder = enforceOrder
         handler(mockEventHistoryResults)
     }
+    
+    public func getServiceProvider() -> ExtensionServiceProvider {
+        ExtensionServiceProvider(identifier: .default, logger: MockLogger())
+    }
+    
 }
 
 /// Convenience properties for `TestableExtensionRuntime`

--- a/AEPCore/Sources/eventhub/EventHubProvider.swift
+++ b/AEPCore/Sources/eventhub/EventHubProvider.swift
@@ -1,0 +1,36 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+
+class EventHubProvider {
+    
+    private let dispatchQueue = DispatchQueue(label: "com.adobe.eventHubProvider")
+    private var eventHubs: [SDKInstanceIdentifier: EventHub] = [
+        .default: EventHub(identifier: .default)
+    ]
+
+    // Creates an EventHub instance for the given identifier if it does not already exist.
+    func createEventHub(for identifier: SDKInstanceIdentifier) {
+        dispatchQueue.sync {
+            guard eventHubs[identifier] == nil else { return }
+            eventHubs[identifier] = EventHub(identifier: identifier)
+        }
+    }
+
+    // Retrieves the EventHub instance for the given identifier.
+    func getEventHub(for identifier: SDKInstanceIdentifier) -> EventHub? {
+        dispatchQueue.sync {
+            return eventHubs[identifier]
+        }
+    }
+}

--- a/AEPCore/Sources/eventhub/Extension.swift
+++ b/AEPCore/Sources/eventhub/Extension.swift
@@ -192,6 +192,7 @@ public extension Extension {
     /// Register a event preprocessor
     /// - Parameter preprocessor: The `EventPreprocessor`
     internal func registerPreprocessor(_ preprocessor: @escaping EventPreprocessor) {
-        EventHub.shared.registerPreprocessor(preprocessor)
+        guard let container = runtime as? ExtensionContainer else { return }
+        container.registerPreprocessor(preprocessor: preprocessor)        
     }
 }

--- a/AEPCore/Sources/eventhub/ExtensionRuntime.swift
+++ b/AEPCore/Sources/eventhub/ExtensionRuntime.swift
@@ -124,4 +124,13 @@ public protocol ExtensionRuntime {
     ///                   from date
     ///   - handler: contains an `EventHistoryResult` for each provided request
     func getHistoricalEvents(_ requests: [EventHistoryRequest], enforceOrder: Bool, handler: @escaping ([EventHistoryResult]) -> Void)
+
+    // MARK: - Extension Services
+
+    /// Returns an instance of `ExtensionServiceProvider`, which is used to provide core services.
+    /// This is a wrapper around the shared `ServiceProvider`, handling service translations for a multi-instance SDK, so extensions don't need to manage them manually.
+    /// 
+    /// - Returns: An instance of `ExtensionServiceProvider`.
+    func getServiceProvider() -> ExtensionServiceProvider
+
 }

--- a/AEPCore/Sources/eventhub/ExtensionServiceProvider.swift
+++ b/AEPCore/Sources/eventhub/ExtensionServiceProvider.swift
@@ -19,9 +19,9 @@ public class ExtensionServiceProvider: NSObject {
     private let identifier: SDKInstanceIdentifier
     private let logger: Logger
 
-    init(identifier: SDKInstanceIdentifier) {
+    init(identifier: SDKInstanceIdentifier, logger: Logger) {
         self.identifier = identifier
-        self.logger = SDKInstanceLogger(identifier: identifier)
+        self.logger = logger
     }
 
     /// Gets the app group.
@@ -98,10 +98,10 @@ extension ExtensionServiceProvider {
     }
 
     #if os(iOS)
-    /// Returns a shared instance of type `UIService` provided by the shared `ServiceProvider`.
-    /// - Returns: a shared instance of type `UIService`
-    public func getUIService() -> UIService {
-        return ServiceProvider.shared.uiService
-    }
+        /// Returns a shared instance of type `UIService` provided by the shared `ServiceProvider`.
+        /// - Returns: a shared instance of type `UIService`
+        public func getUIService() -> UIService {
+            return ServiceProvider.shared.uiService
+        }
     #endif
 }

--- a/AEPCore/Sources/eventhub/SDKInstanceIdentifier.swift
+++ b/AEPCore/Sources/eventhub/SDKInstanceIdentifier.swift
@@ -90,3 +90,15 @@ extension String {
         return "aep.\(instanceId).\(self)"
     }
 }
+
+extension DispatchQueue {
+    /// Initializes a new `DispatchQueue` with a label that is specific to the provided `SDKInstanceIdentifier`.
+    ///
+    /// - Parameters:
+    ///   - identifier: The `SDKInstanceIdentifier` used to make the queue label instance-specific.
+    ///   - label: A base label string, to which the identifier will be appended to create a unique queue label.
+    convenience init(for identifier: SDKInstanceIdentifier, label: String) {
+        let label = label.instanceAwareLabel(for: identifier)
+        self.init(label: label)
+    }
+}

--- a/AEPCore/Tests/EventHubTests/EventHubTests.swift
+++ b/AEPCore/Tests/EventHubTests/EventHubTests.swift
@@ -24,7 +24,7 @@ class EventHubTests: XCTestCase {
     var eventHub: EventHub!
 
     override func setUp() {
-        eventHub = EventHub()
+        eventHub = EventHub(identifier: .default)
         MockExtension.reset()
         MockExtensionTwo.reset()
         registerMockExtension(MockExtension.self)
@@ -769,7 +769,7 @@ class EventHubTests: XCTestCase {
     }
 
     func testEventHubDeinit() {
-        var hub: EventHub? = EventHub()
+        var hub: EventHub? = EventHub(identifier: .default)
         hub = nil
         XCTAssert(hub == nil)
     }

--- a/AEPIdentity/Tests/TestHelpers/TestableExtensionRuntime.swift
+++ b/AEPIdentity/Tests/TestHelpers/TestableExtensionRuntime.swift
@@ -12,6 +12,7 @@
 
 @testable import AEPCore
 import Foundation
+import AEPServicesMocks
 
 class TestableExtensionRuntime: ExtensionRuntime {
     var listeners: [String: EventListener] = [:]
@@ -121,4 +122,9 @@ class TestableExtensionRuntime: ExtensionRuntime {
     func startEvents() {}
 
     func stopEvents() {}
+    
+    func getServiceProvider() -> ExtensionServiceProvider {
+        return ExtensionServiceProvider(identifier: .default, logger: MockLogger())
+    }
+    
 }

--- a/AEPIntegrationTests/TestHelpers.swift
+++ b/AEPIntegrationTests/TestHelpers.swift
@@ -14,7 +14,7 @@ import XCTest
 
 extension EventHub {
     static func reset() {
-        shared = EventHub()
+        shared = EventHub(identifier: .default)
     }
 }
 

--- a/AEPServices/Mocks/PublicTestUtils/MockLogger.swift
+++ b/AEPServices/Mocks/PublicTestUtils/MockLogger.swift
@@ -1,0 +1,25 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+*/
+
+import AEPServices
+
+public class MockLogger: Logger {
+    public init() {}
+    
+    public func trace(label: String, _ message: String) {}
+    
+    public func debug(label: String, _ message: String) {}
+    
+    public func warning(label: String, _ message: String) {}
+    
+    public func error(label: String, _ message: String) {}
+}

--- a/AEPServices/Sources/utility/ThreadSafeDictionary.swift
+++ b/AEPServices/Sources/utility/ThreadSafeDictionary.swift
@@ -34,11 +34,18 @@ public final class ThreadSafeDictionary<K: Hashable, V> {
         return queue.sync { return Array(self.dictionary.keys) }
     }
 
-    // Gets a non-thread-safe shallow copy of the backing dictionary
+    /// Gets a non-thread-safe shallow copy of the backing dictionary
     public var shallowCopy: [K: V] {
         return queue.sync {
             let dictionary = self.dictionary
             return dictionary
+        }
+    }
+
+    /// Clears the dictionary by removing all elements
+    public func clear() {
+        queue.async {
+            self.dictionary.removeAll()
         }
     }
 


### PR DESCRIPTION
**EventHub**
 - Updated EventHub to support multiple instances.
 - Updated labels for DispatchQueue and EventQueue to include instance information. Labels for `ThreadSafeArray` and `ThreadSafeDictionaries` were not updated, as they would not provide useful information and would add unnecessary clutter. 
 - `EventHub.shared` was not cleaned up in this PR; it will be addressed in a separate PR, which will involve significant updates to our tests. 
 
**ExtensionRuntime**
- Added a new API in to expose `ExtensionServiceProvider` to extensions.

**ExtensionContainer**
- Cleanup dependencies and implemented the new `ExtensionRuntime` API.
- Moved `EventPreprocessor` registration to `ExtensionContainer`. This API should ideally be exposed through `ExtensionRuntime` to avoid such workarounds. This issue is outside the scope of multi-instance implementation and will be addressed separately. 

**EventHistory**
- Updated `EventHistory` to support multiple instances.
- Cleaned up current tests 
- Added new tests to verify multi-instance functionality.

**Other**
- Add the `EventHubProvider` class. Tests and integration for this class will be included in a follow-up PR as part of the Core API implementation.