### PR TITLE
HTTPURLResponse headers are now case-insensitive

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		24B4BE5B2714F7730000C3AA /* EventHistoryResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B4BE5A2714F7730000C3AA /* EventHistoryResponseTests.swift */; };
 		24B4BE5D2714F7B30000C3AA /* EventHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B4BE5C2714F7B30000C3AA /* EventHistoryTests.swift */; };
 		24B4BE5F2714F7C80000C3AA /* EventHistoryDatabaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B4BE5E2714F7C80000C3AA /* EventHistoryDatabaseTests.swift */; };
+		24B860492CB5B0A00072868A /* HttpConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B860482CB5B0A00072868A /* HttpConnectionTests.swift */; };
 		24C5E14D26B8B00B005BEA72 /* MessageSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C5E14C26B8B00B005BEA72 /* MessageSettings.swift */; };
 		24C5E15D26B990CB005BEA72 /* MessageGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C5E15C26B990CB005BEA72 /* MessageGesture.swift */; };
 		24C5E17B26B999E4005BEA72 /* MessageAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C5E17A26B999E4005BEA72 /* MessageAlignment.swift */; };
@@ -826,6 +827,7 @@
 		24B4BE5A2714F7730000C3AA /* EventHistoryResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHistoryResponseTests.swift; sourceTree = "<group>"; };
 		24B4BE5C2714F7B30000C3AA /* EventHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHistoryTests.swift; sourceTree = "<group>"; };
 		24B4BE5E2714F7C80000C3AA /* EventHistoryDatabaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHistoryDatabaseTests.swift; sourceTree = "<group>"; };
+		24B860482CB5B0A00072868A /* HttpConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpConnectionTests.swift; sourceTree = "<group>"; };
 		24C5E14C26B8B00B005BEA72 /* MessageSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSettings.swift; sourceTree = "<group>"; };
 		24C5E15C26B990CB005BEA72 /* MessageGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageGesture.swift; sourceTree = "<group>"; };
 		24C5E17A26B999E4005BEA72 /* MessageAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageAlignment.swift; sourceTree = "<group>"; };
@@ -1819,6 +1821,7 @@
 				B6D6A02C26601279005042BE /* FloatingButtonPositionTests.swift */,
 				923973CC25AF92140056A3E5 /* FullscreenMessageTests.swift */,
 				246FD08926CC53E800FD130B /* FullscreenMessage+FrameCalculationTests.swift */,
+				24B860482CB5B0A00072868A /* HttpConnectionTests.swift */,
 				3F03980C24BE61520019F095 /* LogLevelTest.swift */,
 				246FD07F26CC520500FD130B /* MessageAlignmentTests.swift */,
 				246FD08126CC521E00FD130B /* MessageAnimationTests.swift */,
@@ -3499,6 +3502,7 @@
 				3F03981824BE61520019F095 /* DataQueueServiceTests.swift in Sources */,
 				3F03981B24BE61520019F095 /* FileSystemNamedCollectionTest.swift in Sources */,
 				78F2E2D427FF7B900073CE00 /* ServiceProviderTests.swift in Sources */,
+				24B860492CB5B0A00072868A /* HttpConnectionTests.swift in Sources */,
 				2EF54C292BF6C87500685C07 /* URLError+RecoverableTests.swift in Sources */,
 				786C004825B8F43E00F26D34 /* DefaultHeadersFormatterTests.swift in Sources */,
 				246FD08626CC529800FD130B /* MessageGestureRecognizerTests.swift in Sources */,

--- a/AEPServices/Sources/network/HttpConnection.swift
+++ b/AEPServices/Sources/network/HttpConnection.swift
@@ -63,11 +63,11 @@ public extension HttpConnection {
     /// Returns a value for the response header key from the `response` property, if available.
     /// This is protocol specific. For example, HTTP URLs could have headers like "last-modified", or "ETag" set.
     ///
-    /// In alignment with OS behavior for responses where there are duplicate entries in the header,
-    /// calling this method produces a non-deterministic result.
+    /// In alignment with OS behavior for responses where there are duplicate entries of the header,
+    /// calling this method produces a non-deterministic result.  Per HTTP RFC, header field name look ups should be case-insensitive.
     /// - Parameter forKey: the header key name sent in response when requesting a connection to the URL.
     func responseHttpHeader(forKey: String) -> String? {
-        if #available(iOS 13, tvOS 13, *) {
+        if #available(iOS 13, tvOS 13, iOSApplicationExtension 13, *) {
             return response?.value(forHTTPHeaderField: forKey)
         }
         

--- a/AEPServices/Sources/network/HttpConnection.swift
+++ b/AEPServices/Sources/network/HttpConnection.swift
@@ -67,7 +67,7 @@ public extension HttpConnection {
     /// calling this method produces a non-deterministic result.
     /// - Parameter forKey: the header key name sent in response when requesting a connection to the URL.
     func responseHttpHeader(forKey: String) -> String? {
-        if #available(iOS 13, *) {
+        if #available(iOS 13, tvOS 13, *) {
             return response?.value(forHTTPHeaderField: forKey)
         }
         

--- a/AEPServices/Sources/network/HttpConnection.swift
+++ b/AEPServices/Sources/network/HttpConnection.swift
@@ -62,8 +62,28 @@ public extension HttpConnection {
 
     /// Returns a value for the response header key from the `response` property, if available.
     /// This is protocol specific. For example, HTTP URLs could have headers like "last-modified", or "ETag" set.
+    ///
+    /// In alignment with OS behavior for responses where there are duplicate entries in the header,
+    /// calling this method produces a non-deterministic result.
     /// - Parameter forKey: the header key name sent in response when requesting a connection to the URL.
     func responseHttpHeader(forKey: String) -> String? {
-        return response?.allHeaderFields[forKey] as? String
+        if #available(iOS 13, *) {
+            return response?.value(forHTTPHeaderField: forKey)
+        }
+        
+        return response?.lowercasedHeaders[forKey.lowercased()] as? String
+    }
+}
+
+extension HTTPURLResponse {
+    var lowercasedHeaders: [String: Any] {
+        var lcHeaders: [String: Any] = [:]
+        for (key, value) in allHeaderFields {
+            if let keyAsString = key.base as? String {
+                lcHeaders[keyAsString.lowercased()] = value
+            }
+        }
+        
+        return lcHeaders
     }
 }

--- a/AEPServices/Sources/network/HttpConnection.swift
+++ b/AEPServices/Sources/network/HttpConnection.swift
@@ -67,7 +67,7 @@ public extension HttpConnection {
     /// calling this method produces a non-deterministic result.  Per HTTP RFC, header field name look ups should be case-insensitive.
     /// - Parameter forKey: the header key name sent in response when requesting a connection to the URL.
     func responseHttpHeader(forKey: String) -> String? {
-        if #available(iOS 13, tvOS 13, iOSApplicationExtension 13, *) {
+        if #available(iOS 13, tvOS 13, *) {
             return response?.value(forHTTPHeaderField: forKey)
         }
         

--- a/AEPServices/Tests/services/HttpConnectionTests.swift
+++ b/AEPServices/Tests/services/HttpConnectionTests.swift
@@ -1,0 +1,127 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+*/
+
+@testable import AEPServices
+import XCTest
+
+class HttpConnectionTests: XCTestCase {
+    func testResponseHttpHeaderHappy() throws {
+        // setup
+        let searchKey = "some-key"
+        let response = HTTPURLResponse(url: URL(string: "https://someurl")!, statusCode: 200, httpVersion: nil, headerFields: ["some-key": "value"])
+        let connection = HttpConnection(data: nil, response: response, error: nil)
+        
+        // test
+        let iOS13Result = connection.responseHttpHeader(forKey: searchKey)
+        let iOS12Result = connection.response?.lowercasedHeaders[searchKey.lowercased()] as? String
+        
+        // verify
+        XCTAssertEqual("value", iOS13Result)
+        XCTAssertEqual(iOS13Result, iOS12Result)
+    }
+    
+    func testResponseHttpHeaderMisMatchedCasing() throws {
+        // setup
+        let searchKey = "some-key"
+        let response = HTTPURLResponse(url: URL(string: "https://someurl")!, statusCode: 200, httpVersion: nil, headerFields: ["Some-Key": "value"])
+        let connection = HttpConnection(data: nil, response: response, error: nil)
+        
+        // test
+        let iOS13Result = connection.responseHttpHeader(forKey: searchKey)
+        let iOS12Result = connection.response?.lowercasedHeaders[searchKey.lowercased()] as? String
+        
+        // verify
+        XCTAssertEqual("value", iOS13Result)
+        XCTAssertEqual(iOS13Result, iOS12Result)
+    }
+    
+    func testResponseHttpHeaderMisMatchedCasingTwo() throws {
+        // setup
+        let searchKey = "Some-Key"
+        let response = HTTPURLResponse(url: URL(string: "https://someurl")!, statusCode: 200, httpVersion: nil, headerFields: ["some-key": "value"])
+        let connection = HttpConnection(data: nil, response: response, error: nil)
+        
+        // test
+        let iOS13Result = connection.responseHttpHeader(forKey: searchKey)
+        let iOS12Result = connection.response?.lowercasedHeaders[searchKey.lowercased()] as? String
+        
+        // verify
+        XCTAssertEqual("value", iOS13Result)
+        XCTAssertEqual(iOS13Result, iOS12Result)
+    }
+    
+    func testResponseHttpHeaderDuplicateKeys() throws {
+        // setup
+        let searchKey = "some-key"
+        let response = HTTPURLResponse(url: URL(string: "https://someurl")!, statusCode: 200, httpVersion: nil, headerFields: [
+            "Some-Key": "value",
+            "some-key": "anotherValue"])
+        let connection = HttpConnection(data: nil, response: response, error: nil)
+        
+        // test
+        let iOS13Result = connection.responseHttpHeader(forKey: searchKey)
+        let iOS12Result = connection.response?.lowercasedHeaders[searchKey.lowercased()] as? String
+        
+        // verify
+        /// in alignment with os behavior for `value(forHTTPHeaderField:)`,
+        /// requesting a header with duplicate entries is non-deterministic
+        let nonDeterministicResultMatchesOneValue13 = iOS13Result == "value" || iOS13Result == "anotherValue"
+        let nonDeterministicResultMatchesOneValue12 = iOS12Result == "value" || iOS12Result == "anotherValue"
+        XCTAssertTrue(nonDeterministicResultMatchesOneValue13)
+        XCTAssertTrue(nonDeterministicResultMatchesOneValue12)
+    }
+    
+    func testResponseHttpHeaderNoMatch() throws {
+        // setup
+        let searchKey = "something-else"
+        let response = HTTPURLResponse(url: URL(string: "https://someurl")!, statusCode: 200, httpVersion: nil, headerFields: ["Some-Key": "value"])
+        let connection = HttpConnection(data: nil, response: response, error: nil)
+        
+        // test
+        let iOS13Result = connection.responseHttpHeader(forKey: searchKey)
+        let iOS12Result = connection.response?.lowercasedHeaders[searchKey.lowercased()] as? String
+        
+        // verify
+        XCTAssertNil(iOS13Result)
+        XCTAssertEqual(iOS13Result, iOS12Result)
+    }
+    
+    func testResponseHttpHeaderSpecialChars() throws {
+        // setup
+        let searchKey = "$om3-Ke?"
+        let response = HTTPURLResponse(url: URL(string: "https://someurl")!, statusCode: 200, httpVersion: nil, headerFields: ["$om3-Ke?": "value"])
+        let connection = HttpConnection(data: nil, response: response, error: nil)
+        
+        // test
+        let iOS13Result = connection.responseHttpHeader(forKey: searchKey)
+        let iOS12Result = connection.response?.lowercasedHeaders[searchKey.lowercased()] as? String
+        
+        // verify
+        XCTAssertEqual("value", iOS13Result)
+        XCTAssertEqual(iOS13Result, iOS12Result)
+    }
+    
+    func testResponseHttpHeaderMixedCase() throws {
+        // setup
+        let searchKey = "soMe-KeY"
+        let response = HTTPURLResponse(url: URL(string: "https://someurl")!, statusCode: 200, httpVersion: nil, headerFields: ["SOmE-kEy": "value"])
+        let connection = HttpConnection(data: nil, response: response, error: nil)
+        
+        // test
+        let iOS13Result = connection.responseHttpHeader(forKey: searchKey)
+        let iOS12Result = connection.response?.lowercasedHeaders[searchKey.lowercased()] as? String
+        
+        // verify
+        XCTAssertEqual("value", iOS13Result)
+        XCTAssertEqual(iOS13Result, iOS12Result)
+    }
+}

--- a/AEPServices/Tests/services/HttpConnectionTests.swift
+++ b/AEPServices/Tests/services/HttpConnectionTests.swift
@@ -14,7 +14,7 @@
 import XCTest
 
 class HttpConnectionTests: XCTestCase {
-    func testResponseHttpHeaderHappy() throws {
+    func testResponseHttpHeader_Happy() throws {
         // setup
         let searchKey = "some-key"
         let response = HTTPURLResponse(url: URL(string: "https://someurl")!, statusCode: 200, httpVersion: nil, headerFields: ["some-key": "value"])
@@ -29,7 +29,7 @@ class HttpConnectionTests: XCTestCase {
         XCTAssertEqual(iOS13Result, iOS12Result)
     }
     
-    func testResponseHttpHeaderMisMatchedCasing() throws {
+    func testResponseHttpHeader_MisMatchedCasing() throws {
         // setup
         let searchKey = "some-key"
         let response = HTTPURLResponse(url: URL(string: "https://someurl")!, statusCode: 200, httpVersion: nil, headerFields: ["Some-Key": "value"])
@@ -44,7 +44,7 @@ class HttpConnectionTests: XCTestCase {
         XCTAssertEqual(iOS13Result, iOS12Result)
     }
     
-    func testResponseHttpHeaderMisMatchedCasingTwo() throws {
+    func testResponseHttpHeader_MisMatchedCasingTwo() throws {
         // setup
         let searchKey = "Some-Key"
         let response = HTTPURLResponse(url: URL(string: "https://someurl")!, statusCode: 200, httpVersion: nil, headerFields: ["some-key": "value"])
@@ -59,7 +59,7 @@ class HttpConnectionTests: XCTestCase {
         XCTAssertEqual(iOS13Result, iOS12Result)
     }
     
-    func testResponseHttpHeaderDuplicateKeys() throws {
+    func testResponseHttpHeader_DuplicateKeys() throws {
         // setup
         let searchKey = "some-key"
         let response = HTTPURLResponse(url: URL(string: "https://someurl")!, statusCode: 200, httpVersion: nil, headerFields: [
@@ -80,7 +80,7 @@ class HttpConnectionTests: XCTestCase {
         XCTAssertTrue(nonDeterministicResultMatchesOneValue12)
     }
     
-    func testResponseHttpHeaderNoMatch() throws {
+    func testResponseHttpHeader_NoMatch() throws {
         // setup
         let searchKey = "something-else"
         let response = HTTPURLResponse(url: URL(string: "https://someurl")!, statusCode: 200, httpVersion: nil, headerFields: ["Some-Key": "value"])
@@ -95,7 +95,7 @@ class HttpConnectionTests: XCTestCase {
         XCTAssertEqual(iOS13Result, iOS12Result)
     }
     
-    func testResponseHttpHeaderSpecialChars() throws {
+    func testResponseHttpHeader_SpecialChars() throws {
         // setup
         let searchKey = "$om3-Ke?"
         let response = HTTPURLResponse(url: URL(string: "https://someurl")!, statusCode: 200, httpVersion: nil, headerFields: ["$om3-Ke?": "value"])
@@ -110,7 +110,7 @@ class HttpConnectionTests: XCTestCase {
         XCTAssertEqual(iOS13Result, iOS12Result)
     }
     
-    func testResponseHttpHeaderMixedCase() throws {
+    func testResponseHttpHeader_MixedCase() throws {
         // setup
         let searchKey = "soMe-KeY"
         let response = HTTPURLResponse(url: URL(string: "https://someurl")!, statusCode: 200, httpVersion: nil, headerFields: ["SOmE-kEy": "value"])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When SDK network services retrieve headers from an `HTTPURLResponse`, the lookup is now case-insensitive.

## Related Issue

Addresses #1086

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
