### PR TITLE
Fix TestBase getSharedStateFor

### DIFF
--- a/AEPCore/Mocks/PublicTestUtils/TestBase.swift
+++ b/AEPCore/Mocks/PublicTestUtils/TestBase.swift
@@ -17,13 +17,6 @@ import AEPServices
 @testable import AEPCore
 
 open class TestBase: XCTestCase {
-    /// Represents the `SharedState` types in ``EventHub`` that can be used by an extension to share data with other extensions and for rules execution.
-    /// This is a publicly accessible version of the ``SharedStateType`` used internally.
-    public enum SharedStateTypeTestHelper: String {
-        case standard = "standard"  // regular data, the key names and structure can be defined by each extension
-        case xdm = "XDM"  // data mapped on XDM mixins populated by an extension
-    }
-
     /// Use this property to execute code logic in the first run in this test class; this value changes to False after the parent tearDown is executed
     public private(set) static var isFirstRun: Bool = true
     /// Use this setting to enable debug mode logging in the `TestBase`
@@ -190,7 +183,7 @@ open class TestBase: XCTestCase {
         return InstrumentedExtension.receivedEvents[EventSpec(type: type, source: source)] ?? []
     }
 
-    /// Retrieves the `SharedState` for a specific extension.
+    /// Retrieves the standard `SharedState` for a specific extension (as opposed to XDM).
     /// This method fetches the shared state for a given extension name, optionally based on a specific event.
     /// The shared state can be resolved according to the specified resolution and shared state type.
     /// - Parameters:
@@ -201,12 +194,11 @@ open class TestBase: XCTestCase {
     ///              Defaults to `true`.
     ///   - resolution: The `SharedStateResolution` used to determine how to resolve the shared state.
     ///                 Defaults to `.any`.
-    ///   - sharedStateType: The type of shared state to be read from. Defaults to `.standard`.
     /// - Returns: A `SharedStateResult` containing the shared state data and status for the specified extension,
     ///            or `nil` if no shared state is available.
-    public func getSharedStateFor(extensionName: String, event: Event? = nil, barrier: Bool = true, resolution: SharedStateResolution = .any, sharedStateType: SharedStateTypeTestHelper = .standard) -> SharedStateResult? {
+    public func getSharedStateFor(extensionName: String, event: Event? = nil, barrier: Bool = true, resolution: SharedStateResolution = .any) -> SharedStateResult? {
         log("Getting shared state for: \(extensionName)")
-        return EventHub.shared.getSharedState(extensionName: extensionName, event: event, barrier: barrier, resolution: resolution, sharedStateType: sharedStateType)
+        return EventHub.shared.getSharedState(extensionName: extensionName, event: event, barrier: barrier, resolution: resolution, sharedStateType: .standard)
     }
 
     /// Print message to console if `TestBase.debug` is true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes the getSharedStateFor method in TestBase by updating its return type from `[AnyHashable: Any]?` to `SharedStateResult`.

The existing logic was silently failing to cast the actual value type of `SharedStateResult` (NSObject) into the `[AnyHashable: Any]?` and always returning `nil` whether a valid shared state existed or not.

Logic chain:
1. TestBase's getSharedStateFor dispatches an InstrumentedExtension shared state request event: https://github.com/adobe/aepsdk-testutils-ios/blob/5ec3b66f4c74ecc639a8471790628bd84925c59d/Sources/TestBase.swift#L193
2. InstrumentedExtension handles this event by calling: https://github.com/adobe/aepsdk-testutils-ios/blob/5ec3b66f4c74ecc639a8471790628bd84925c59d/Sources/InstrumentedExtension.swift#L92
3. `ExtensionRuntime`'s `getSharedState` returns a `SharedStateResult`: https://github.com/adobe/aepsdk-core-ios/blob/eab8353a2ccc2d3cc760c98f8e48e2dd9fc5168d/AEPCore/Sources/eventhub/ExtensionRuntime.swift#L68
4. `InstrumentedExtension` sets this value as the state: https://github.com/adobe/aepsdk-testutils-ios/blob/5ec3b66f4c74ecc639a8471790628bd84925c59d/Sources/InstrumentedExtension.swift#L93

So when using TestBase's `getSharedStateFor` method, the value of the `state` key is always a `SharedStateResult` anyways.

Currently there appears to only be a single usage of this API in iOS: 
NoConfigFunctionalTests.swift - testHandleExperienceEventRequest_withPendingConfigurationState_expectEventsQueueIsBlocked(): https://github.com/adobe/aepsdk-edge-ios/blob/726f7b158a80fea0b827ceca5ddc9e71932689bf/Tests/FunctionalTests/NoConfigFunctionalTests.swift#L50
* In this test case, it actually wants a nil value to verify that configuration is in a pending state (shared state will be nil), so the return value failing to cast causes this check to always pass as long as the getting of the shared state itself doesn't time out.

Proposing updating this method to be a passthrough to EventHub's `getSharedState(extensionName:event:barrier:resolution:sharedStateType:)` method, with the main difference being that the `SharedStateType` is hardcoded to `.standard` (as `SharedStateType` is not a public type).

This is a breaking change, but given that:
1. The existing behavior doesn't work as expected (always returns `nil`), and this behavior is strongly tied to the return type itself
2. There's only 1 usage
I believe the change is worth it

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
