### PR TITLE
[WIP] Bugfix : Reframing IAM during iPad splitScreen

### DIFF
--- a/AEPCore/Mocks/PublicTestUtils/MobileCore+TestHelper.swift
+++ b/AEPCore/Mocks/PublicTestUtils/MobileCore+TestHelper.swift
@@ -8,7 +8,7 @@
  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
-*/
+ */
 
 @testable import AEPCore
 

--- a/AEPServices/Mocks/MockUnzipper.swift
+++ b/AEPServices/Mocks/MockUnzipper.swift
@@ -18,7 +18,7 @@ public class MockUnzipper: Unzipping {
     public var unzipCalled = false
 
     public init() {}
-    
+
     public func unzipItem(at _: URL, to _: URL) -> [String] {
         unzipCalled = true
         return unzippedResults

--- a/AEPServices/Sources/network/HttpConnection.swift
+++ b/AEPServices/Sources/network/HttpConnection.swift
@@ -70,7 +70,7 @@ public extension HttpConnection {
         if #available(iOS 13, tvOS 13, *) {
             return response?.value(forHTTPHeaderField: forKey)
         }
-        
+
         return response?.lowercasedHeaders[forKey.lowercased()] as? String
     }
 }
@@ -83,7 +83,7 @@ extension HTTPURLResponse {
                 lcHeaders[keyAsString.lowercased()] = value
             }
         }
-        
+
         return lcHeaders
     }
 }

--- a/AEPServices/Sources/ui/MessageMonitor.swift
+++ b/AEPServices/Sources/ui/MessageMonitor.swift
@@ -16,7 +16,7 @@
         private let LOG_PREFIX = "MessageMonitor"
         private var isMsgDisplayed = false
         private let messageQueue = DispatchQueue(label: "com.adobe.uiService.messageMonitor.queue")
-        
+
         internal func isMessageDisplayed() -> Bool {
             return messageQueue.sync {
                 self.isMsgDisplayed

--- a/AEPServices/Sources/ui/PresentationError.swift
+++ b/AEPServices/Sources/ui/PresentationError.swift
@@ -17,7 +17,7 @@ import Foundation
 public class PresentationError: NSObject {
     static let CONFLICT = PresentationError(.showFailure("Conflict"))
     static let SUPPRESSED_BY_APP_DEVELOPER = PresentationError(.showFailure("SuppressedByAppDeveloper"))
-    
+
     /// Internal enum that allows capturing a reason for the provided kind of failure
     enum ErrorType {
         case showFailure(String)

--- a/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
+++ b/AEPServices/Sources/ui/fullscreen/FullscreenMessage.swift
@@ -48,7 +48,7 @@
         var messagingDelegate: MessagingDelegate? {
             return ServiceProvider.shared.messagingDelegate
         }
-        
+
         /// Observes key window frame changes to trigger frame updates for Fullscreen Message.
         private var windowFrameObserver: NSKeyValueObservation?
 
@@ -100,7 +100,8 @@
         }
 
         deinit {
-            NotificationCenter.default.removeObserver(self)
+            windowFrameObserver?.invalidate()
+            windowFrameObserver = nil
 
             // remove the temporary html if it exists
             if let tempFile = self.tempHtmlFile {
@@ -123,16 +124,16 @@
 
             DispatchQueue.main.async {
 
-                // add observer to handle device rotation
                 if !self.observerSet {
-                    
+
                     // Register to observe changes to frame of application's key window
+                    // This observer will also recognize the device orientation changes
                     if let keyWindow = UIApplication.shared.getKeyWindow() {
                         self.windowFrameObserver = keyWindow.observe(\.frame, options: [.new]) { [weak self] _, _ in
                             self?.reframeMessage()
                         }
                     }
-                                        
+
                     self.observerSet = true
                 }
 
@@ -218,11 +219,10 @@
 
         public func dismiss() {
             DispatchQueue.main.async {
-                // remove device orientation observer
-                NotificationCenter.default.removeObserver(self)
-                self.observerSet = false
+                // remove window frame observer
                 self.windowFrameObserver?.invalidate()
                 self.windowFrameObserver = nil
+                self.observerSet = false
 
                 if self.messageMonitor.dismiss() == false {
                     return

--- a/AEPServices/Tests/services/HttpConnectionTests.swift
+++ b/AEPServices/Tests/services/HttpConnectionTests.swift
@@ -8,7 +8,7 @@
  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
-*/
+ */
 
 @testable import AEPServices
 import XCTest

--- a/AEPServices/Tests/services/PresentationErrorTests.swift
+++ b/AEPServices/Tests/services/PresentationErrorTests.swift
@@ -8,7 +8,7 @@
  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
-*/
+ */
 
 import XCTest
 
@@ -18,16 +18,16 @@ class PresentationErrorTests: XCTestCase {
     func testHappy() throws {
         // test
         let error = PresentationError(.showFailure("test"))
-        
+
         // verify
         XCTAssertEqual("test", error.getReason())
     }
-    
+
     func testConflict() throws {
         // verify
         XCTAssertEqual("Conflict", PresentationError.CONFLICT.getReason())
     }
-    
+
     func testSuppressedByAppDeveloper() throws {
         // verify
         XCTAssertEqual("SuppressedByAppDeveloper", PresentationError.SUPPRESSED_BY_APP_DEVELOPER.getReason())


### PR DESCRIPTION
Fixed a FullScreenMessage bug that does not redraw when the application enters split screen mode.

Used NSKeyValueObservation to observer changes to the Application's key UIWindow's frame to detect device rotation and split screen size change.

The fix is tested on following Apps
- Application based on Scene Delegate
- Application based on UIAppDelegate lifecycle 
- Complete SwiftUI Application

The fix was tested on various orientation and status bar settings
<img width="496" alt="Screenshot 2024-11-21 at 3 47 27 PM" src="https://github.com/user-attachments/assets/4091635e-684e-49b1-96b3-dd87394f5d9d">


The fix is tested on the following devices
- iPhone 18 Simulator
- iPhone 18 device
- iPad 18 Simulator
- iPad 14 device


![Simulator Screen Recording - iPad Pro - 2024-11-21 at 14 44 13](https://github.com/user-attachments/assets/ef862183-9f9a-4294-8de3-bb88866f3f90)

