### PR TITLE
TestUtils cleanup and updates

### DIFF
--- a/AEPCore/Mocks/PublicTestUtils/InstrumentedExtension.swift
+++ b/AEPCore/Mocks/PublicTestUtils/InstrumentedExtension.swift
@@ -16,6 +16,7 @@ import AEPCore
 import AEPServices
 
 /// Instrumented extension that registers a wildcard listener for intercepting events in current session. Use it along with `TestBase`
+@available(*, deprecated, message: "InstrumentedExtension is deprecated and will be replaced by a new wildcard listener class soon. Please avoid using InstrumentedExtension in your tests.")
 public class InstrumentedExtension: NSObject, Extension {
     private static let logTag = "InstrumentedExtension"
     public var name = "com.adobe.InstrumentedExtension"

--- a/AEPCore/Mocks/PublicTestUtils/InstrumentedExtension.swift
+++ b/AEPCore/Mocks/PublicTestUtils/InstrumentedExtension.swift
@@ -16,7 +16,7 @@ import AEPCore
 import AEPServices
 
 /// Instrumented extension that registers a wildcard listener for intercepting events in current session. Use it along with `TestBase`
-@available(*, deprecated, message: "InstrumentedExtension is deprecated and will be replaced by a new wildcard listener class soon. Please avoid using InstrumentedExtension in your tests.")
+@available(*, deprecated, message: "Will be replaced by a new wildcard listener class soon. Please avoid using InstrumentedExtension directly in your tests.")
 public class InstrumentedExtension: NSObject, Extension {
     private static let logTag = "InstrumentedExtension"
     public var name = "com.adobe.InstrumentedExtension"

--- a/AEPCore/Mocks/PublicTestUtils/InstrumentedExtension.swift
+++ b/AEPCore/Mocks/PublicTestUtils/InstrumentedExtension.swift
@@ -16,7 +16,7 @@ import AEPCore
 import AEPServices
 
 /// Instrumented extension that registers a wildcard listener for intercepting events in current session. Use it along with `TestBase`
-@available(*, deprecated, message: "Will be replaced by a new wildcard listener class soon. Please avoid using InstrumentedExtension directly in your tests.")
+@available(*, deprecated, message: "A new class for capturing events using MobileCore.registerEventListener will be added in the next version. Please avoid using InstrumentedExtension directly in your tests.")
 public class InstrumentedExtension: NSObject, Extension {
     private static let logTag = "InstrumentedExtension"
     public var name = "com.adobe.InstrumentedExtension"

--- a/AEPCore/Mocks/PublicTestUtils/MockEventHistoryDatabase.swift
+++ b/AEPCore/Mocks/PublicTestUtils/MockEventHistoryDatabase.swift
@@ -15,7 +15,6 @@ import Foundation
 @testable import AEPCore
 
 class MockEventHistoryDatabase: EventHistoryDatabase {
-
     var paramHash: UInt32?
     var paramTimestamp: Date?
     var paramFrom: Date?

--- a/AEPCore/Mocks/PublicTestUtils/TestBase.swift
+++ b/AEPCore/Mocks/PublicTestUtils/TestBase.swift
@@ -17,8 +17,8 @@ import AEPServices
 @testable import AEPCore
 
 open class TestBase: XCTestCase {
-    /// Use this setting to enable debug mode logging in the `TestBase`
-    public static var debugEnabled = false
+    /// Use this setting to enable logging in `TestBase`.
+    public var loggingEnabled = false
 
     // Runs once per test suite
     open class override func setUp() {
@@ -206,17 +206,10 @@ open class TestBase: XCTestCase {
         return returnedState
     }
 
-    /// Print message to console if `TestBase.debug` is true
+    /// Print message to console if ``loggingEnabled`` is true.
     /// - Parameter message: message to log to console
     public func log(_ message: String) {
-        TestBase.log(message)
-
-    }
-
-    /// Print message to console if `TestBase.debug` is true
-    /// - Parameter message: message to log to console
-    public static func log(_ message: String) {
-        guard !message.isEmpty && TestBase.debugEnabled else { return }
+        guard !message.isEmpty && loggingEnabled else { return }
         print("TestBase - \(message)")
     }
 }

--- a/AEPCore/Mocks/PublicTestUtils/TestBase.swift
+++ b/AEPCore/Mocks/PublicTestUtils/TestBase.swift
@@ -17,8 +17,6 @@ import AEPServices
 @testable import AEPCore
 
 open class TestBase: XCTestCase {
-    /// Use this property to execute code logic in the first run in this test class; this value changes to False after the parent tearDown is executed
-    public private(set) static var isFirstRun: Bool = true
     /// Use this setting to enable debug mode logging in the `TestBase`
     public static var debugEnabled = false
 
@@ -41,7 +39,6 @@ open class TestBase: XCTestCase {
         // Wait .2 seconds in case there are unexpected events that were in the dispatch process during cleanup
         usleep(200000)
         resetTestExpectations()
-        TestBase.isFirstRun = false
         MobileCore.resetSDK()
         NamedCollectionDataStore.clear()
     }

--- a/AEPCore/Tests/FunctionalTests/EventHubContractTests.swift
+++ b/AEPCore/Tests/FunctionalTests/EventHubContractTests.swift
@@ -18,7 +18,7 @@ import XCTest
 
 class EventHubContractTest: XCTestCase {
     override func setUp() {
-        EventHub.reset()  
+        MobileCore.resetSDK()
         NamedCollectionDataStore.clear()
         ContractExtensionOne.reset()
         ContractExtensionTwo.reset()

--- a/AEPCore/Tests/LifecycleTests/AEPCore+LifecycleTests.swift
+++ b/AEPCore/Tests/LifecycleTests/AEPCore+LifecycleTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 class AEPCoreLifecycleTests: XCTestCase {
     override func setUp() {
-        EventHub.reset()
+        MobileCore.resetSDK()
         MockExtension.reset()
         registerMockExtension(MockExtension.self)
     }

--- a/AEPCore/Tests/MobileCore+ConfigurationTests.swift
+++ b/AEPCore/Tests/MobileCore+ConfigurationTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 class MobileCore_ConfigurationTests: XCTestCase {
     override func setUp() {
-        EventHub.reset()
+        MobileCore.resetSDK()
         MockExtension.reset()
         EventHub.shared.start()
         registerMockExtension(Configuration.self)
@@ -24,7 +24,7 @@ class MobileCore_ConfigurationTests: XCTestCase {
     }
 
     override func tearDown() {
-        EventHub.reset()
+        MobileCore.resetSDK()
     }
 
     private func registerMockExtension<T: Extension>(_ type: T.Type) {

--- a/AEPCore/Tests/MobileCore+IdentityTests.swift
+++ b/AEPCore/Tests/MobileCore+IdentityTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 class MobileCore_IdentityTests: XCTestCase {
     override func setUp() {
-        EventHub.reset()
+        MobileCore.resetSDK()
         MockExtension.reset()
     }
 

--- a/AEPCore/Tests/MobileCore+TrackingTests.swift
+++ b/AEPCore/Tests/MobileCore+TrackingTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 class MobileCoreTrackingTests: XCTestCase {
     override func setUp() {
-        EventHub.reset()
+        MobileCore.resetSDK()
         MockExtension.reset()
         registerMockExtension(MockExtension.self)
     }

--- a/AEPCore/Tests/MobileCoreTests.swift
+++ b/AEPCore/Tests/MobileCoreTests.swift
@@ -20,7 +20,7 @@ class MobileCoreTests: XCTestCase {
         NamedCollectionDataStore.clear()
         MobileCore.setWrapperType(.none) // reset wrapper type before each test
         MobileCore.setLogLevel(.error) // reset log level to error before each test
-        EventHub.reset()
+        MobileCore.resetSDK()
         MockExtension.reset()
         MockExtensionTwo.reset()
         MockLegacyExtension.reset()

--- a/AEPIdentity/Tests/IdentityPublicAPITests.swift
+++ b/AEPIdentity/Tests/IdentityPublicAPITests.swift
@@ -18,7 +18,7 @@ import XCTest
 class IdentityAPITests: XCTestCase {
 
     override func setUp() {
-        EventHub.reset()
+        MobileCore.resetSDK()
         MockExtension.reset()
         EventHub.shared.start()
         registerMockExtension(MockExtension.self)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR does some cleanup of TestUtils related classes and usages: 
1. Removes the `isFirstRun` Bool from TestBase. 
    * If first run setup behavior is required, we can use the class level setup/teardown methods: https://developer.apple.com/documentation/xctest/xctestcase/set_up_and_tear_down_state_in_your_tests#3909114
    * Based on search through repos, it doesn't look like this Bool is used today and should be safe to remove
2. Removes `static` from `TestBase` property `debugEnabled` and rename to `loggingEnabled`
    * Rename motivation is to make the intent of the property more clear. Its only purpose is to control whether print logs are sent out or not; it does not affect any debugging behavior or business logic
    * `static` to non-static is also already a breaking change anyways, so bundling these changes together is probably the most optimal timing
3. Add deprecation warning to InstrumentedExtension, as the intent is to replace this (hacky) class with a wildcard listener implementation instead
4. Replace usages of EventHub.reset() with MobileCore.resetSDK() throughout project tests

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
