### PR TITLE
Address data races in AEPTestUtil classes

### DIFF
--- a/AEPCore/Mocks/PublicTestUtils/MockExtension.swift
+++ b/AEPCore/Mocks/PublicTestUtils/MockExtension.swift
@@ -15,14 +15,48 @@ import Foundation
 @testable import AEPCore
 
 public class MockExtension: NSObject, Extension {
+    private static let queue = DispatchQueue(label: "com.adobe.mockextension.syncqueue")
+
     public var name = "com.adobe.mockExtension"
     public var friendlyName = "mockExtension"
-    public static var extensionVersion = "0.0.1"
+    private static var _extensionVersion = "0.0.1"
+    public static var extensionVersion: String {
+        get {
+            return queue.sync { _extensionVersion }
+        }
+        set {
+            queue.sync { _extensionVersion = newValue }
+        }
+    }
     public var metadata: [String: String]?
 
-    public static var registrationClosure: (() -> Void)?
-    public static var unregistrationClosure: (() -> Void)?
-    public static var eventReceivedClosure: ((Event) -> Void)?
+    private static var _registrationClosure: (() -> Void)?
+    public static var registrationClosure: (() -> Void)? {
+        get {
+            return queue.sync { _registrationClosure }
+        }
+        set {
+            queue.sync { _registrationClosure = newValue }
+        }
+    }
+    private static var _unregistrationClosure: (() -> Void)?
+    public static var unregistrationClosure: (() -> Void)? {
+        get {
+            return queue.sync { _unregistrationClosure }
+        }
+        set {
+            queue.sync { _unregistrationClosure = newValue }
+        }
+    }
+    private static var _eventReceivedClosure: ((Event) -> Void)?
+    public static var eventReceivedClosure: ((Event) -> Void)? {
+        get {
+            return queue.sync { _eventReceivedClosure }
+        }
+        set {
+            queue.sync { _eventReceivedClosure = newValue }
+        }
+    }
 
     public let runtime: ExtensionRuntime
 

--- a/AEPServices/Mocks/PublicTestUtils/MockDataStore.swift
+++ b/AEPServices/Mocks/PublicTestUtils/MockDataStore.swift
@@ -12,7 +12,17 @@
 import AEPServices
 
 public class MockDataStore: NamedCollectionProcessing {
-    public var dict = ThreadSafeDictionary<String, Any>()
+    private let queue = DispatchQueue(label: "com.adobe.mockdatastore.syncqueue")
+
+    private var _dict = ThreadSafeDictionary<String, Any>()
+    public var dict: ThreadSafeDictionary<String, Any> {
+        get {
+            return queue.sync { _dict }
+        }
+        set {
+            queue.sync { _dict = newValue }
+        }
+    }
     private var appGroup: String?
 
     public init() {}


### PR DESCRIPTION
> [!NOTE]
> The changes in this PR should not affect the signature of any existing public APIs, so the patch version will be increased from: `testutils-5.2.2` -> `testutils-5.2.3`

## Description

This PR addresses data race issues with public test classes available in AEPTestUtils by protecting access to shared access public vars in a sync queue:
`InstrumentedExtension`
* `extensionVersion`
* `expectedEvents`
* `receivedEvents`

`MockExtension`
* `extensionVersion`
* `registrationClosure`
* `unregistrationClosure`
* `eventReceivedClosure`

`MockDataStore`
* `dict`

This implementation tested via:
MockExtension
* EdgeIdentity - IdentityAPITests
InstrumentedExtension 
* Edge - NetworkResponseHandlerFunctionalTests
MockDataStore
* Core - all tests

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Data race caught by thread sanitizer:

Test Case '-[FunctionalTests.NetworkResponseHandlerFunctionalTests testProcessResponseOnSuccess_afterPersistedResetEvent_savesStorePayloads]' passed (1.246 seconds).
Test Case '-[FunctionalTests.NetworkResponseHandlerFunctionalTests testProcessResponseOnSuccess_afterPersistedResetEvent_updatesLocationHint]' started.

AEPTestUtils/AEPCore/Mocks/PublicTestUtils/InstrumentedExtension.swift:115 Data race in static AEPTestUtils.InstrumentedExtension.reset() -> () at static AEPTestUtils.InstrumentedExtension.receivedEvents : AEPServices.ThreadSafeDictionary<AEPTestUtils.EventSpec, Swift.Array<AEPCore.Event>>

'static AEPTestUtils.InstrumentedExtension.receivedEvents : AEPServices.ThreadSafeDictionary<AEPTestUtils.EventSpec, Swift.Array<AEPCore.Event>>' is a global variable (0x110038f38)

Test Case '-[FunctionalTests.NetworkResponseHandlerFunctionalTests testProcessResponseOnSuccess_afterPersistedResetEvent_updatesLocationHint]' passed (3.407 seconds).
Test Case '-[FunctionalTests.NetworkResponseHandlerFunctionalTests testProcessResponseOnSuccess_afterResetEvent_savesStorePayloads]' started.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
