### PR TITLE
Allow disabling timeout when registering response listener

### DIFF
--- a/AEPCore/Sources/core/MobileCore.swift
+++ b/AEPCore/Sources/core/MobileCore.swift
@@ -119,7 +119,8 @@ public final class MobileCore: NSObject {
     /// Dispatches an `Event` through the `EventHub` and invokes a closure with the response `Event`.
     /// - Parameters:
     ///   - event: The trigger `Event` to be dispatched through the `EventHub`
-    ///   - timeout A timeout in seconds, if the response listener is not invoked within the timeout, then the `EventHub` invokes the response listener with a nil `Event`
+    ///   - timeout A timeout in seconds, if the response listener is not invoked within the timeout, then the `EventHub` invokes the response listener with a nil `Event`.
+    ///            Use `.infinity` to wait indefinitely without `EventHub` triggering timeout.
     ///   - responseCallback: Callback to be invoked with `event`'s response `Event`
     @objc(dispatch:timeout:responseCallback:)
     public static func dispatch(event: Event, timeout: TimeInterval = 1, responseCallback: @escaping (Event?) -> Void) {

--- a/AEPCore/Sources/eventhub/EventHub.swift
+++ b/AEPCore/Sources/eventhub/EventHub.swift
@@ -25,7 +25,11 @@ final class EventHub {
     private let eventHubQueue = DispatchQueue(label: "com.adobe.eventHub.queue")
     private var registeredExtensions = ThreadSafeDictionary<String, ExtensionContainer>(identifier: "com.adobe.eventHub.registeredExtensions.queue")
     private let eventNumberMap = ThreadSafeDictionary<UUID, Int>(identifier: "com.adobe.eventHub.eventNumber.queue")
-    private let responseEventListeners = ThreadSafeArray<EventListenerContainer>(identifier: "com.adobe.eventHub.response.queue")
+    #if DEBUG
+        internal let responseEventListeners = ThreadSafeArray<EventListenerContainer>(identifier: "com.adobe.eventHub.response.queue")
+    #else
+        private let responseEventListeners = ThreadSafeArray<EventListenerContainer>(identifier: "com.adobe.eventHub.response.queue")
+    #endif
     private var eventNumberCounter = AtomicCounter()
     private let eventQueue = OperationOrderer<Event>("EventHub")
     private var preprocessors = ThreadSafeArray<EventPreprocessor>(identifier: "com.adobe.eventHub.preprocessors.queue")

--- a/AEPCore/Tests/EventHubTests/EventHubTests.swift
+++ b/AEPCore/Tests/EventHubTests/EventHubTests.swift
@@ -388,6 +388,20 @@ class EventHubTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
+    func testEventHubTestResponseListenerWithInfiniteTimeout() {
+        // setup
+        let requestEvent = Event(name: "testEvent", type: EventType.analytics, source: EventSource.requestContent, data: nil)
+
+        // test
+        eventHub.registerResponseListener(triggerEvent: requestEvent, timeout: .infinity) { event in
+            XCTFail()
+        }
+
+        let listener = eventHub.responseEventListeners.shallowCopy.first { $0.triggerEventId == requestEvent.id }
+        XCTAssertNotNil(listener)
+        XCTAssertNil(listener?.timeoutTask)
+    }
+
     func testEventHubDispatchesEventsWithBlockingListener() {
         // setup
         let expectation = XCTestExpectation(description: "Invoke blocking listener with matching Event and ignored Event of non-matching type and source")


### PR DESCRIPTION
Some extensions don't want the request listener to time out when they call the API. They can achieve this by setting a large timeout. This is just a minor optimization to prevent adding additional timeout tasks for such listeners.