### PR TITLE
Update podspec to include BUILD_LIBRARY_FOR_DISTRIBUTION

### DIFF
--- a/AEPTestUtils.podspec
+++ b/AEPTestUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "AEPTestUtils"
-    s.version          = "5.2.0"
+    s.version          = "5.2.1"
     s.summary          = "Adobe Experience Platform test utilities for Adobe Experience Platform Mobile SDK. Written and maintained by Adobe."
   
     s.description      = <<-DESC


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds: 
1. The `BUILD_LIBRARY_FOR_DISTRIBUTION => YES` flag to the AEPTestUtils podspec and 
2. Bumps the version of AEPTestUtils to 5.2.1  

This flag being missing is causing some AEPTestUtil class method calls to fail with a mysterious error: "Thread 1: EXC_BAD_ACCESS (code=1, address=0x0)", where the error happens on method call (not inside the method body, etc)

<img width="1580" alt="Screenshot 2024-10-03 at 5 19 10 PM" src="https://github.com/user-attachments/assets/72647f04-47b0-4570-b657-4caa7c3f3437">

After adding this flag and pulling from the branch with this change, the error is resolved.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
