### PR TITLE
Fix event history operation `insertIfNotExists` logical error and race with insert operation

### DIFF
--- a/AEPCore/Sources/rules/LaunchRulesEngine.swift
+++ b/AEPCore/Sources/rules/LaunchRulesEngine.swift
@@ -406,7 +406,9 @@ public class LaunchRulesEngine {
 
                 // Check that a valid result exists and that a database error (-1) was not returned
                 guard let result = results.first, result.count >= 0 else {
-                    Log.warning(label: LOG_TAG, "\(logPrefix) - Unable to retrieve historical events, skipping '\(operation)' operation. Returned with result value: \(String(describing: results.first?.count))")
+                    Log.warning(label: LOG_TAG,
+                        "\(logPrefix) - Unable to retrieve historical events, skipping '\(operation)' operation. " +
+                        "Returned with result value: \(String(describing: results.first?.count))")
                     return
                 }
                 if result.count >= 1 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes `insertIfNotExists` handling logic by addressing the following issues:
1. A logical error where the early exit cases for `insertIfNotExists` return from the escaping closure, but those returns do not actually affect the main `processEventHistoryOperation` block that would continue to do the event insert into event history.
2. A race between the `insertIfNotExists` event history record check which uses an escaping closure in `getHistoricalEvents` and the insertion of the event into event history using `recordHistoricalEvent`
3. Also added handling for the `insertIfNotExists` case where a database error value (-1) is returned, skipping the insert if an error occurs.  
   * I was thinking that the logic behind checking for records is to affirmatively insert, so if the check fails, it would be safer to default to not inserting, rather than inserting regardless, as inserting in this case could violate the utility provided by the `IfNotExists` portion of the logic.
4. For the logical checks and related logging in `insertIfNotExists`, I chose to maintain more granularity in the log messages rather than condensing all the checks into a single guard, because I felt that providing non-technical explanations (ex: just the result code) for why an insert is not happening makes it much easier to self-service troubleshooting for workflows that rely on this feature. 
    * Basically, in weighing the tradeoff between the maintenance cost of the code and the ease of understanding the debugging workflow for those outside of our team, I leaned more towards prioritizing the latter in this case

## Alternative
Could more simply add the insert separately for both operations instead of having them merge back into the same insert path.
* `insert` would have its own conditional block checking separately for this specific operation instead of sharing logic with `insertIfNotExists`
* `insertIfNotExists` would have "insert event into event history" logic separately inside its escaping closure

However, this would change the behavior of rules consequences when `insertIfNotExists` is used such that when `insertIfNotExists` consequences are used, their effects are no longer guaranteed to: 
1. Complete running in the same consequence order as defined in a given rule's consequences, nor
2. Complete running within the context of the rule condition it was defined under.

Given these knock on effects, I elected to make the `getHistoricalEvents` synchronous instead

**Example**
```swift
// Inner function that handles shared insert logic
func insert(event: Event) {
    Log.trace(label: LOG_TAG, "\(logPrefix) - Recording event in history with operation '\(operation)'")

    // For INSERT and INSERT_IF_NOT_EXISTS (which passed not exists check), insert the event
    self.extensionRuntime.recordHistoricalEvent(event) { [weak self] success in
        guard let self = self else { return }
        if success {
            self.extensionRuntime.dispatch(event: event)
        } else {
            Log.warning(label: LOG_TAG, "\(logPrefix) - Failed to record event in history for '\(operation)'")
        }
    }
}
// insertIfNotExists handling
if operation == LaunchRulesEngine.CONSEQUENCE_EVENT_HISTORY_OPERATION_INSERT_IF_NOT_EXISTS {
    let eventHash = eventToRecord.eventHash
    if eventHash == 0 {
        Log.warning(label: LOG_TAG, "\(logPrefix) - Unable to process '\(operation)' operation, event hash is 0")
        return
    }

    extensionRuntime.getHistoricalEvents([eventToRecord.toEventHistoryRequest()], enforceOrder: false) { [weak self] results in
        guard let self = self else { return }

        guard let result = results.first else {
            Log.warning(label: LOG_TAG, "\(logPrefix) - Unable to retrieve historical events, skipping '\(operation)' operation")
            return
        }
        if result.count >= 1 {
            Log.trace(label: LOG_TAG, "\(logPrefix) - Event already exists in history, skipping '\(operation)' operation")
            return
        }
        insert(event: eventToRecord)
    }
}
// insert handling
if operation == LaunchRulesEngine.CONSEQUENCE_EVENT_HISTORY_OPERATION_INSERT {
    insert(event: eventToRecord)
}
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
