### PR TITLE
Add multi-instance support for Configuration extension

### DIFF
--- a/AEPCore/Sources/configuration/Configuration.swift
+++ b/AEPCore/Sources/configuration/Configuration.swift
@@ -48,10 +48,10 @@ class Configuration: NSObject, Extension, MultiInstanceCapable {
             networking: serviceProvider.getNetworkService(),
             systemInfoService: serviceProvider.getSystemInfoService())
         self.configState = ConfigurationState(
-            dataStore: dataStore,
-            logger: logger,
             configDownloader: configDownloader,
-            appIdManager: appIdManager)
+            appIdManager: appIdManager,
+            dataStore: dataStore,
+            logger: logger)
     }
 
     /// Invoked when the Configuration extension has been registered by the `EventHub`, this results in the Configuration extension loading the first configuration for the SDK

--- a/AEPCore/Sources/configuration/Configuration.swift
+++ b/AEPCore/Sources/configuration/Configuration.swift
@@ -14,7 +14,7 @@ import AEPServices
 import Foundation
 
 /// Responsible for retrieving the configuration of the SDK and updating the shared state and dispatching configuration updates through the `EventHub`
-class Configuration: NSObject, Extension {
+class Configuration: NSObject, Extension, MultiInstanceCapable {
     let runtime: ExtensionRuntime
     let name = ConfigurationConstants.EXTENSION_NAME
     let friendlyName = ConfigurationConstants.FRIENDLY_NAME

--- a/AEPCore/Sources/configuration/Configuration.swift
+++ b/AEPCore/Sources/configuration/Configuration.swift
@@ -21,7 +21,7 @@ class Configuration: NSObject, Extension {
     public static let extensionVersion = ConfigurationConstants.EXTENSION_VERSION
     let metadata: [String: String]? = nil
 
-    private let dataStore = NamedCollectionDataStore(name: ConfigurationConstants.DATA_STORE_NAME)
+    private let dataStore: NamedCollectionDataStore
     private var appIdManager: LaunchIDManager
     private var configState: ConfigurationState // should only be modified/used within the event queue
     private let rulesEngine: LaunchRulesEngine
@@ -29,15 +29,29 @@ class Configuration: NSObject, Extension {
     private let rulesEngineName = "\(ConfigurationConstants.EXTENSION_NAME).rulesengine"
     private var retryConfigurationCounter: Double = 1
 
+    private let logger: Logger
+
     // MARK: - Extension
 
     /// Initializes the Configuration extension and it's dependencies
     required init(runtime: ExtensionRuntime) {
         self.runtime = runtime
-        rulesEngine = LaunchRulesEngine(name: rulesEngineName, extensionRuntime: runtime)
+        let serviceProvider = runtime.getServiceProvider()
+        self.logger = serviceProvider.getLogger()
+        self.dataStore = serviceProvider.getNamedCollectionDataStore(name: ConfigurationConstants.DATA_STORE_NAME)
 
-        appIdManager = LaunchIDManager(dataStore: dataStore)
-        configState = ConfigurationState(dataStore: dataStore, configDownloader: ConfigurationDownloader())
+        self.rulesEngine = LaunchRulesEngine(name: rulesEngineName, extensionRuntime: runtime)
+
+        self.appIdManager = LaunchIDManager(dataStore: dataStore, logger: logger)
+        let configDownloader = ConfigurationDownloader(
+            logger: logger,
+            networking: serviceProvider.getNetworkService(),
+            systemInfoService: serviceProvider.getSystemInfoService())
+        self.configState = ConfigurationState(
+            dataStore: dataStore,
+            logger: logger,
+            configDownloader: configDownloader,
+            appIdManager: appIdManager)
     }
 
     /// Invoked when the Configuration extension has been registered by the `EventHub`, this results in the Configuration extension loading the first configuration for the SDK
@@ -54,12 +68,16 @@ class Configuration: NSObject, Extension {
         configState.loadInitialConfig()
         let config = configState.environmentAwareConfiguration
         if !config.isEmpty {
-            let responseEvent = Event(name: CoreConstants.EventNames.CONFIGURATION_RESPONSE_EVENT, type: EventType.configuration, source: EventSource.responseContent, data: config)
+            let responseEvent = Event(
+                name: CoreConstants.EventNames.CONFIGURATION_RESPONSE_EVENT,
+                type: EventType.configuration,
+                source: EventSource.responseContent,
+                data: config)
             dispatch(event: responseEvent)
             createSharedState(data: config, event: nil)
             // notify rules engine to load cached rules
             if let rulesURLString = config[ConfigurationConstants.Keys.RULES_URL] as? String {
-                Log.trace(label: name, "Reading rules from cache for URL: \(rulesURLString)")
+                logger.trace(label: name, "Reading rules from cache for URL: \(rulesURLString)")
                 if !rulesEngine.replaceRulesWithCache(from: rulesURLString) {
                     if let url = Bundle.main.url(forResource: RulesDownloaderConstants.RULES_BUNDLED_FILE_NAME, withExtension: "zip") {
                         // Attempt to load rules from manifest if none in cache
@@ -107,7 +125,7 @@ class Configuration: NSObject, Extension {
     private func processUpdateConfig(event: Event, sharedStateResolver: SharedStateResolver) {
         // Update the overriddenConfig with the new config from API and persist them in disk, and abort if overridden config is empty
         guard let updatedConfig = event.data?[ConfigurationConstants.Keys.UPDATE_CONFIG] as? [String: Any], !updatedConfig.isEmpty else {
-            Log.warning(label: name, "Overriden config is empty, resolving pending shared state with current config")
+            logger.warning(label: name, "Overriden config is empty, resolving pending shared state with current config")
             sharedStateResolver(configState.environmentAwareConfiguration)
             return
         }
@@ -125,7 +143,7 @@ class Configuration: NSObject, Extension {
     private func processConfigureWith(appId: String, event: Event, sharedStateResolver: @escaping SharedStateResolver) {
         guard !appId.isEmpty else {
             // Error: No appId provided or its empty, resolve pending shared state with current config
-            Log.warning(label: name, "No AppID provided or it is empty, resolving pending shared state with current config")
+            logger.warning(label: name, "No AppID provided or it is empty, resolving pending shared state with current config")
             appIdManager.removeAppIdFromPersistence()
             sharedStateResolver(configState.environmentAwareConfiguration)
             return
@@ -138,7 +156,7 @@ class Configuration: NSObject, Extension {
         }
 
         guard !isStaleAppIdUpdateRequest(newAppId: appId, isInternalEvent: event.isInternalConfigEvent) else {
-            Log.debug(label: name, "An explicit configureWithAppId request has preceded this internal event.")
+            logger.debug(label: name, "An explicit configureWithAppId request has preceded this internal event.")
             return
         }
 
@@ -154,10 +172,13 @@ class Configuration: NSObject, Extension {
                 sharedStateResolver(self.configState.environmentAwareConfiguration)
                 self.startEvents()
                 let retryInterval = self.retryConfigurationCounter * 5
-                Log.trace(label: self.name, "Downloading config failed, trying again after \(retryInterval) secs")
+                logger.trace(label: self.name, "Downloading config failed, trying again after \(retryInterval) secs")
                 self.retryQueue.asyncAfter(deadline: .now() + retryInterval) {
-                    let event = Event(name: CoreConstants.EventNames.CONFIGURE_WITH_APP_ID, type: EventType.configuration, source: EventSource.requestContent,
-                                      data: [CoreConstants.Keys.JSON_APP_ID: appId, CoreConstants.Keys.IS_INTERNAL_EVENT: true])
+                    let event = Event(
+                        name: CoreConstants.EventNames.CONFIGURE_WITH_APP_ID,
+                        type: EventType.configuration,
+                        source: EventSource.requestContent,
+                        data: [CoreConstants.Keys.JSON_APP_ID: appId, CoreConstants.Keys.IS_INTERNAL_EVENT: true])
                     self.dispatch(event: event)
                     self.retryConfigurationCounter += 1
                 }
@@ -194,7 +215,7 @@ class Configuration: NSObject, Extension {
     private func processConfigureWith(filePath: String, event: Event, sharedStateResolver: SharedStateResolver) {
         guard let filePath = event.data?[ConfigurationConstants.Keys.JSON_FILE_PATH] as? String, !filePath.isEmpty else {
             // Error: Shared state is updated with previous config
-            Log.warning(label: name, "Loaded configuration from file path was empty, using previous config.")
+            logger.warning(label: name, "Loaded configuration from file path was empty, using previous config.")
             sharedStateResolver(configState.environmentAwareConfiguration)
             return
         }
@@ -222,13 +243,21 @@ class Configuration: NSObject, Extension {
     ///   - data: Optional data to be attached to the event
     private func dispatchConfigurationResponse(requestEvent: Event?, data: [String: Any]?) {
         if let requestEvent = requestEvent {
-            let pairedResponseEvent = requestEvent.createResponseEvent(name: CoreConstants.EventNames.CONFIGURATION_RESPONSE_EVENT, type: EventType.configuration, source: EventSource.responseContent, data: data)
+            let pairedResponseEvent = requestEvent.createResponseEvent(
+                name: CoreConstants.EventNames.CONFIGURATION_RESPONSE_EVENT,
+                type: EventType.configuration,
+                source: EventSource.responseContent,
+                data: data)
             dispatch(event: pairedResponseEvent)
             return
         }
 
         // send a generic event if this is not the response to a getter
-        let responseEvent = Event(name: CoreConstants.EventNames.CONFIGURATION_RESPONSE_EVENT, type: EventType.configuration, source: EventSource.responseContent, data: data)
+        let responseEvent = Event(
+            name: CoreConstants.EventNames.CONFIGURATION_RESPONSE_EVENT,
+            type: EventType.configuration,
+            source: EventSource.responseContent,
+            data: data)
         dispatch(event: responseEvent)
         return
 

--- a/AEPCore/Sources/configuration/ConfigurationState.swift
+++ b/AEPCore/Sources/configuration/ConfigurationState.swift
@@ -19,6 +19,7 @@ class ConfigurationState {
 
     private let queue = DispatchQueue(label: "com.adobe.configurationState")
     private let dataStore: NamedCollectionDataStore
+    private let logger: Logger
     private let appIdManager: LaunchIDManager
     private let configDownloader: ConfigurationDownloadable
 
@@ -35,7 +36,7 @@ class ConfigurationState {
             if let storedConfig: [String: AnyCodable] = dataStore.getObject(key: ConfigurationConstants.DataStoreKeys.PERSISTED_OVERRIDDEN_CONFIG) {
                 return storedConfig
             } else {
-                Log.trace(label: logTag, "Config not found in data store, returning empty config")
+                logger.trace(label: logTag, "Config not found in data store, returning empty config")
                 return [:]
             }
         }
@@ -47,12 +48,14 @@ class ConfigurationState {
     /// Creates a new `ConfigurationState` with an empty current configuration
     /// - Parameters:
     ///   - dataStore: The datastore in which configurations are cached
-    ///   - configDownloader: A `ConfigurationDownloadable` which will be responsible for loading the configuration
-    ///     from various locations
-    init(dataStore: NamedCollectionDataStore, configDownloader: ConfigurationDownloadable) {
+    ///   - logger: The logging service
+    ///   - configDownloader: A `ConfigurationDownloadable` which will be responsible for loading the configuration from various locations
+    ///   - appIdManager: Manger for storing and loading the app ID
+    init(dataStore: NamedCollectionDataStore, logger: Logger, configDownloader: ConfigurationDownloadable, appIdManager: LaunchIDManager) {
         self.dataStore = dataStore
+        self.logger = logger
         self.configDownloader = configDownloader
-        appIdManager = LaunchIDManager(dataStore: dataStore)
+        self.appIdManager = appIdManager
     }
 
     /// Computes and returns environment aware configuration based on `self.currentConfiguration`
@@ -133,7 +136,7 @@ class ConfigurationState {
         // Remove all __env__ keys, only need to process config keys who do not have the environment prefix
         var environmentAwareConfig = currentConfiguration.filter { !$0.key.hasPrefix(ConfigurationConstants.ENVIRONMENT_PREFIX_DELIMITER) }
         guard let buildEnvironment = currentConfiguration[ConfigurationConstants.Keys.BUILD_ENVIRONMENT] as? String else {
-            Log.trace(label: logTag, "Build environment not found in current config, returning environment aware config.")
+            logger.trace(label: logTag, "Build environment not found in current config, returning environment aware config.")
             return environmentAwareConfig
         }
 
@@ -153,7 +156,7 @@ class ConfigurationState {
     /// - Returns: `programmaticConfig` with all keys mapped to their build environment equivalent
     private func mapEnvironmentKeys(programmaticConfig: [String: Any]) -> [String: Any] {
         guard let buildEnvironment = currentConfiguration[ConfigurationConstants.Keys.BUILD_ENVIRONMENT] as? String else {
-            Log.trace(label: logTag, "Build environment not found in current config, returning programmatic config.")
+            logger.trace(label: logTag, "Build environment not found in current config, returning programmatic config.")
             return programmaticConfig
         }
 
@@ -201,7 +204,7 @@ extension ConfigurationState {
                 ?? configDownloader.loadDefaultConfigFromManifest()
                 ?? [:]
         } else {
-            Log.trace(label: logTag, "App ID not found, attempting to load default config from manifest")
+            logger.trace(label: logTag, "App ID not found, attempting to load default config from manifest")
             config = configDownloader.loadDefaultConfigFromManifest() ?? [:]
         }
 

--- a/AEPCore/Sources/configuration/ConfigurationState.swift
+++ b/AEPCore/Sources/configuration/ConfigurationState.swift
@@ -47,11 +47,11 @@ class ConfigurationState {
 
     /// Creates a new `ConfigurationState` with an empty current configuration
     /// - Parameters:
-    ///   - dataStore: The datastore in which configurations are cached
-    ///   - logger: The logging service
     ///   - configDownloader: A `ConfigurationDownloadable` which will be responsible for loading the configuration from various locations
     ///   - appIdManager: Manger for storing and loading the app ID
-    init(dataStore: NamedCollectionDataStore, logger: Logger, configDownloader: ConfigurationDownloadable, appIdManager: LaunchIDManager) {
+    ///   - dataStore: The datastore in which configurations are cached
+    ///   - logger: The logging service
+    init(configDownloader: ConfigurationDownloadable, appIdManager: LaunchIDManager, dataStore: NamedCollectionDataStore, logger: Logger) {
         self.dataStore = dataStore
         self.logger = logger
         self.configDownloader = configDownloader

--- a/AEPCore/Sources/configuration/LaunchIDManager.swift
+++ b/AEPCore/Sources/configuration/LaunchIDManager.swift
@@ -16,6 +16,7 @@ import Foundation
 /// Handles loading and saving the launch appId to the data store and manifest
 struct LaunchIDManager {
     let dataStore: NamedCollectionDataStore
+    let logger: Logger
     private let logTag = "LaunchIDManager"
 
     /// Loads the appId from the data store, if not present in the data store loads from the manifest
@@ -29,7 +30,7 @@ struct LaunchIDManager {
     /// - Parameter appId: appId to be saved to data store
     func saveAppIdToPersistence(appId: String) {
         if appId.isEmpty {
-            Log.trace(label: logTag, "Attempting to set App ID in data store with empty string")
+            logger.trace(label: logTag, "Attempting to set App ID in data store with empty string")
             return
         }
         dataStore.set(key: ConfigurationConstants.DataStoreKeys.PERSISTED_APPID, value: appId)
@@ -44,10 +45,10 @@ struct LaunchIDManager {
     /// - Returns: appId loaded from persistence, nil if not present
     func loadAppIdFromPersistence() -> String? {
         if let appId = dataStore.getString(key: ConfigurationConstants.DataStoreKeys.PERSISTED_APPID) {
-            Log.trace(label: logTag, "Loading App ID from persistence with appId: \(appId)")
+            logger.trace(label: logTag, "Loading App ID from persistence with appId: \(appId)")
             return appId
         }
-        Log.trace(label: logTag, "App ID not found in data store")
+        logger.trace(label: logTag, "App ID not found in data store")
         return nil
     }
 
@@ -56,10 +57,10 @@ struct LaunchIDManager {
     func loadAppIdFromManifest() -> String? {
         if let appId = ServiceProvider.shared.systemInfoService.getProperty(for: ConfigurationConstants.CONFIG_MANIFEST_APPID_KEY) {
             saveAppIdToPersistence(appId: appId)
-            Log.trace(label: logTag, "Loading App ID from manifest with appId: \(appId)")
+            logger.trace(label: logTag, "Loading App ID from manifest with appId: \(appId)")
             return appId
         }
-        Log.trace(label: logTag, "App ID not found in manifest")
+        logger.trace(label: logTag, "App ID not found in manifest")
         return nil
     }
 }

--- a/AEPCore/Sources/rules/LaunchRuleTransformer.swift
+++ b/AEPCore/Sources/rules/LaunchRuleTransformer.swift
@@ -18,11 +18,9 @@ import AEPRulesEngine
 class LaunchRuleTransformer {
 
     let transformer: Transformer
-    let runtime: ExtensionRuntime
 
-    init(runtime: ExtensionRuntime) {
+    init() {
         self.transformer = Transformer()
-        self.runtime = runtime
         addFunctionalTransformations(to: self.transformer)
         addTypeTransformations(to: self.transformer)
     }

--- a/AEPCore/Sources/rules/LaunchRulesEngine+Downloader.swift
+++ b/AEPCore/Sources/rules/LaunchRulesEngine+Downloader.swift
@@ -20,26 +20,32 @@ public extension LaunchRulesEngine {
     /// - Parameter urlString: the url of the remote rules
     func replaceRules(from urlString: String) {
         guard let url = URL(string: urlString) else {
-            Log.warning(label: RulesConstants.LOG_MODULE_PREFIX, "Invalid rules url: \(urlString)")
+            logger.warning(label: RulesConstants.LOG_MODULE_PREFIX, "Invalid rules url: \(urlString)")
             return
         }
-        let rulesDownloader = RulesDownloader(fileUnzipper: FileUnzipper())
+        let serviceProvider = extensionRuntime.getServiceProvider()
+        let rulesDownloader = RulesDownloader(
+            fileUnzipper: FileUnzipper(),
+            cache: serviceProvider.getCache(name: RulesDownloaderConstants.RULES_CACHE_NAME),
+            logger: logger,
+            networking: serviceProvider.getNetworkService()
+        )
         rulesDownloader.loadRulesFromUrl(rulesUrl: url) { [weak self] result in
             guard let self = self else { return }
 
             switch result {
             case .success(let data):
                 guard let rules = JSONRulesParser.parse(data) else {
-                    Log.debug(label: RulesConstants.LOG_MODULE_PREFIX, "Unable to parse rules for data from URL: \(urlString)")
+                    logger.debug(label: RulesConstants.LOG_MODULE_PREFIX, "Unable to parse rules for data from URL: \(urlString)")
                     return
                 }
                 self.replaceRules(with: rules)
             case .failure(let error):
                 switch error {
                 case .notModified:
-                    Log.trace(label: RulesConstants.LOG_MODULE_PREFIX, "Rules were not modified, not loading rules from url: \(urlString)")
+                    logger.trace(label: RulesConstants.LOG_MODULE_PREFIX, "Rules were not modified, not loading rules from url: \(urlString)")
                 default:
-                    Log.debug(label: RulesConstants.LOG_MODULE_PREFIX, "Failed to load rules from url: \(urlString), with error: \(error.localizedDescription)")
+                    logger.debug(label: RulesConstants.LOG_MODULE_PREFIX, "Failed to load rules from url: \(urlString), with error: \(error.localizedDescription)")
                 }
             }
         }
@@ -49,33 +55,45 @@ public extension LaunchRulesEngine {
     /// - Parameter urlString: the url of the remote rules
     func replaceRulesWithCache(from urlString: String) -> Bool {
         guard let url = URL(string: urlString) else {
-            Log.warning(label: RulesConstants.LOG_MODULE_PREFIX, "Invalid rules url: \(urlString)")
+            logger.warning(label: RulesConstants.LOG_MODULE_PREFIX, "Invalid rules url: \(urlString)")
             return false
         }
-        let rulesDownloader = RulesDownloader(fileUnzipper: FileUnzipper())
+        let serviceProvider = extensionRuntime.getServiceProvider()
+        let rulesDownloader = RulesDownloader(
+            fileUnzipper: FileUnzipper(),
+            cache: serviceProvider.getCache(name: RulesDownloaderConstants.RULES_CACHE_NAME),
+            logger: logger,
+            networking: serviceProvider.getNetworkService()
+        )
         guard let data = rulesDownloader.loadRulesFromCache(rulesUrl: url), let rules = JSONRulesParser.parse(data, runtime: extensionRuntime) else {
-            Log.debug(label: RulesConstants.LOG_MODULE_PREFIX, "Failed to load cached rules for url: \(urlString)")
+            logger.debug(label: RulesConstants.LOG_MODULE_PREFIX, "Failed to load cached rules for url: \(urlString)")
             return false
         }
 
-        Log.debug(label: RulesConstants.LOG_MODULE_PREFIX, "Successfully loaded rules from cache")
+        logger.debug(label: RulesConstants.LOG_MODULE_PREFIX, "Successfully loaded rules from cache")
         self.replaceRules(with: rules)
         return true
     }
 
     /// Reads the manifest for bundled rules and replaces rules with bundled rules if found
     func replaceRulesWithManifest(from url: URL) {
-        let rulesDownloader = RulesDownloader(fileUnzipper: FileUnzipper())
+        let serviceProvider = extensionRuntime.getServiceProvider()
+        let rulesDownloader = RulesDownloader(
+            fileUnzipper: FileUnzipper(),
+            cache: serviceProvider.getCache(name: RulesDownloaderConstants.RULES_CACHE_NAME),
+            logger: logger,
+            networking: serviceProvider.getNetworkService()
+        )
         switch rulesDownloader.loadRulesFromManifest(for: url) {
         case .success(let data):
             guard let rules = JSONRulesParser.parse(data) else {
-                Log.debug(label: RulesConstants.LOG_MODULE_PREFIX, "Unable to parse rules for data from manifest")
+                logger.debug(label: RulesConstants.LOG_MODULE_PREFIX, "Unable to parse rules for data from manifest")
                 return
             }
-            Log.debug(label: RulesConstants.LOG_MODULE_PREFIX, "Successfully loaded rules from manifest")
+            logger.debug(label: RulesConstants.LOG_MODULE_PREFIX, "Successfully loaded rules from manifest")
             self.replaceRules(with: rules)
         case .failure(let error):
-            Log.debug(label: RulesConstants.LOG_MODULE_PREFIX, "Failed to load rules from manifest, with error: \(error.localizedDescription)")
+            logger.debug(label: RulesConstants.LOG_MODULE_PREFIX, "Failed to load rules from manifest, with error: \(error.localizedDescription)")
         }
     }
 }

--- a/AEPCore/Sources/rules/RulesEngineNativeLogging.swift
+++ b/AEPCore/Sources/rules/RulesEngineNativeLogging.swift
@@ -15,6 +15,12 @@ import Foundation
 import AEPRulesEngine
 
 class RulesEngineNativeLogging: AEPRulesEngine.Logging {
+    private let logger: Logger
+
+    init(logger: Logger) {
+        self.logger = logger
+    }
+
     /// Converts RulesEngine `LogLevel` to Core `LogLevel`
     /// - Parameter logLevel: a RulesEngine `LogLevel` object
     /// - Returns: a Core `LogLevel` object
@@ -34,8 +40,21 @@ class RulesEngineNativeLogging: AEPRulesEngine.Logging {
     }
 
     func log(level: AEPRulesEngine.LogLevel, label: String, message: String) {
-        if Log.logFilter >= convert(level) {
-            ServiceProvider.shared.loggingService.log(level: convert(level), label: label, message: message)
+        let logLevel = convert(level)
+        guard Log.logFilter >= convert(level) else {
+            return
+        }
+        switch logLevel {
+        case .error:
+            logger.error(label: label, message)
+        case .warning:
+            logger.warning(label: label, message)
+        case .debug:
+            logger.debug(label: label, message)
+        case .trace:
+            logger.trace(label: label, message)
+        @unknown default:
+            logger.error(label: label, message)
         }
     }
 }

--- a/AEPCore/Tests/ConfigurationTests/ConfigurationStateTests.swift
+++ b/AEPCore/Tests/ConfigurationTests/ConfigurationStateTests.swift
@@ -24,7 +24,8 @@ class ConfigurationStateTests: XCTestCase, AnyCodableAsserts {
     override func setUp() {
         configDownloader = MockConfigurationDownloader()
         NamedCollectionDataStore.clear()
-        configState = ConfigurationState(dataStore: dataStore, configDownloader: configDownloader)
+        let idManager = LaunchIDManager(dataStore: dataStore, logger: MockLogger())
+        configState = ConfigurationState(dataStore: dataStore, logger: MockLogger(), configDownloader: configDownloader, appIdManager: idManager)
         for key in UserDefaults.standard.dictionaryRepresentation().keys {
             UserDefaults.standard.removeObject(forKey: key)
         }

--- a/AEPCore/Tests/ConfigurationTests/ConfigurationStateTests.swift
+++ b/AEPCore/Tests/ConfigurationTests/ConfigurationStateTests.swift
@@ -25,7 +25,7 @@ class ConfigurationStateTests: XCTestCase, AnyCodableAsserts {
         configDownloader = MockConfigurationDownloader()
         NamedCollectionDataStore.clear()
         let idManager = LaunchIDManager(dataStore: dataStore, logger: MockLogger())
-        configState = ConfigurationState(dataStore: dataStore, logger: MockLogger(), configDownloader: configDownloader, appIdManager: idManager)
+        configState = ConfigurationState(configDownloader: configDownloader, appIdManager: idManager, dataStore: dataStore, logger: MockLogger())
         for key in UserDefaults.standard.dictionaryRepresentation().keys {
             UserDefaults.standard.removeObject(forKey: key)
         }

--- a/AEPCore/Tests/ConfigurationTests/LaunchIDManagerTests.swift
+++ b/AEPCore/Tests/ConfigurationTests/LaunchIDManagerTests.swift
@@ -20,7 +20,7 @@ class LaunchIDManagerTests: XCTestCase {
 
     override func setUp() {
         ServiceProvider.shared.systemInfoService = MockSystemInfoService()
-        appIdManager = LaunchIDManager(dataStore: dataStore)
+        appIdManager = LaunchIDManager(dataStore: dataStore, logger: MockLogger())
         for key in UserDefaults.standard.dictionaryRepresentation().keys {
             UserDefaults.standard.removeObject(forKey: key)
         }

--- a/AEPCore/Tests/MigrationTests/UserDefaultMigratorTests.swift
+++ b/AEPCore/Tests/MigrationTests/UserDefaultMigratorTests.swift
@@ -44,7 +44,6 @@ class UserDefaultMigratorTests: XCTestCase {
     
     override func setUp() {
         ServiceProvider.shared.namedKeyValueService = MockDataStore()
-        let date = Date()
         removeMigrationComplete()
     }
 

--- a/AEPCore/Tests/RulesTests/LaunchRuleTransformerTests.swift
+++ b/AEPCore/Tests/RulesTests/LaunchRuleTransformerTests.swift
@@ -15,130 +15,128 @@ import XCTest
 
 class LaunchRuleTransformerTests: XCTestCase {
 
-    let mockRuntime = TestableExtensionRuntime()
-
     func testStringFromInt() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "string", parameter: 3)
         XCTAssertEqual("3", result as? String)
     }
 
     func testStringFromBool() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "string", parameter: true)
         XCTAssertEqual("true", result as? String)
     }
 
     func testStringFromDouble() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "string", parameter: 3.33)
         XCTAssertTrue((result as? String)?.starts(with: "3.3") ?? false)
     }
 
     func testStringFromString() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "string", parameter: "something")
         XCTAssertEqual("something", result as? String)
     }
 
     func testIntFromInt() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "int", parameter: 3)
         XCTAssertEqual(3, result as? Int)
     }
 
     func testIntFromBool() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "int", parameter: true)
         XCTAssertEqual(1, result as? Int)
     }
 
     func testIntFromDouble() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "int", parameter: 3.33)
         XCTAssertEqual(3, result as? Int)
     }
 
     func testIntFromStringValid() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "int", parameter: "3")
         XCTAssertEqual(3, result as? Int)
     }
 
     func testIntFromStringInvalid() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "int", parameter: "something")
         XCTAssertNil(result as? Int)
     }
 
     func testDoubleFromInt() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "double", parameter: 3)
         XCTAssertEqual(3, result as? Double)
     }
 
     func testDoubleFromBool() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "double", parameter: true)
         XCTAssertEqual(1, result as? Double)
     }
 
     func testDoubleFromDouble() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "double", parameter: 3.33)
         XCTAssertEqual(3.33, result as? Double ?? 0.0,accuracy: 0.01)
     }
 
     func testDoubleFromStringValid() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "double", parameter: "3.33")
         XCTAssertEqual(3.33, result as? Double ?? 0.0,accuracy: 0.01)
     }
 
     func testDoubleFromStringInvalid() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "double", parameter: "something")
         XCTAssertNil(result as? Double)
     }
 
     func testBoolFromInt0() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "bool", parameter: 0)
         XCTAssertFalse(result as? Bool ?? false)
     }
 
     func testBoolFromInt1() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "bool", parameter: 1)
         XCTAssertTrue(result as? Bool ?? false)
     }
 
     func testBoolFromIntRandom() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "bool", parameter: 5)
         XCTAssertFalse(result as? Bool ?? false)
     }
 
     func testBoolFromBool() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "bool", parameter: true)
         XCTAssertTrue(result as? Bool ?? false)
     }
 
     func testBoolFromDouble() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "bool", parameter: 1.0)
         XCTAssertTrue(result as? Bool ?? false)
     }
 
     func testBoolFromStringValid() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "bool", parameter: "true")
         XCTAssertTrue(result as? Bool ?? false)
     }
 
     func testBoolFromStringInvalid() {
-        let transform = LaunchRuleTransformer(runtime: mockRuntime).transformer
+        let transform = LaunchRuleTransformer().transformer
         let result = transform.transform(name: "bool", parameter: "something")
         XCTAssertFalse(result as? Bool ?? false)
     }

--- a/AEPCore/Tests/RulesTests/LaunchRulesEngineTests.swift
+++ b/AEPCore/Tests/RulesTests/LaunchRulesEngineTests.swift
@@ -43,7 +43,7 @@ class LaunchRulesEngineTests: XCTestCase {
         let rules = JSONRulesParser.parse(data)
         let rulesEngine = LaunchRulesEngine(name: "test_rules_engine", extensionRuntime: runtime)
         // ~state.com.adobe.module.lifecycle/lifecyclecontextdata.devicename
-        let tokens = TokenFinder(event: event, extensionRuntime: runtime)
+        let tokens = TokenFinder(event: event, logger: MockLogger(), sharedStateProvider: runtime.getSharedState(extensionName:event:barrier:))
         let result = rulesEngine.replaceToken(for: (rules?[0].consequences[0])!, data: tokens)
         // http://adobe.com/device=abc
 
@@ -67,9 +67,9 @@ class LaunchRulesEngineTests: XCTestCase {
         /// Then: this json rules should be parsed to `LaunchRule` objects
         let rules = JSONRulesParser.parse(data)
         let rulesEngine = LaunchRulesEngine(name: "test_rules_engine", extensionRuntime: runtime)
-        let transformer = LaunchRuleTransformer(runtime: runtime)
-        let traversableTokenFinder = TokenFinder(event: event, extensionRuntime: runtime)
-        
+        let transformer = LaunchRuleTransformer()
+        let traversableTokenFinder = TokenFinder(event: event, logger: MockLogger(), sharedStateProvider: runtime.getSharedState(extensionName:event:barrier:))
+
         /// Then: this json rules should be parsed to `LaunchRule` objects
         XCTAssertEqual(1, rules?.count)
         XCTAssertTrue(rules?[0].condition is LogicalExpression)

--- a/AEPCore/Tests/RulesTests/TokenFinderTests.swift
+++ b/AEPCore/Tests/RulesTests/TokenFinderTests.swift
@@ -18,7 +18,7 @@ class TokenFinderTests: XCTestCase, AnyCodableAsserts {
     func testGetTokenValue_event_type_source() {
         /// Given: initialize `TokenFinder` with mocked extension runtime & dummy event
         let runtime = TestableExtensionRuntime()
-        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: nil), extensionRuntime: runtime)
+        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: nil), logger: MockLogger(), sharedStateProvider: runtime.getSharedState(extensionName:event:barrier:))
         /// When: retrieve token `~type` and `~source`
         guard let type = tokenFinder.get(key: "~type") as? String, let source = tokenFinder.get(key: "~source") as? String else {
             XCTFail("Expected no-nil event type and event source")
@@ -32,7 +32,7 @@ class TokenFinderTests: XCTestCase, AnyCodableAsserts {
     func testGetTokenValue_sdk_version() {
         /// Given: initialize `TokenFinder` with mocked extension runtime & dummy event
         let runtime = TestableExtensionRuntime()
-        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: nil), extensionRuntime: runtime)
+        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: nil), logger: MockLogger(), sharedStateProvider: runtime.getSharedState(extensionName:event:barrier:))
         /// When: retrieve token `~sdkver`
         guard let version = tokenFinder.get(key: "~sdkver") as? String else {
             XCTFail("Expected no-nil SDK version")
@@ -45,7 +45,7 @@ class TokenFinderTests: XCTestCase, AnyCodableAsserts {
     func testGetTokenValue_cachebust() {
         /// Given: initialize `TokenFinder` with mocked extension runtime & dummy event
         let runtime = TestableExtensionRuntime()
-        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: nil), extensionRuntime: runtime)
+        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: nil), logger: MockLogger(), sharedStateProvider: runtime.getSharedState(extensionName:event:barrier:))
         /// When: retrieve token `~cachebust`
         guard let randomString = tokenFinder.get(key: "~cachebust") as? String, let randomInt = Int(randomString) else {
             XCTFail("Expected no-nil random int")
@@ -58,7 +58,7 @@ class TokenFinderTests: XCTestCase, AnyCodableAsserts {
     func testGetTokenValue_url() {
         /// Given: initialize `TokenFinder` with mocked extension runtime & dummy event which should contain non-nil event data and it's data value should contain `String` and `Double`
         let runtime = TestableExtensionRuntime()
-        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: ["key1": "value1", "key2": ["key22": 22.0]]), extensionRuntime: runtime)
+        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: ["key1": "value1", "key2": ["key22": 22.0]]), logger: MockLogger(), sharedStateProvider: runtime.getSharedState(extensionName:event:barrier:))
         /// When: retrieve token `~all_url`
         guard let urlQueryString = tokenFinder.get(key: "~all_url") as? String else {
             XCTFail("Expected no-nil url query string")
@@ -71,7 +71,7 @@ class TokenFinderTests: XCTestCase, AnyCodableAsserts {
     func testGetTokenValue_url_empty_kvp() {
         /// Given: initialize `TokenFinder` with mocked extension runtime & dummy event whose event data property is `nil`
         let runtime = TestableExtensionRuntime()
-        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: nil), extensionRuntime: runtime)
+        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: nil), logger: MockLogger(), sharedStateProvider: runtime.getSharedState(extensionName:event:barrier:))
         /// When: retrieve token `~all_url`
         guard let urlQueryString = tokenFinder.get(key: "~all_url") as? String else {
             XCTFail("Expected no-nil url query string")
@@ -84,7 +84,7 @@ class TokenFinderTests: XCTestCase, AnyCodableAsserts {
     func testGetTokenValue_json() {
         /// Given: initialize `TokenFinder` with mocked extension runtime & dummy event which should contain non-nil event data and it's data value should contain `String` and `Double`
         let runtime = TestableExtensionRuntime()
-        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: ["key1": "value1", "key2": ["key22": 22.0]]), extensionRuntime: runtime)
+        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: ["key1": "value1", "key2": ["key22": 22.0]]), logger: MockLogger(), sharedStateProvider: runtime.getSharedState(extensionName:event:barrier:))
         /// When: retrieve token `~all_json`
         guard let json = tokenFinder.get(key: "~all_json") as? String else {
             XCTFail("Expected no-nil json string")
@@ -97,7 +97,7 @@ class TokenFinderTests: XCTestCase, AnyCodableAsserts {
     func testGetTokenValue_json_empty_kvp() {
         /// Given: initialize `TokenFinder` with mocked extension runtime & dummy event whose event data property is `nil`
         let runtime = TestableExtensionRuntime()
-        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: nil), extensionRuntime: runtime)
+        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: nil), logger: MockLogger(), sharedStateProvider: runtime.getSharedState(extensionName:event:barrier:))
         /// When: retrieve token `~all_json`
         guard let json = tokenFinder.get(key: "~all_json") as? String else {
             XCTFail("Expected no-nil json string")
@@ -110,7 +110,7 @@ class TokenFinderTests: XCTestCase, AnyCodableAsserts {
     func testGetTokenValue_timestamp() {
         /// Given: initialize `TokenFinder` with mocked extension runtime & dummy event
         let runtime = TestableExtensionRuntime()
-        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: nil), extensionRuntime: runtime)
+        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: nil), logger: MockLogger(), sharedStateProvider: runtime.getSharedState(extensionName:event:barrier:))
         let formatter_ISO8601 = DateFormatter()
         formatter_ISO8601.timeZone = TimeZone.init(abbreviation: "UTC")
         formatter_ISO8601.locale = Locale(identifier: "en_US_POSIX")
@@ -134,7 +134,7 @@ class TokenFinderTests: XCTestCase, AnyCodableAsserts {
         /// Given: initialize `TokenFinder` with mocked  dummy event & extension runtime which contains a valid shared state
         let runtime = TestableExtensionRuntime()
         runtime.mockedSharedStates["com.adobe.module.lifecycle"] = SharedStateResult(status: .set, value: ["lifecyclecontextdata": ["dayssincelastupgrade": 10]])
-        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: nil), extensionRuntime: runtime)
+        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: nil), logger: MockLogger(), sharedStateProvider: runtime.getSharedState(extensionName:event:barrier:))
         /// When: retrieve token `~state.com.adobe.module.lifecycle/lifecyclecontextdata.dayssincelastupgrade`
         guard let days = tokenFinder.get(key: "~state.com.adobe.module.lifecycle/lifecyclecontextdata.dayssincelastupgrade") as? Int else {
             XCTFail("Expected no-nil shared state")
@@ -147,7 +147,7 @@ class TokenFinderTests: XCTestCase, AnyCodableAsserts {
     func testGetTokenValue_shared_state_extension_name_not_exist() {
         /// Given: initialize `TokenFinder` with mocked  dummy event & extension runtime which don't have the right extension registered
         let runtime = TestableExtensionRuntime()
-        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: nil), extensionRuntime: runtime)
+        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: nil), logger: MockLogger(), sharedStateProvider: runtime.getSharedState(extensionName:event:barrier:))
         /// When: retrieve token `~state.com.adobe.module.lifecycle/lifecyclecontextdata.dayssincelastupgrade`
         guard tokenFinder.get(key: "~state.com.adobe.module.lifecycle/lifecyclecontextdata.dayssincelastupgrade") != nil else {
             /// Then: return `nil`
@@ -160,7 +160,7 @@ class TokenFinderTests: XCTestCase, AnyCodableAsserts {
         /// Given: initialize `TokenFinder` with mocked  dummy event & extension runtime which don't contain the right key
         let runtime = TestableExtensionRuntime()
         runtime.mockedSharedStates["com.adobe.module.lifecycle"] = SharedStateResult(status: .set, value: ["lifecyclecontextdata": ["a": 10]])
-        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: nil), extensionRuntime: runtime)
+        let tokenFinder = TokenFinder(event: Event(name: "eventName", type: "eventType", source: "eventSource", data: nil), logger: MockLogger(), sharedStateProvider: runtime.getSharedState(extensionName:event:barrier:))
         /// When: retrieve token `~state.com.adobe.module.lifecycle/lifecyclecontextdata.dayssincelastupgrade`
         guard tokenFinder.get(key: "~state.com.adobe.module.lifecycle/lifecyclecontextdata.dayssincelastupgrade") != nil else {
             /// Then: return `nil`

--- a/AEPCore/Tests/TestHelpers/MockConfigurationDownloaderNetworkService.swift
+++ b/AEPCore/Tests/TestHelpers/MockConfigurationDownloaderNetworkService.swift
@@ -20,9 +20,9 @@ enum MockConfigurationDownloaderResponses {
     case notModified
 }
 
-struct MockConfigurationDownloaderNetworkService: Networking {
+class MockConfigurationDownloaderNetworkService: Networking {
     let validResponseDictSize = 16
-    let responseType: MockConfigurationDownloaderResponses!
+    public var responseType: MockConfigurationDownloaderResponses!
     let expectedData = """
     {
       "target.timeout": 5,
@@ -48,6 +48,10 @@ struct MockConfigurationDownloaderNetworkService: Networking {
     let expectedInValidHttpUrlResponse = HTTPURLResponse(url: URL(string: "https://adobe.com")!, statusCode: 500, httpVersion: nil, headerFields: [:])
     let expectedNotModifiedHttpUrlResponse = HTTPURLResponse(url: URL(string: "https://adobe.com")!, statusCode: 304, httpVersion: nil, headerFields: [:])
 
+
+    init(responseType: MockConfigurationDownloaderResponses) {
+        self.responseType = responseType
+    }
     func connectAsync(networkRequest _: NetworkRequest, completionHandler: ((HttpConnection) -> Void)?) {
         switch responseType {
         case .success:

--- a/AEPCore/Tests/TestHelpers/MockRulesDownloaderNetworkService.swift
+++ b/AEPCore/Tests/TestHelpers/MockRulesDownloaderNetworkService.swift
@@ -18,8 +18,12 @@ enum MockRulesDownloaderResponses {
     case notModified
 }
 
-struct MockRulesDownloaderNetworkService: Networking {
-    var response: MockRulesDownloaderResponses!
+class MockRulesDownloaderNetworkService: Networking {
+    public var response: MockRulesDownloaderResponses
+
+    init(response: MockRulesDownloaderResponses) {
+        self.response = response
+    }
 
     let expectedData = try? Data(contentsOf: RulesDownloaderTests.rulesUrl!)
 
@@ -37,8 +41,6 @@ struct MockRulesDownloaderNetworkService: Networking {
         case .notModified:
             let httpConnection = HttpConnection(data: nil, response: notModifiedResponse, error: nil)
             completionHandler!(httpConnection)
-        case .none:
-            print("Invalid response type")
         }
     }
 }


### PR DESCRIPTION
- Refactored Configuration extension to use ExtensionServiceProvider from ExtensionRuntime and inject dependencies.

Todo:

- A new method for creating DispatchQueue with instance specific labels will be added in a separate PR.
- Tests for multi-instance functionality will be added in a separate PR

