### PR TITLE
Rules : Fix logical operation for negative matchers with multiple values

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -469,6 +469,8 @@
 		B3E6E9762859BEC553298E95 /* Pods_AEPCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57BD6E641AFED0510599B36C /* Pods_AEPCore.framework */; };
 		B6D6A019265EC9D8005042BE /* FloatingButtonPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D6A018265EC9D8005042BE /* FloatingButtonPosition.swift */; };
 		B6D6A02D26601279005042BE /* FloatingButtonPositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D6A02C26601279005042BE /* FloatingButtonPositionTests.swift */; };
+		B6E568C72DF3AE20006F1741 /* rules_testMatcherNe_multipleValues.json in Resources */ = {isa = PBXBuildFile; fileRef = B6E568C62DF3AE20006F1741 /* rules_testMatcherNe_multipleValues.json */; };
+		B6E568C92DF3B28C006F1741 /* rules_testMatcherNc_multipleValues.json in Resources */ = {isa = PBXBuildFile; fileRef = B6E568C82DF3B28C006F1741 /* rules_testMatcherNc_multipleValues.json */; };
 		BB00E26824D8C94600C578C1 /* TokenFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00E26624D8C94600C578C1 /* TokenFinder.swift */; };
 		BB00E26924D8C94600C578C1 /* Dictionary+Flatten.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00E26724D8C94600C578C1 /* Dictionary+Flatten.swift */; };
 		BB00E26B24D8C9A600C578C1 /* Date+Format.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00E26A24D8C9A600C578C1 /* Date+Format.swift */; };
@@ -1194,6 +1196,8 @@
 		B59C21EF8D78FC053D2404B0 /* Pods_TestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6D6A018265EC9D8005042BE /* FloatingButtonPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingButtonPosition.swift; sourceTree = "<group>"; };
 		B6D6A02C26601279005042BE /* FloatingButtonPositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingButtonPositionTests.swift; sourceTree = "<group>"; };
+		B6E568C62DF3AE20006F1741 /* rules_testMatcherNe_multipleValues.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = rules_testMatcherNe_multipleValues.json; sourceTree = "<group>"; };
+		B6E568C82DF3B28C006F1741 /* rules_testMatcherNc_multipleValues.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = rules_testMatcherNc_multipleValues.json; sourceTree = "<group>"; };
 		BB00E26624D8C94600C578C1 /* TokenFinder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenFinder.swift; sourceTree = "<group>"; };
 		BB00E26724D8C94600C578C1 /* Dictionary+Flatten.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Flatten.swift"; sourceTree = "<group>"; };
 		BB00E26A24D8C9A600C578C1 /* Date+Format.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+Format.swift"; sourceTree = "<group>"; };
@@ -1968,6 +1972,8 @@
 				BBA512A624F4A18B0030DAD1 /* rules_testMatcherNc.json */,
 				BBA5129A24F477550030DAD1 /* rules_testMatcherNe.json */,
 				BBA512A824F4A7EE0030DAD1 /* rules_testMatcherNx.json */,
+				B6E568C82DF3B28C006F1741 /* rules_testMatcherNc_multipleValues.json */,
+				B6E568C62DF3AE20006F1741 /* rules_testMatcherNe_multipleValues.json */,
 				BB3E86E124F975E000E39C53 /* rules_testMatcherWithDifferentTypesOfParameters.json */,
 				BBA512BA24F6C6CA0030DAD1 /* rules_testModifyData_invalidJson.json */,
 				BBA512B224F5CF380030DAD1 /* rules_testModifyData.json */,
@@ -2794,6 +2800,7 @@
 				BF4A6EE726BB47FE00612434 /* rules_testDispatchEventNewData.json in Resources */,
 				3F08FF9B24DA0DA100D34DE3 /* rules_functional_1.zip in Resources */,
 				3F39520C24CA096100F7325B /* rules_1.json in Resources */,
+				B6E568C72DF3AE20006F1741 /* rules_testMatcherNe_multipleValues.json in Resources */,
 				BBA512A524F4A1790030DAD1 /* rules_testMatcherCo.json in Resources */,
 				BBA512A924F4A7EE0030DAD1 /* rules_testMatcherNx.json in Resources */,
 				BBA512A124F4A15C0030DAD1 /* rules_testMatcherLt.json in Resources */,
@@ -2806,6 +2813,7 @@
 				BF4A6F2826BB4A1B00612434 /* rules_testDispatchEventNoSource.json in Resources */,
 				BF4A6EB826BB3B9D00612434 /* rules_testDispatchEventCopy.json in Resources */,
 				3F39520F24CA096100F7325B /* testRulesDownloader.zip in Resources */,
+				B6E568C92DF3B28C006F1741 /* rules_testMatcherNc_multipleValues.json in Resources */,
 				BF4A6F2626BB4A1B00612434 /* rules_testDispatchEventNoAction.json in Resources */,
 				3F39520A24CA096100F7325B /* TestRules.zip in Resources */,
 				3F39520E24CA096100F7325B /* TestConfig.json in Resources */,

--- a/AEPCore/Sources/rules/JSONRulesParser.swift
+++ b/AEPCore/Sources/rules/JSONRulesParser.swift
@@ -133,7 +133,10 @@ class JSONCondition: Codable {
                             operands.append(operand)
                         }
                     }
-                    return operands.count == 0 ? nil : LogicalExpression(operationName: "or", operands: operands)
+                    // For "ne" (not equals) and "nc" (not contains) matchers, use "and" logic instead of "or"
+                    // This ensures all conditions must be true: value != A AND value != B AND value != C
+                    let logicalOperation = (matcher == "ne" || matcher == "nc") ? "and" : "or"
+                    return operands.count == 0 ? nil : LogicalExpression(operationName: logicalOperation, operands: operands)
                 }
             }
             return nil

--- a/AEPCore/Tests/FunctionalTests/RulesEngineFunctionalTests.swift
+++ b/AEPCore/Tests/FunctionalTests/RulesEngineFunctionalTests.swift
@@ -188,6 +188,33 @@ class RulesEngineFunctionalTests: XCTestCase {
         }
         XCTAssertEqual("pb", dataWithType["type"] as! String)
     }
+    
+    // Matcher: ne
+    func testMatcherNe_multipleValues() {
+        /// Given:
+        resetRulesEngine(withNewRules: "rules_testMatcherNe_multipleValues")
+
+        mockRuntime.simulateSharedState(for: "com.adobe.module.lifecycle", data: (value: ["lifecyclecontextdata": ["carriername": "AT&T"]], status: .set))
+        /// When:
+        rulesEngine.process(event: defaultEvent)
+        /// Then:
+        XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
+
+        /// When:
+        mockRuntime.simulateSharedState(for: "com.adobe.module.lifecycle", data: (value: ["lifecyclecontextdata": ["carriername": "Blue"]], status: .set))
+        rulesEngine.process(event: defaultEvent)
+        /// Then:
+        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
+        let consequenceEvent = mockRuntime.dispatchedEvents[0]
+        XCTAssertEqual(EventType.rulesEngine, consequenceEvent.type)
+        XCTAssertEqual(EventSource.responseContent, consequenceEvent.source)
+        guard let data = consequenceEvent.data?["triggeredconsequence"], let dataWithType = data as? [String: Any] else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual("pb", dataWithType["type"] as! String)
+    }
+    
 
     // Matcher: ex
     func testMatcherEx() {
@@ -383,6 +410,32 @@ class RulesEngineFunctionalTests: XCTestCase {
 
         /// When:
         mockRuntime.simulateSharedState(for: "com.adobe.module.lifecycle", data: (value: ["lifecyclecontextdata": ["carriername": "Verizon"]], status: .set))
+        rulesEngine.process(event: defaultEvent)
+        /// Then:
+        XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
+        let consequenceEvent = mockRuntime.dispatchedEvents[0]
+        XCTAssertEqual(EventType.rulesEngine, consequenceEvent.type)
+        XCTAssertEqual(EventSource.responseContent, consequenceEvent.source)
+        guard let data = consequenceEvent.data?["triggeredconsequence"], let dataWithType = data as? [String: Any] else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual("pb", dataWithType["type"] as! String)
+    }
+
+    // Matcher: nc (Not Contains) with multiple values
+    func testMatcherNc_multipleValues() {
+        /// Given:
+        resetRulesEngine(withNewRules: "rules_testMatcherNc_multipleValues")
+
+        mockRuntime.simulateSharedState(for: "com.adobe.module.lifecycle", data: (value: ["lifecyclecontextdata": ["carriername": "AT&T Wireless"]], status: .set))
+        /// When:
+        rulesEngine.process(event: defaultEvent)
+        /// Then:
+        XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
+
+        /// When:
+        mockRuntime.simulateSharedState(for: "com.adobe.module.lifecycle", data: (value: ["lifecyclecontextdata": ["carriername": "T-Mobile USA"]], status: .set))
         rulesEngine.process(event: defaultEvent)
         /// Then:
         XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)

--- a/AEPCore/Tests/TestResources/rules_testMatcherNc_multipleValues.json
+++ b/AEPCore/Tests/TestResources/rules_testMatcherNc_multipleValues.json
@@ -1,0 +1,89 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "condition": {
+        "type": "group",
+        "definition": {
+          "logic": "and",
+          "conditions": [
+            {
+              "type": "group",
+              "definition": {
+                "logic": "or",
+                "conditions": [
+                  {
+                    "type": "group",
+                    "definition": {
+                      "logic": "and",
+                      "conditions": [
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~type",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventType.lifecycle"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~source",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventSource.responseContent"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "lifecyclecontextdata.launchevent",
+                            "matcher": "ex",
+                            "values": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "group",
+              "definition": {
+                "logic": "and",
+                "conditions": [
+                  {
+                    "type": "matcher",
+                    "definition": {
+                      "key": "~state.com.adobe.module.lifecycle/lifecyclecontextdata.carriername",
+                      "matcher": "nc",
+                      "values": [
+                        "AT&T",
+                        "Verizon",
+                        "Sprint"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "consequences": [
+        {
+          "id": "RCnc123456789abcdef",
+          "type": "pb",
+          "detail": {
+            "timeout": 0,
+            "templateurl": "http://www.adobe.com"
+          }
+        }
+      ]
+    }
+  ]
+} 

--- a/AEPCore/Tests/TestResources/rules_testMatcherNe_multipleValues.json
+++ b/AEPCore/Tests/TestResources/rules_testMatcherNe_multipleValues.json
@@ -1,0 +1,90 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "condition": {
+        "type": "group",
+        "definition": {
+          "logic": "and",
+          "conditions": [
+            {
+              "type": "group",
+              "definition": {
+                "logic": "or",
+                "conditions": [
+                  {
+                    "type": "group",
+                    "definition": {
+                      "logic": "and",
+                      "conditions": [
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~type",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventType.lifecycle"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~source",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventSource.responseContent"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "lifecyclecontextdata.launchevent",
+                            "matcher": "ex",
+                            "values": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "group",
+              "definition": {
+                "logic": "and",
+                "conditions": [
+                  {
+                    "type": "matcher",
+                    "definition": {
+                      "key": "~state.com.adobe.module.lifecycle/lifecyclecontextdata.carriername",
+                      "matcher": "ne",
+                      "values": [
+                        "AT&T",
+                        "Verizon",
+                        "Cricket"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "consequences": [
+        {
+          "id": "RC2500e6b0140744d49e6fd503a55a66d4",
+          "type": "pb",
+          "detail": {
+            "timeout": 0,
+            "templateurl": "http://www.adobe.com"
+          }
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION

### **Problem**
 When processing multiple values, the rules engine used OR logic for all matchers , which creates a logical flaw for negative 
conditions. For example 
```
carriername != "AT&T" OR  carriername != "Verizon" OR carriername != "Cricket"
```
This is always true for negative matchers! If carriername = "AT&T", the condition carriername != "Verizon" makes the entire OR expression true, causing incorrect rule firing.


###  **Impact**
This was causing rules to fire when they shouldn't. (Customer issue : IAM was fired too often)


### **Solution**
Modified JSONRulesParser.swift to use AND logic for negative matchers like notContains (nc) and notExists (ne).

Correct evaluation
```
carriername != "AT&T" AND carriername != "Verizon" AND carriername != "Cricket"
```
