### PR TITLE
Added support to provide callback in MobileCore.initialize() for multiple initialize calls

### DIFF
--- a/AEPCore/Sources/core/MobileCoreInitializer.swift
+++ b/AEPCore/Sources/core/MobileCoreInitializer.swift
@@ -50,6 +50,7 @@ final class MobileCoreInitializer {
 
         if initialized.incrementAndGet() != 1 {
             Log.debug(label: LOG_TAG, "initialize - ignoring as it was already called.")
+            completion?()
             return
         }
 

--- a/AEPCore/Tests/MobileCoreInitializerTests.swift
+++ b/AEPCore/Tests/MobileCoreInitializerTests.swift
@@ -99,12 +99,14 @@ class MobileCoreInitializerTests: XCTestCase {
 
         wait(for: [expectation], timeout: 10)
 
-        // Second call, callback is not called
+        // Second call, callback is still invoked so callers are not left hanging
+        let secondCallExpectation = XCTestExpectation(description: "Completion closure is invoked on subsequent calls to initialize().")
+        secondCallExpectation.assertForOverFulfill = true
         MobileCore.initialize(options: options) {
-            XCTFail("Completion closure should not be called from subsequent calls to initialize().")
+            secondCallExpectation.fulfill()
         }
 
-        sleep(1) // wait as callback to second initialize call is not called
+        wait(for: [secondCallExpectation], timeout: 10)
 
         let eventHubState = EventHub.shared.getSharedState(extensionName: EventHubConstants.NAME, event: nil)?.value
 
@@ -118,6 +120,75 @@ class MobileCoreInitializerTests: XCTestCase {
         XCTAssertTrue(registeredExtensions.keys.contains { $0 == "com.adobe.module.configuration" })
         XCTAssertTrue(registeredExtensions.keys.contains { $0 == "com.adobe.mockExtension" })
         XCTAssertFalse(registeredExtensions.keys.contains { $0 == "com.adobe.mockExtensionTwo" })
+    }
+
+    func testInitializeSecondCallInvokesCompletionWithoutReRunningInitialization() {
+        let firstCallExpectation = XCTestExpectation(description: "First initialize completion is invoked")
+        firstCallExpectation.assertForOverFulfill = true
+
+        var finderExecutionCount = 0
+        MobileCore.mobileCoreInitializer = MobileCoreInitializer(extensionFinder: {
+            finderExecutionCount += 1
+            return [MockExtension.self]
+        })
+
+        MobileCore.initialize(options: InitOptions()) {
+            firstCallExpectation.fulfill()
+        }
+        wait(for: [firstCallExpectation], timeout: 10)
+
+        // Second call: completion must still fire, but extensionFinder must not run again
+        let secondCallExpectation = XCTestExpectation(description: "Second initialize completion is invoked")
+        secondCallExpectation.assertForOverFulfill = true
+        MobileCore.initialize(options: InitOptions()) {
+            secondCallExpectation.fulfill()
+        }
+        wait(for: [secondCallExpectation], timeout: 10)
+
+        XCTAssertEqual(1, finderExecutionCount, "extensionFinder should only run once across multiple initialize calls.")
+    }
+
+    func testInitializeSubsequentCallsAllInvokeCompletion() {
+        let firstCallExpectation = XCTestExpectation(description: "First initialize completion is invoked")
+        firstCallExpectation.assertForOverFulfill = true
+
+        MobileCore.mobileCoreInitializer = MobileCoreInitializer(extensionFinder: {
+            return [MockExtension.self]
+        })
+
+        MobileCore.initialize(options: InitOptions()) {
+            firstCallExpectation.fulfill()
+        }
+        wait(for: [firstCallExpectation], timeout: 10)
+
+        // Every subsequent call should invoke its completion
+        let subsequentExpectation = XCTestExpectation(description: "All subsequent initialize completions are invoked")
+        subsequentExpectation.expectedFulfillmentCount = 3
+        subsequentExpectation.assertForOverFulfill = true
+
+        for _ in 0..<3 {
+            MobileCore.initialize(options: InitOptions()) {
+                subsequentExpectation.fulfill()
+            }
+        }
+        wait(for: [subsequentExpectation], timeout: 10)
+    }
+
+    func testInitializeSecondCallWithNilCompletionDoesNotCrash() {
+        let firstCallExpectation = XCTestExpectation(description: "First initialize completion is invoked")
+        firstCallExpectation.assertForOverFulfill = true
+
+        MobileCore.mobileCoreInitializer = MobileCoreInitializer(extensionFinder: {
+            return [MockExtension.self]
+        })
+
+        MobileCore.initialize(options: InitOptions()) {
+            firstCallExpectation.fulfill()
+        }
+        wait(for: [firstCallExpectation], timeout: 10)
+
+        // Second call with no completion should be a safe no-op
+        MobileCore.initialize(options: InitOptions())
     }
 
     func testInitializeCallsConfigWithAppId() {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
